### PR TITLE
fix(security): hardening leftovers for #19 (PR D)

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -47,7 +47,11 @@ flowchart TB
 |--------|-----------|
 | Poll `fwlive.poll` (~1s) | Wraps `log.read` + server firewall filter; line count in `addresses[0]` |
 | Client-side normalize/filter | Normalization stays in JS; `isFirewallEvent` retained as safety net |
-| Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off |
+| Parser disagreement | After poll, the client re-applies `isFirewallEvent`; **client wins** (drops lines the shell kept if heuristics disagree) |
+| MAC redaction | Client display only (`formatMessageDisplay` strips `MAC=…`, including message `title`); poll JSON may still contain MACs on the wire |
+| Rule / prefix XSS | Rule labels render via LuCI `E(..., text)` (text nodes); server map keys gated by `is_uci_style_name` |
+| Log filter injection | `fwlive-log-filter.sh` feeds messages as data through jsonfilter/grep stdin — not a shell-injection surface |
+| Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off; server validates IPv4/IPv6 shape before lookup |
 | `core/` + LuCI mirror | Parser tested without browser or router |
 | nft/fw4 primary | Validated on **21.02.7** (fw3 lab), **22.03.7**, **23.05.5**, **24.10.5**, **25.12.0** lab matrix |
 | iptables LOG | Primary on **21.02.x** (fw3); best-effort on **22.03+** when nft absent — same logd pipe; rule map from `iptables-save` |

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -57,7 +57,7 @@ const callFwliveDisableLogging = rpc.declare({
 const ROW_LIMIT_OPTIONS = [ 25, 50, 100, 250, 500, 1000, 2000 ];
 const DEFAULT_ROW_LIMIT = 100;
 const FETCH_LINES_MAX = 2000;
-const RENDER_CAP_PER_SEC = 250;
+const RENDER_CAP_PER_SEC = 250; // DOM budget: ~250 new/updated rows per second on typical LuCI routers
 const VIEW_MODES = [ 'simple', 'detailed' ];
 const COLUMN_SETS = {
 	simple: [ 'action', 'time', 'iface', 'flow', 'proto', 'rule' ],
@@ -588,12 +588,12 @@ return view.extend({
 			if (this.messageLayout === 'wrap') {
 				return E('td', {
 					'class': 'fwlive-message',
-					'title': row.message || ''
+					'title': msgDisplay || ''
 				}, E('div', { 'class': 'fwlive-message-wrap' }, msgDisplay || '—'));
 			}
 			return E('td', {
 				'class': 'fwlive-message',
-				'title': row.message || ''
+				'title': msgDisplay || ''
 			}, msgDisplay || '—');
 		default:
 			return E('td', {}, '');

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh
@@ -3,7 +3,8 @@
 # Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com>
 #
 # Filter log.read JSON to firewall-only entries (isFirewallEvent parity).
-# Usage: ubus call log read '...' | /usr/libexec/fwlive-log-filter.sh
+# Log messages are treated as data (jsonfilter + grep stdin); never interpolated
+# into shell command strings. Usage: ubus call log read '...' | fwlive-log-filter.sh
 
 FILTER_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$FILTER_DIR/fwlive-is-firewall-event.sh"

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -13,12 +13,20 @@ FW4_TAG='!fw4: '
 LIBEXEC_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 FILTER_SH="$LIBEXEC_DIR/fwlive-log-filter.sh"
 LOGGING_SH="$LIBEXEC_DIR/fwlive-logging.sh"
+# Max reverse-DNS lookups per resolve call (~32 names keeps getent load bounded on small routers).
 RESOLVE_MAX=32
+# Fixed 1s getent timeout; passed as argv to `timeout`, never interpolated into a shell string.
 RESOLVE_TIMEOUT=1
+# Cap raw logd lines per poll (~2000 ≈ typical logd ring / ~200 KB JSON before filter).
 POLL_LINES_MAX=2000
 
 json_escape() {
-	awk 'BEGIN { RS = ""; ORS = "" }
+	# Escape for JSON string content per RFC 8259 (including remaining C0 controls).
+	awk 'BEGIN {
+		RS = ""; ORS = ""
+		for (n = 1; n < 128; n++)
+			ord[sprintf("%c", n)] = n
+	}
 	{
 		for (i = 1; i <= length($0); i++) {
 			c = substr($0, i, 1)
@@ -27,7 +35,15 @@ json_escape() {
 			else if (c == "\t") printf "\\t"
 			else if (c == "\r") printf "\\r"
 			else if (c == "\n") printf "\\n"
-			else printf "%s", c
+			else {
+				o = ord[c] + 0
+				if (o > 0 && o < 32)
+					printf "\\u%04x", o
+				else if (o == 127)
+					printf "\\u007f"
+				else
+					printf "%s", c
+			}
 		}
 	}'
 }
@@ -245,6 +261,7 @@ poll_logs() {
 resolve_hostname() {
 	ip="$1"
 	[ -n "$ip" ] || return 1
+	is_resolvable_address "$ip" || return 1
 	line=""
 	if command -v timeout >/dev/null 2>&1; then
 		line=$(timeout "$RESOLVE_TIMEOUT" getent hosts "$ip" 2>/dev/null | head -1)
@@ -255,6 +272,18 @@ resolve_hostname() {
 	set -- $line
 	[ "$#" -ge 2 ] || return 1
 	printf '%s' "$2"
+}
+
+# Accept only IPv4/IPv6-shaped tokens before getent (reject shell metachar / hostnames).
+is_resolvable_address() {
+	addr="$1"
+	[ -n "$addr" ] || return 1
+	case "$addr" in
+		*[!0-9a-fA-F:.]*) return 1 ;;
+		*.*.*.*|*:* ) ;;
+		*) return 1 ;;
+	esac
+	return 0
 }
 
 resolve_addresses() {
@@ -282,6 +311,10 @@ resolve_addresses() {
 		while json_get_type atype "$idx" && [ "$atype" = string ]; do
 			[ "$count" -ge "$RESOLVE_MAX" ] && break
 			json_get_var ip "$idx"
+			if ! is_resolvable_address "$ip"; then
+				idx=$((idx + 1))
+				continue
+			fi
 			name=$(resolve_hostname "$ip")
 			if [ -n "$name" ]; then
 				map_add "$ip" "$name"
@@ -301,6 +334,36 @@ run_selftest() {
 	expected=$(printf 'a\\\\b\\"c\\nd\\te')
 	if [ "$escaped" != "$expected" ]; then
 		echo "json_escape: mismatch" >&2
+		return 1
+	fi
+
+	# Remaining C0 controls must become \u00XX (RFC 8259), not raw bytes.
+	input=$(printf 'x\001y\037z')
+	escaped=$(printf '%s' "$input" | json_escape)
+	expected='x\u0001y\u001fz'
+	if [ "$escaped" != "$expected" ]; then
+		echo "json_escape C0: expected $expected got $escaped" >&2
+		return 1
+	fi
+
+	if is_resolvable_address 'not an ip'; then
+		echo 'is_resolvable_address: expected reject for spaces' >&2
+		return 1
+	fi
+	if is_resolvable_address '$(reboot)'; then
+		echo 'is_resolvable_address: expected reject for metachar' >&2
+		return 1
+	fi
+	if is_resolvable_address 'example.com'; then
+		echo 'is_resolvable_address: expected reject for hostname' >&2
+		return 1
+	fi
+	if ! is_resolvable_address '192.0.2.1'; then
+		echo 'is_resolvable_address: expected accept IPv4' >&2
+		return 1
+	fi
+	if ! is_resolvable_address '2001:db8::1'; then
+		echo 'is_resolvable_address: expected accept IPv6' >&2
 		return 1
 	fi
 

--- a/tests/fwlive-shell-filter.test.js
+++ b/tests/fwlive-shell-filter.test.js
@@ -67,9 +67,43 @@ function runJsonParity() {
 	assert.deepEqual(shMsgs, jsMsgs);
 }
 
+function runMetacharSafety() {
+	const nasty = [
+		'$(reboot); IN=wan OUT= SRC=203.0.113.1 DST=192.0.2.1 PROTO=TCP SPT=1 DPT=2',
+		'`id` IN=wan OUT= SRC=203.0.113.1 DST=192.0.2.1 PROTO=UDP SPT=1 DPT=53',
+		'IN=wan OUT= SRC=203.0.113.1 DST=192.0.2.1 PROTO=TCP; rm -rf /',
+		'IN=wan OUT= SRC=203.0.113.1 DST=192.0.2.1 PROTO=TCP $(echo pwned)',
+		'dropbear[1]: Bad packet length 12345'
+	];
+
+	for (const msg of nasty) {
+		assert.doesNotThrow(() => shellIsFirewall(msg));
+	}
+
+	if (!fs.existsSync(FILTER_SH))
+		throw new Error('missing fwlive-log-filter.sh');
+
+	const jf = spawnSync('sh', ['-c', 'command -v jsonfilter'], { encoding: 'utf8' });
+	if (jf.status !== 0 || !jf.stdout.trim()) {
+		console.log('fwlive shell filter: skip metachar JSON round-trip (jsonfilter not on host)');
+		return;
+	}
+
+	const payload = JSON.stringify({
+		log: nasty.map((msg, i) => ({ msg, id: i }))
+	});
+	const filtered = spawnSync('sh', [FILTER_SH], {
+		input: payload,
+		encoding: 'utf8'
+	});
+	assert.equal(filtered.status, 0, filtered.stderr || filtered.stdout);
+	assert.doesNotThrow(() => JSON.parse(filtered.stdout));
+}
+
 function run() {
 	runMsgParity();
 	runJsonParity();
+	runMetacharSafety();
 	console.log('fwlive shell filter parity tests passed');
 }
 


### PR DESCRIPTION
## Summary
- Expand `json_escape` to emit `\u00XX` for remaining C0 controls (RFC 8259) + selftest.
- Validate resolve addresses as IPv4/IPv6-shaped before `getent`; timeout remains a fixed argv (not shell-interpolated).
- Use MAC-stripped `msgDisplay` for message cell `title` attributes.
- Metacharacter safety coverage in shell filter tests; document not-a-findings (filter injection, XSS via `E()`, MAC client-only boundary, client-wins parser disagreement) and constant rationales.

Part of #19. Related: #20 (ACL), #21 (disable bit-clear).

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [x] `sh …/rpcd/fwlive __selftest`
- [ ] Optional QEMU: resolve with junk addresses is ignored; poll still works


Made with [Cursor](https://cursor.com)