### PR TITLE
refactor: Phase 0 fwlive.constants plain-export spike (#23)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -9,6 +9,7 @@ LuCI **Firewall Live View** — client-side JS view polling `ubus fwlive poll` (
 | `Makefile` | `LUCI_TITLE`, `LUCI_DEPENDS`, includes `luci.mk` |
 | `htdocs/luci-static/resources/view/status/fwlive.js` | LuCI view (`view.extend`) |
 | `htdocs/luci-static/resources/fwlive/log.js` | Parser/filter module (mirror of repo `core/fwlive-log.js`) |
+| `htdocs/luci-static/resources/fwlive/constants.js` | Shared view constants (plain LuCI `return { … }` module) |
 | `root/usr/share/luci/menu.d/*.json` | Menu entry (`admin/status/fwlive`) |
 | `root/usr/share/rpcd/acl.d/*.json` | ubus ACL (read + write for logging enable/disable) |
 | `root/usr/libexec/rpcd/fwlive` | rpcd plugin (`rules`, `poll`, `resolve`, `logging_status`, `enable_wan_logging`, `disable_wan_logging`) |

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Shared view constants for luci-app-fwlive (plain LuCI module export).
+ * Phase 0 spike (#23): verify `'require fwlive.constants as constants'` resolves.
+ */
+return {
+	ROW_LIMIT_OPTIONS: [ 25, 50, 100, 250, 500, 1000, 2000 ],
+	DEFAULT_ROW_LIMIT: 100,
+	FETCH_LINES_MAX: 2000,
+	/* DOM budget: ~250 new/updated rows per second on typical LuCI routers */
+	RENDER_CAP_PER_SEC: 250,
+	VIEW_MODES: [ 'simple', 'detailed' ],
+	COLUMN_SETS: {
+		simple: [ 'action', 'time', 'iface', 'flow', 'proto', 'rule' ],
+		detailed: [ 'time', 'action', 'rule', 'iface_in', 'iface_out', 'dir', 'proto', 'src', 'sport', 'dst', 'dport', 'flags', 'len', 'message' ]
+	}
+};

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -8,6 +8,7 @@
 'require poll';
 'require rpc';
 'require fwlive.log as log';
+'require fwlive.constants as constants';
 
 const callFwlivePoll = rpc.declare({
 	object: 'fwlive',
@@ -53,16 +54,6 @@ const callFwliveDisableLogging = rpc.declare({
 	method: 'disable_wan_logging',
 	expect: { '': { ok: false, changed: false, wan_zone: null } }
 });
-
-const ROW_LIMIT_OPTIONS = [ 25, 50, 100, 250, 500, 1000, 2000 ];
-const DEFAULT_ROW_LIMIT = 100;
-const FETCH_LINES_MAX = 2000;
-const RENDER_CAP_PER_SEC = 250; // DOM budget: ~250 new/updated rows per second on typical LuCI routers
-const VIEW_MODES = [ 'simple', 'detailed' ];
-const COLUMN_SETS = {
-	simple: [ 'action', 'time', 'iface', 'flow', 'proto', 'rule' ],
-	detailed: [ 'time', 'action', 'rule', 'iface_in', 'iface_out', 'dir', 'proto', 'src', 'sport', 'dst', 'dport', 'flags', 'len', 'message' ]
-};
 
 /* FWLIVE_TINT_HELPERS_START */
 var FWLIVE_TINT_PAINT_DELTA_MIN = 8;
@@ -124,10 +115,10 @@ function fwliveTintShouldEngageFallback(opts) {
 /* FWLIVE_TINT_HELPERS_END */
 
 return view.extend({
-	rowLimit: DEFAULT_ROW_LIMIT,
-	maxHistory: DEFAULT_ROW_LIMIT,
-	fetchLines: FETCH_LINES_MAX,
-	visibleRows: DEFAULT_ROW_LIMIT,
+	rowLimit: constants.DEFAULT_ROW_LIMIT,
+	maxHistory: constants.DEFAULT_ROW_LIMIT,
+	fetchLines: constants.FETCH_LINES_MAX,
+	visibleRows: constants.DEFAULT_ROW_LIMIT,
 	entries: [],
 	sessionSeen: null,
 	sessionNewTotal: 0,
@@ -135,7 +126,7 @@ return view.extend({
 	pauseBufferLoading: false,
 	paused: false,
 	messageLayout: 'wrap',
-	renderBucket: RENDER_CAP_PER_SEC,
+	renderBucket: constants.RENDER_CAP_PER_SEC,
 	renderBucketMs: 0,
 	floodSuppressed: false,
 	lastPollNewEvents: 0,
@@ -189,7 +180,7 @@ return view.extend({
 		const parts = Object.keys(filters)
 			.filter((k) => filters[k])
 			.map((k) => '%s=%s'.format(encodeURIComponent(k), encodeURIComponent(filters[k])));
-		if (this.rowLimit !== DEFAULT_ROW_LIMIT)
+		if (this.rowLimit !== constants.DEFAULT_ROW_LIMIT)
 			parts.push('limit=%s'.format(encodeURIComponent(this.rowLimit)));
 		if (this.viewMode === 'detailed')
 			parts.push('view=detailed');
@@ -209,7 +200,7 @@ return view.extend({
 			const val = decodeURIComponent(kv[1]);
 			if (key === 'limit') {
 				const n = parseInt(val, 10);
-				if (isFinite(n) && ROW_LIMIT_OPTIONS.indexOf(n) >= 0) {
+				if (isFinite(n) && constants.ROW_LIMIT_OPTIONS.indexOf(n) >= 0) {
 					this.applyRowLimit(n);
 					this.saveRowLimit();
 				}
@@ -384,7 +375,7 @@ return view.extend({
 	},
 
 	activeColumns() {
-		return COLUMN_SETS[this.viewMode] || COLUMN_SETS.simple;
+		return constants.COLUMN_SETS[this.viewMode] || constants.COLUMN_SETS.simple;
 	},
 
 	columnLabel(col) {
@@ -455,7 +446,7 @@ return view.extend({
 	},
 
 	setViewMode(mode) {
-		if (VIEW_MODES.indexOf(mode) < 0 || mode === this.viewMode)
+		if (constants.VIEW_MODES.indexOf(mode) < 0 || mode === this.viewMode)
 			return;
 
 		this.viewMode = mode;
@@ -1000,7 +991,7 @@ return view.extend({
 	},
 
 	ingestCap() {
-		return this.paused ? FETCH_LINES_MAX : this.rowLimit;
+		return this.paused ? constants.FETCH_LINES_MAX : this.rowLimit;
 	},
 
 	trimEntriesToLiveCap() {
@@ -1035,8 +1026,8 @@ return view.extend({
 		const elapsed = now - this.renderBucketMs;
 		this.renderBucketMs = now;
 		this.renderBucket = Math.min(
-			RENDER_CAP_PER_SEC,
-			this.renderBucket + (elapsed * RENDER_CAP_PER_SEC / 1000)
+			constants.RENDER_CAP_PER_SEC,
+			this.renderBucket + (elapsed * constants.RENDER_CAP_PER_SEC / 1000)
 		);
 	},
 
@@ -1156,13 +1147,13 @@ return view.extend({
 	readRowLimit() {
 		try {
 			const n = parseInt(localStorage.getItem('fwlive-row-limit'), 10);
-			if (ROW_LIMIT_OPTIONS.indexOf(n) >= 0)
+			if (constants.ROW_LIMIT_OPTIONS.indexOf(n) >= 0)
 				return n;
 		} catch (e) {
 			/* private mode / no storage */
 		}
 
-		return DEFAULT_ROW_LIMIT;
+		return constants.DEFAULT_ROW_LIMIT;
 	},
 
 	saveRowLimit() {
@@ -1174,10 +1165,10 @@ return view.extend({
 	},
 
 	applyRowLimit(limit) {
-		const n = ROW_LIMIT_OPTIONS.indexOf(limit) >= 0 ? limit : DEFAULT_ROW_LIMIT;
+		const n = constants.ROW_LIMIT_OPTIONS.indexOf(limit) >= 0 ? limit : constants.DEFAULT_ROW_LIMIT;
 		this.rowLimit = n;
 		this.maxHistory = n;
-		this.fetchLines = FETCH_LINES_MAX;
+		this.fetchLines = constants.FETCH_LINES_MAX;
 		this.visibleRows = n;
 		if (!this.paused && this.entries.length > n)
 			this.entries = this.entries.slice(-n);
@@ -1251,7 +1242,7 @@ return view.extend({
 
 	onRowLimitChange(ev) {
 		const n = parseInt(ev && ev.target ? ev.target.value : '', 10);
-		if (!isFinite(n) || ROW_LIMIT_OPTIONS.indexOf(n) < 0)
+		if (!isFinite(n) || constants.ROW_LIMIT_OPTIONS.indexOf(n) < 0)
 			return;
 
 		this.applyRowLimit(n);
@@ -1271,8 +1262,8 @@ return view.extend({
 
 	limitSelectOptions() {
 		const opts = [];
-		for (let i = 0; i < ROW_LIMIT_OPTIONS.length; i++) {
-			const n = ROW_LIMIT_OPTIONS[i];
+		for (let i = 0; i < constants.ROW_LIMIT_OPTIONS.length; i++) {
+			const n = constants.ROW_LIMIT_OPTIONS[i];
 			opts.push(E('option', { 'value': String(n) }, String(n)));
 		}
 		return opts;

--- a/scripts/qemu-install-fwlive.sh
+++ b/scripts/qemu-install-fwlive.sh
@@ -112,9 +112,15 @@ if [[ -f "$FWLIVE_DIR/view/status/fwlive.js" ]]; then
 	ssh -p "$OPENWRT_SSH_PORT" "${SSH_OPTS[@]}" "${OPENWRT_USER}@${OPENWRT_HOST}" \
 		"cat > /www/luci-static/resources/view/status/fwlive.js" \
 		< "$FWLIVE_DIR/view/status/fwlive.js"
-	ssh -p "$OPENWRT_SSH_PORT" "${SSH_OPTS[@]}" "${OPENWRT_USER}@${OPENWRT_HOST}" \
-		"cat > /www/luci-static/resources/fwlive/log.js" \
-		< "$FWLIVE_DIR/fwlive/log.js"
+	shopt -s nullglob
+	for js in "$FWLIVE_DIR"/fwlive/*.js; do
+		base=$(basename "$js")
+		echo "  sync fwlive/${base}"
+		ssh -p "$OPENWRT_SSH_PORT" "${SSH_OPTS[@]}" "${OPENWRT_USER}@${OPENWRT_HOST}" \
+			"cat > /www/luci-static/resources/fwlive/${base}" \
+			< "$js"
+	done
+	shopt -u nullglob
 	ssh -p "$OPENWRT_SSH_PORT" "${SSH_OPTS[@]}" "${OPENWRT_USER}@${OPENWRT_HOST}" \
 		"rm -f /www/luci-static/resources/fwlive/parser.js"
 fi


### PR DESCRIPTION
## Summary
- Add `fwlive/constants.js` as a plain LuCI module (`return { … }`).
- Wire `'require fwlive.constants as constants'` in the view; delete inlined copies.
- README shipped-files updated.

Part of #23 / #17. Design lock: Phase 0 spike.

### i18n note
Current `po/templates/luci-app-fwlive.pot` only references `view/status/fwlive.js` (where `_()` lives). `fwlive/log.js` / `constants.js` have no `_()`. Future `_()` under `resources/fwlive/` must be included when regenerating the pot.

## Test plan
- [x] `node --check` on `constants.js`
- [x] `./scripts/fwlive-test.sh`
- [ ] QEMU install + smoke (follow-up in this session)
- [ ] Row-limit select still works on LuCI page


Made with [Cursor](https://cursor.com)