### PR TITLE
fix(security): remove ACL log.read (#19 PR A)

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -39,14 +39,16 @@ flowchart TB
 | **Rule map** | `root/usr/libexec/rpcd/fwlive` | `rules`, `poll` (filtered log), `resolve` (reverse DNS), `logging_status`, `enable_wan_logging`, `disable_wan_logging` |
 | **WAN logging** | `root/usr/libexec/fwlive-logging.sh` | WAN zone `log=1` helpers (sourced by rpcd) |
 | **Log filter** | `root/usr/libexec/fwlive-log-filter.sh` | Shell `isFirewallEvent` parity before JSON leaves router |
-| **Menu / ACL** | `root/usr/share/luci/menu.d`, `rpcd/acl.d` | `admin/status/fwlive`, read `fwlive.*` + write enable/disable |
+| **Menu / ACL** | `root/usr/share/luci/menu.d`, `rpcd/acl.d` | `admin/status/fwlive`, read `fwlive.*` only (no session `log.read`) + write enable/disable |
 
 ## Design choices
 
 | Choice | Rationale |
 |--------|-----------|
 | Poll `fwlive.poll` (~1s) | Wraps `log.read` + server firewall filter; line count in `addresses[0]` |
+| ACL omits `log.read` | Session callers use `fwlive.poll` only; the rpcd plugin invokes `ubus call log read` as root |
 | Client-side normalize/filter | Normalization stays in JS; `isFirewallEvent` retained as safety net |
+| Enable/disable concurrency | No confirm dialog / no flock — low multi-admin risk; UI uses `loggingBusy`; concurrent toggles are last-writer-wins |
 | Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off |
 | `core/` + LuCI mirror | Parser tested without browser or router |
 | nft/fw4 primary | Validated on **21.02.7** (fw3 lab), **22.03.7**, **23.05.5**, **24.10.5**, **25.12.0** lab matrix |

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -29,7 +29,7 @@
 
 - `Makefile` — `LUCI_DEPENDS`, version, maintainer
 - `menu.d` — path `admin/status/fwlive`
-- `rpcd/acl.d` — grant `fwlive.rules`, `fwlive.poll`, `fwlive.resolve`, `fwlive.logging_status` (read); `fwlive.enable_wan_logging`, `fwlive.disable_wan_logging` (write)
+- `rpcd/acl.d` — grant `fwlive.rules`, `fwlive.poll`, `fwlive.resolve`, `fwlive.logging_status` (read); `fwlive.enable_wan_logging`, `fwlive.disable_wan_logging` (write). Do **not** grant `ubus log.read` — poll performs filtered log reads inside the root rpcd plugin
 
 Package README: [`../../openwrt-feed/luci-app-fwlive/README.md`](../../openwrt-feed/luci-app-fwlive/README.md)
 

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -17,7 +17,7 @@ Use before making this repo public upstream.
 - [ ] rpcd JSON responses escape control characters (`json_escape` / `map_add`)
 - [ ] `core/fwlive-log.js` tracked as a normal file (not a stale submodule gitlink)
 - [ ] `node_modules/` not committed; dev deps declared in root `package.json`
-- [ ] ACL scope understood: `luci-app-fwlive` grants read (logs, rules, `logging_status`) and write (`enable_wan_logging`, `disable_wan_logging`) — grant only to trusted admin LuCI users
+- [ ] ACL scope understood: `luci-app-fwlive` grants read (`fwlive.rules|poll|resolve|logging_status`) and write (`enable_wan_logging`, `disable_wan_logging`) — **not** direct `ubus log.read` (poll reads logd as root inside rpcd). Grant only to trusted admin LuCI users
 
 ## Distribution (canonical)
 

--- a/docs/user/using-the-ui.md
+++ b/docs/user/using-the-ui.md
@@ -53,7 +53,7 @@ The **Message: wrap / one-line** toolbar control applies in Detailed view only.
 | **Limit** | Rows to keep (25 … 2000, default 100). Stored in the browser. |
 | **Show Detail / Hide Detail** | Toggles Simple ↔ Detailed; preference saved in `localStorage` after you use it. |
 | **Show hostnames** | Off by default. When checked, resolved names replace IPs in **Flow** and address columns; hover shows the IP. Click still filters by IP. |
-| **Enable logging / Disable logging** | Toggles WAN zone drop/reject logging. The shown rate is the firewall `log_limit` (default `10/minute`), not a fwlive cap. |
+| **Enable logging / Disable logging** | Toggles WAN zone drop/reject logging (mutates firewall UCI and reloads). No confirm step — use carefully on shared admin sessions. Concurrent toggles from multiple admins are last-writer-wins. The shown rate is the firewall `log_limit` (default `10/minute`), not a fwlive cap. |
 | **Quick search** | Matches across all normalized fields. |
 
 ## Filtering

--- a/openwrt-feed/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json
+++ b/openwrt-feed/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json
@@ -3,8 +3,7 @@
 		"description": "Grant access to firewall live log view",
 		"read": {
 			"ubus": {
-				"fwlive": [ "rules", "poll", "resolve", "logging_status" ],
-				"log": [ "read" ]
+				"fwlive": [ "rules", "poll", "resolve", "logging_status" ]
 			}
 		},
 		"write": {

--- a/tests/fwlive-rpcd-security.test.js
+++ b/tests/fwlive-rpcd-security.test.js
@@ -2,12 +2,26 @@
 'use strict';
 
 const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const ROOT = path.join(__dirname, '..');
 const RPCD = path.join(ROOT,
 	'openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive');
+const ACL = path.join(ROOT,
+	'openwrt-feed/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json');
 const LOGGING_TEST = path.join(ROOT, 'tests/fwlive-logging.test.sh');
+
+const acl = JSON.parse(fs.readFileSync(ACL, 'utf8'));
+const readUbus = acl['luci-app-fwlive']?.read?.ubus || {};
+if (Object.prototype.hasOwnProperty.call(readUbus, 'log')) {
+	console.error('ACL must not grant ubus log.* (poll uses root log.read inside rpcd)');
+	process.exit(1);
+}
+if (!Array.isArray(readUbus.fwlive) || !readUbus.fwlive.includes('poll')) {
+	console.error('ACL must grant fwlive.poll for Luci sessions');
+	process.exit(1);
+}
 
 const out = execFileSync('sh', [RPCD, '__selftest'], { encoding: 'utf8' });
 if (out.includes('skip:'))


### PR DESCRIPTION
## Summary
- Remove `"log": ["read"]` from `luci-app-fwlive` ACL so sessions cannot pull unfiltered syslog via `ubus call log read`.
- Add a negative ACL regression test in `tests/fwlive-rpcd-security.test.js`.
- Document ACL least privilege and Finding #2 policy: no confirm/flock; UI uses `loggingBusy`; concurrent toggles are last-writer-wins.

Part of #19.

## Test plan
- [x] `node tests/fwlive-rpcd-security.test.js`
- [ ] QEMU smoke after install: `ubus call fwlive poll` still works
- [ ] Restricted LuCI session (when available): direct `ubus call log read` denied


Made with [Cursor](https://cursor.com)