### PR TITLE
refactor: Phase 2 extract links chips logging (#23)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -12,6 +12,9 @@ LuCI **Firewall Live View** — client-side JS view polling `ubus fwlive poll` (
 | `htdocs/luci-static/resources/fwlive/constants.js` | Shared view constants (plain LuCI `return { … }` module) |
 | `htdocs/luci-static/resources/fwlive/css.js` | Inline stylesheet string (`styleText` for `E('style', …)`) |
 | `htdocs/luci-static/resources/fwlive/tint.js` | Row-tint paint helpers (plain module) |
+| `htdocs/luci-static/resources/fwlive/links.js` | Link-builder helpers (pure + filter-aware; no host) |
+| `htdocs/luci-static/resources/fwlive/chips.js` | Filter-chip DOM renderer (`renderFilterChips`) |
+| `htdocs/luci-static/resources/fwlive/logging.js` | Logging toolbar and empty-state DOM renderers |
 | `root/usr/share/luci/menu.d/*.json` | Menu entry (`admin/status/fwlive`) |
 | `root/usr/share/rpcd/acl.d/*.json` | ubus ACL (read + write for logging enable/disable) |
 | `root/usr/libexec/rpcd/fwlive` | rpcd plugin (`rules`, `poll`, `resolve`, `logging_status`, `enable_wan_logging`, `disable_wan_logging`) |

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
@@ -1,0 +1,94 @@
+'use strict';
+'require fwlive.log as log';
+
+/**
+ * Filter-chip DOM renderer for luci-app-fwlive.
+ *
+ * renderFilterChips(host, state, callbacks) → void
+ *   host      - container element (cleared and rebuilt; element itself is kept)
+ *   state     - shallow copy: { filters: {q, action, interface, proto, src, dst, sport, dport},
+ *                               chipFields: [{key, label}, ...] }
+ *   callbacks - { onInvert(field, ev), onClear(field, ev), onClearAll(ev) }
+ *
+ * Modules must not mutate state. host is cleared then rebuilt (idempotent replace).
+ */
+
+function chipLabelNodes(field, val) {
+	const p = log.parseFilterValue(val);
+	if (!p.value)
+		return [ '' ];
+
+	if (!p.negate)
+		return [ log.formatFilterChipLabel(field, val) ];
+
+	if (field === 'q' || field === 'src' || field === 'dst')
+		return [
+			field + ': ',
+			E('strong', { 'class': 'fwlive-chip-not' }, 'not'),
+			' contains ' + p.value
+		];
+
+	return [
+		field + ': ',
+		E('strong', { 'class': 'fwlive-chip-not' }, 'not'),
+		' ' + p.value
+	];
+}
+
+function renderFilterChips(host, state, callbacks) {
+	const filters = state.filters || {};
+	const chipFields = state.chipFields || [];
+	const chips = [];
+
+	for (let i = 0; i < chipFields.length; i++) {
+		const spec = chipFields[i];
+		const val = filters[spec.key];
+		if (!val)
+			continue;
+
+		const parsed = log.parseFilterValue(val);
+		const negated = parsed.negate;
+
+		chips.push(E('span', {
+			'class': 'fwlive-chip' + (negated ? ' fwlive-chip-negated' : '')
+		}, [
+			E('span', { 'class': 'fwlive-chip-label' }, chipLabelNodes(spec.label, val)),
+			E('span', {
+				'class': 'fwlive-chip-invert-wrap',
+				'data-tip': negated ? _('Include instead') : _('Exclude instead')
+			}, [
+				E('button', {
+					'type': 'button',
+					'class': 'fwlive-chip-invert',
+					'click': function(ev) { callbacks.onInvert(spec.key, ev); }
+				}, '≠')
+			]),
+			E('a', {
+				'href': '#',
+				'class': 'fwlive-chip-remove',
+				'title': _('Remove filter'),
+				'click': function(ev) { callbacks.onClear(spec.key, ev); }
+			}, '×')
+		]));
+	}
+
+	host.innerHTML = '';
+	if (!chips.length) {
+		host.style.display = 'none';
+		return;
+	}
+
+	host.style.display = 'flex';
+	for (let i = 0; i < chips.length; i++)
+		host.appendChild(chips[i]);
+
+	host.appendChild(E('a', {
+		'href': '#',
+		'class': 'fwlive-chip-clear',
+		'click': function(ev) { callbacks.onClearAll(ev); }
+	}, _('Clear all')));
+}
+
+return {
+	renderFilterChips: renderFilterChips
+};

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
@@ -1,0 +1,150 @@
+'use strict';
+'require fwlive.log as log';
+
+/**
+ * Link-builder helpers for luci-app-fwlive.
+ *
+ * Pure helpers (no filter side-effects):
+ *   luciUrl, firewallZonesPath, firewallZonesUrl, firewallZonesLink
+ *
+ * Filter-aware helpers (require an onFilterClick callback):
+ *   filterLink, addrFilterLink, ruleAdminPath, ruleAdminLink, ifaceLink
+ *
+ * No host element — all functions return DOM nodes or strings.
+ * May require fwlive.log for formatCell.
+ */
+
+function luciUrl(path) {
+	if (typeof L !== 'undefined' && L.url)
+		return L.url(path);
+
+	return '/cgi-bin/luci/' + path;
+}
+
+function firewallZonesPath() {
+	return 'admin/network/firewall/zones';
+}
+
+function firewallZonesUrl() {
+	return luciUrl(firewallZonesPath());
+}
+
+function firewallZonesLink(label) {
+	return E('a', {
+		'href': firewallZonesUrl(),
+		'class': 'fwlive-filter-link'
+	}, label || _('Network → Firewall'));
+}
+
+/**
+ * @param {string} field  - filter field name
+ * @param {string} value  - filter value
+ * @param {string} [label] - display label (defaults to value)
+ * @param {function} onFilterClick - callback(field, value, ev)
+ */
+function filterLink(field, value, label, onFilterClick) {
+	if (!value)
+		return log.formatCell(value);
+
+	return E('a', {
+		'href': '#',
+		'class': 'fwlive-filter-link',
+		'title': _('Filter by %s').format(field),
+		'click': function(ev) { onFilterClick(field, value, ev); }
+	}, label || value);
+}
+
+/**
+ * @param {string} field  - filter field ('src' or 'dst')
+ * @param {string} ip     - IP address
+ * @param {boolean} showHostnames
+ * @param {Map|null} hostnameCache
+ * @param {function} onFilterClick - callback(field, value, ev)
+ */
+function addrFilterLink(field, ip, showHostnames, hostnameCache, onFilterClick) {
+	if (!ip)
+		return log.formatCell(ip);
+
+	const name = showHostnames && hostnameCache ? hostnameCache.get(ip) : null;
+	const display = name || ip;
+	const title = name ? ip : _('Filter by %s').format(field);
+
+	return E('a', {
+		'href': '#',
+		'class': 'fwlive-filter-link',
+		'title': title,
+		'click': function(ev) { onFilterClick(field, ip, ev); }
+	}, display);
+}
+
+/**
+ * @param {string} hint           - rule hint token
+ * @param {string} firewallBackend - 'nft' or 'iptables'
+ */
+function ruleAdminPath(hint, firewallBackend) {
+	if (hint === 'fw4')
+		return 'admin/network/firewall/rules';
+
+	if (firewallBackend === 'iptables')
+		return 'admin/status/iptables';
+
+	return 'admin/status/nftables';
+}
+
+/**
+ * @param {string} hint            - rule hint token
+ * @param {string} label           - display label
+ * @param {string} firewallBackend - 'nft' or 'iptables'
+ * @param {function} onFilterClick - callback(field, value, ev)
+ */
+function ruleAdminLink(hint, label, firewallBackend, onFilterClick) {
+	if (!hint)
+		return log.formatCell(hint);
+
+	const path = ruleAdminPath(hint, firewallBackend);
+	const url = '%s#%s'.format(luciUrl(path), encodeURIComponent(hint));
+	const text = label || hint;
+
+	return E('a', {
+		'href': '#',
+		'class': 'fwlive-filter-link fwlive-rule-link',
+		'title': _('Filter logs by rule (hint: %s). Ctrl+click to open firewall settings.').format(hint),
+		'click': function(ev) {
+			if (ev && (ev.ctrlKey || ev.metaKey)) {
+				if (ev.preventDefault)
+					ev.preventDefault();
+				window.location = url;
+				return;
+			}
+			onFilterClick('q', hint, ev);
+		}
+	}, text);
+}
+
+/**
+ * @param {string} value           - interface name
+ * @param {function} onFilterClick - callback(field, value, ev)
+ */
+function ifaceLink(value, onFilterClick) {
+	if (!value)
+		return log.formatCell(value);
+
+	return E('a', {
+		'href': '#',
+		'class': 'fwlive-filter-link fwlive-iface-badge',
+		'title': _('Filter by interface'),
+		'click': function(ev) { onFilterClick('interface', value, ev); }
+	}, value);
+}
+
+return {
+	luciUrl: luciUrl,
+	firewallZonesPath: firewallZonesPath,
+	firewallZonesUrl: firewallZonesUrl,
+	firewallZonesLink: firewallZonesLink,
+	filterLink: filterLink,
+	addrFilterLink: addrFilterLink,
+	ruleAdminPath: ruleAdminPath,
+	ruleAdminLink: ruleAdminLink,
+	ifaceLink: ifaceLink
+};

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
@@ -1,0 +1,186 @@
+'use strict';
+'require fwlive.links as links';
+
+/**
+ * Logging toolbar and empty-state DOM renderers for luci-app-fwlive.
+ *
+ * renderToolbar(host, state, callbacks) → void
+ *   host      - #fwlive-logging-bar element (cleared and rebuilt; element kept)
+ *   state     - shallow copy: { loggingStatus, loggingBusy, entriesLength,
+ *                               loggingNotice, firewallBackend }
+ *   callbacks - { onEnable() → Promise, onDisable() → Promise }
+ *
+ * renderManualTestNodes(host, state, callbacks) → void
+ *   host      - <ul> element inside #fwlive-help (cleared and rebuilt)
+ *   state     - shallow copy: { firewallBackend }
+ *   callbacks - {} (unused; present for API consistency)
+ *
+ * Empty-state helpers:
+ *   buildEmptyStateNodes(state) → Node[]
+ *   renderEmptyState(host, state, callbacks) → void
+ *     host      - #fwlive-empty element
+ *     state     - same as renderToolbar state
+ *     callbacks - { onEnable() → Promise }
+ *
+ * Modules must not mutate state. host is cleared then rebuilt (idempotent replace).
+ */
+
+function blockerCode(state) {
+	const blockers = (state.loggingStatus && state.loggingStatus.blockers) || [];
+	if (blockers.indexOf('no_wan_zone') >= 0)
+		return 'no_wan_zone';
+	if (blockers.indexOf('nf_log_ipv4_missing') >= 0 ||
+	    blockers.indexOf('nf_log_ipv6_missing') >= 0)
+		return 'nf_log_missing';
+	return '';
+}
+
+function renderToolbar(host, state, callbacks) {
+	host.innerHTML = '';
+	const st = state.loggingStatus;
+	if (!st) {
+		host.style.display = 'none';
+		return;
+	}
+
+	if (!st.wan_log && state.entriesLength === 0) {
+		host.style.display = 'none';
+		return;
+	}
+
+	host.style.display = 'flex';
+	const blocker = blockerCode(state);
+
+	if (blocker === 'no_wan_zone') {
+		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
+			_('WAN logging unavailable: no WAN zone')));
+		host.appendChild(links.firewallZonesLink());
+		return;
+	}
+
+	if (blocker === 'nf_log_missing') {
+		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
+			_('WAN logging unavailable: missing kernel log modules')));
+		return;
+	}
+
+	const limit = st.wan_log_limit || _('default 10/minute');
+	if (st.wan_log) {
+		host.appendChild(E('span', { 'class': 'fwlive-logging-status' }, [
+			_('WAN logging on ('),
+			E('a', {
+				'href': '#fwlive-help',
+				'class': 'fwlive-filter-link',
+				'title': _('This is the firewall zone log_limit. fwlive only displays events after fw3/fw4 applies this rate cap.'),
+				'click': function(ev) {
+					const help = document.getElementById('fwlive-help');
+					if (ev && ev.preventDefault)
+						ev.preventDefault();
+					if (help) {
+						help.open = true;
+						help.scrollIntoView({ block: 'nearest' });
+					}
+				}
+			}, limit),
+			_(')')
+		]));
+		host.appendChild(E('button', {
+			'class': 'cbi-button cbi-button-action',
+			'type': 'button',
+			'disabled': state.loggingBusy ? '' : null,
+			'click': function() { callbacks.onDisable(); }
+		}, state.loggingBusy ? _('Disabling…') : _('Disable logging')));
+		return;
+	}
+
+	host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
+		_('WAN logging off')));
+	host.appendChild(E('button', {
+		'class': 'cbi-button cbi-button-action',
+		'type': 'button',
+		'disabled': state.loggingBusy ? '' : null,
+		'click': function() { callbacks.onEnable(); }
+	}, state.loggingBusy ? _('Enabling…') : _('Enable logging')));
+}
+
+function buildEmptyStateNodes(state, callbacks) {
+	const nodes = [];
+	const st = state.loggingStatus;
+	const blocker = blockerCode(state);
+
+	if (state.loggingNotice) {
+		nodes.push(E('p', { 'class': 'fwlive-logging-notice' }, [
+			state.loggingNotice,
+			' ',
+			links.firewallZonesLink()
+		]));
+	}
+
+	if (blocker === 'no_wan_zone') {
+		nodes.push(E('p', {}, [
+			_('No WAN firewall zone found in /etc/config/firewall. Configure zones under '),
+			links.firewallZonesLink()
+		]));
+		return nodes;
+	}
+
+	if (blocker === 'nf_log_missing') {
+		nodes.push(E('p', {}, _('Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall.')));
+		nodes.push(E('p', {}, [
+			E('code', {}, 'opkg update && opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6')
+		]));
+		return nodes;
+	}
+
+	if (st && st.wan_log) {
+		nodes.push(E('p', {}, _('Logging is enabled on WAN. Waiting for firewall events — blocked inbound traffic appears here (not normal LAN browsing).')));
+		nodes.push(E('p', {}, links.firewallZonesLink(_('Open firewall zone settings'))));
+		return nodes;
+	}
+
+	nodes.push(E('p', {}, _('No firewall events yet. OpenWrt does not log firewall traffic until you turn it on.')));
+	nodes.push(E('p', {}, _('Enable logging to record blocked inbound traffic on WAN (rate-limited). Normal LAN browsing is not logged.')));
+	nodes.push(E('p', {}, [
+		E('button', {
+			'class': 'cbi-button cbi-button-action',
+			'type': 'button',
+			'disabled': state.loggingBusy ? '' : null,
+			'click': function() { callbacks.onEnable(); }
+		}, state.loggingBusy ? _('Enabling…') : _('Enable logging')),
+		' ',
+		links.firewallZonesLink()
+	]));
+	return nodes;
+}
+
+function renderEmptyState(host, state, callbacks) {
+	const nodes = buildEmptyStateNodes(state, callbacks);
+	host.innerHTML = '';
+	for (let i = 0; i < nodes.length; i++)
+		host.appendChild(nodes[i]);
+}
+
+/**
+ * renderManualTestNodes — fills a <li> host element with the backend-specific
+ * manual test instruction. Call from addFooter() after render() has inserted
+ * the placeholder <li id="fwlive-manual-test">.
+ */
+function renderManualTestNodes(host, state, _callbacks) {
+	host.innerHTML = '';
+	if (state.firewallBackend === 'iptables') {
+		host.appendChild(document.createTextNode(_('Manual test (System → Terminal): ')));
+		host.appendChild(E('code', {}, 'iptables -I INPUT -p icmp --icmp-type echo-request -j LOG --log-prefix "fwlive-ping: "'));
+		host.appendChild(document.createTextNode(_(' then ping the router.')));
+	} else {
+		host.appendChild(document.createTextNode(_('Manual test (System → Terminal): ')));
+		host.appendChild(E('code', {}, 'nft insert rule inet fw4 input ip protocol icmp icmp type echo-request log prefix "fwlive-ping " accept'));
+		host.appendChild(document.createTextNode(_(' then ping the router.')));
+	}
+}
+
+return {
+	renderToolbar: renderToolbar,
+	buildEmptyStateNodes: buildEmptyStateNodes,
+	renderEmptyState: renderEmptyState,
+	renderManualTestNodes: renderManualTestNodes
+};

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -11,6 +11,9 @@
 'require fwlive.constants as constants';
 'require fwlive.css as css';
 'require fwlive.tint as tint';
+'require fwlive.links as links';
+'require fwlive.chips as chips';
+'require fwlive.logging as logging';
 
 const callFwlivePoll = rpc.declare({
 	object: 'fwlive',
@@ -367,27 +370,6 @@ return view.extend({
 		}
 	},
 
-	filterChipLabelNodes(field, val) {
-		const p = log.parseFilterValue(val);
-		if (!p.value)
-			return [ '' ];
-
-		if (!p.negate)
-			return [ log.formatFilterChipLabel(field, val) ];
-
-		if (field === 'q' || field === 'src' || field === 'dst')
-			return [
-				field + ': ',
-				E('strong', { 'class': 'fwlive-chip-not' }, 'not'),
-				' contains ' + p.value
-			];
-
-		return [
-			field + ': ',
-			E('strong', { 'class': 'fwlive-chip-not' }, 'not'),
-			' ' + p.value
-		];
-	},
 
 	setViewMode(mode) {
 		if (constants.VIEW_MODES.indexOf(mode) < 0 || mode === this.viewMode)
@@ -595,18 +577,15 @@ return view.extend({
 	},
 
 	firewallZonesPath() {
-		return 'admin/network/firewall/zones';
+		return links.firewallZonesPath();
 	},
 
 	firewallZonesUrl() {
-		return this.luciUrl(this.firewallZonesPath());
+		return links.firewallZonesUrl();
 	},
 
 	firewallZonesLink(label) {
-		return E('a', {
-			'href': this.firewallZonesUrl(),
-			'class': 'fwlive-filter-link'
-		}, label || _('Network → Firewall'));
+		return links.firewallZonesLink(label);
 	},
 
 	loggingHasBlocker(code) {
@@ -625,21 +604,6 @@ return view.extend({
 		return '';
 	},
 
-	manualLoggingTestNodes() {
-		if (this.firewallBackend === 'iptables') {
-			return E('li', {}, [
-				_('Manual test (System → Terminal): '),
-				E('code', {}, 'iptables -I INPUT -p icmp --icmp-type echo-request -j LOG --log-prefix "fwlive-ping: "'),
-				_(' then ping the router.')
-			]);
-		}
-
-		return E('li', {}, [
-			_('Manual test (System → Terminal): '),
-			E('code', {}, 'nft insert rule inet fw4 input ip protocol icmp icmp type echo-request log prefix "fwlive-ping " accept'),
-			_(' then ping the router.')
-		]);
-	},
 
 	async loadLoggingStatus() {
 		try {
@@ -716,125 +680,25 @@ return view.extend({
 		}
 	},
 
+	loggingState() {
+		return {
+			loggingStatus: this.loggingStatus,
+			loggingBusy: this.loggingBusy,
+			entriesLength: this.entries.length,
+			loggingNotice: this.loggingNotice,
+			firewallBackend: this.firewallBackend
+		};
+	},
+
 	updateLoggingToolbarUi() {
 		const bar = document.getElementById('fwlive-logging-bar');
 		if (!bar)
 			return;
 
-		bar.innerHTML = '';
-		const st = this.loggingStatus;
-		if (!st) {
-			bar.style.display = 'none';
-			return;
-		}
-
-		if (!st.wan_log && this.entries.length === 0) {
-			bar.style.display = 'none';
-			return;
-		}
-
-		bar.style.display = 'flex';
-		const blocker = this.loggingBlockerMessage();
-		if (blocker === 'no_wan_zone') {
-			bar.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-				_('WAN logging unavailable: no WAN zone')));
-			bar.appendChild(this.firewallZonesLink());
-			return;
-		}
-
-		if (blocker === 'nf_log_missing') {
-			bar.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-				_('WAN logging unavailable: missing kernel log modules')));
-			return;
-		}
-
-		const limit = st.wan_log_limit || _('default 10/minute');
-		if (st.wan_log) {
-			bar.appendChild(E('span', { 'class': 'fwlive-logging-status' }, [
-				_('WAN logging on ('),
-				E('a', {
-					'href': '#fwlive-help',
-					'class': 'fwlive-filter-link',
-					'title': _('This is the firewall zone log_limit. fwlive only displays events after fw3/fw4 applies this rate cap.'),
-					'click': function(ev) {
-						const help = document.getElementById('fwlive-help');
-						if (ev && ev.preventDefault)
-							ev.preventDefault();
-						if (help) {
-							help.open = true;
-							help.scrollIntoView({ block: 'nearest' });
-						}
-					}
-				}, limit),
-				_(')')
-			]));
-			bar.appendChild(E('button', {
-				'class': 'cbi-button cbi-button-action',
-				'type': 'button',
-				'disabled': this.loggingBusy ? '' : null,
-				'click': this.handleDisableLogging.bind(this)
-			}, this.loggingBusy ? _('Disabling…') : _('Disable logging')));
-			return;
-		}
-
-		bar.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-			_('WAN logging off')));
-		bar.appendChild(E('button', {
-			'class': 'cbi-button cbi-button-action',
-			'type': 'button',
-			'disabled': this.loggingBusy ? '' : null,
-			'click': this.handleEnableLogging.bind(this)
-		}, this.loggingBusy ? _('Enabling…') : _('Enable logging')));
-	},
-
-	buildEmptyStateNodes() {
-		const nodes = [];
-		const st = this.loggingStatus;
-		const blocker = this.loggingBlockerMessage();
-
-		if (this.loggingNotice) {
-			nodes.push(E('p', { 'class': 'fwlive-logging-notice' }, [
-				this.loggingNotice,
-				' ',
-				this.firewallZonesLink()
-			]));
-		}
-
-		if (blocker === 'no_wan_zone') {
-			nodes.push(E('p', {}, [
-				_('No WAN firewall zone found in /etc/config/firewall. Configure zones under '),
-				this.firewallZonesLink()
-			]));
-			return nodes;
-		}
-
-		if (blocker === 'nf_log_missing') {
-			nodes.push(E('p', {}, _('Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall.')));
-			nodes.push(E('p', {}, [
-				E('code', {}, 'opkg update && opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6')
-			]));
-			return nodes;
-		}
-
-		if (st && st.wan_log) {
-			nodes.push(E('p', {}, _('Logging is enabled on WAN. Waiting for firewall events — blocked inbound traffic appears here (not normal LAN browsing).')));
-			nodes.push(E('p', {}, this.firewallZonesLink(_('Open firewall zone settings'))));
-			return nodes;
-		}
-
-		nodes.push(E('p', {}, _('No firewall events yet. OpenWrt does not log firewall traffic until you turn it on.')));
-		nodes.push(E('p', {}, _('Enable logging to record blocked inbound traffic on WAN (rate-limited). Normal LAN browsing is not logged.')));
-		nodes.push(E('p', {}, [
-			E('button', {
-				'class': 'cbi-button cbi-button-action',
-				'type': 'button',
-				'disabled': this.loggingBusy ? '' : null,
-				'click': this.handleEnableLogging.bind(this)
-			}, this.loggingBusy ? _('Enabling…') : _('Enable logging')),
-			' ',
-			this.firewallZonesLink()
-		]));
-		return nodes;
+		logging.renderToolbar(bar, this.loggingState(), {
+			onEnable: () => this.handleEnableLogging(),
+			onDisable: () => this.handleDisableLogging()
+		});
 	},
 
 	updateEmptyStateUi() {
@@ -843,10 +707,9 @@ return view.extend({
 			return;
 
 		const visible = empty.style.display !== 'none';
-		const nodes = this.buildEmptyStateNodes();
-		empty.innerHTML = '';
-		for (let i = 0; i < nodes.length; i++)
-			empty.appendChild(nodes[i]);
+		logging.renderEmptyState(empty, this.loggingState(), {
+			onEnable: () => this.handleEnableLogging()
+		});
 		if (visible)
 			empty.style.display = 'block';
 	},
@@ -1225,32 +1088,14 @@ return view.extend({
 	},
 
 	filterLink(field, value, label) {
-		if (!value)
-			return log.formatCell(value);
-
-		return E('a', {
-			'href': '#',
-			'class': 'fwlive-filter-link',
-			'title': _('Filter by %s').format(field),
-			'click': this.filterClick.bind(this, field, value)
-		}, label || value);
+		return links.filterLink(field, value, label,
+			(f, v, ev) => this.filterClick(f, v, ev));
 	},
 
 	addrFilterLink(field, ip) {
-		if (!ip)
-			return log.formatCell(ip);
-
-		const name = this.showHostnames && this.hostnameCache
-			? this.hostnameCache.get(ip) : null;
-		const display = name || ip;
-		const title = name ? ip : _('Filter by %s').format(field);
-
-		return E('a', {
-			'href': '#',
-			'class': 'fwlive-filter-link',
-			'title': title,
-			'click': this.filterClick.bind(this, field, ip)
-		}, display);
+		return links.addrFilterLink(field, ip,
+			this.showHostnames, this.hostnameCache,
+			(f, v, ev) => this.filterClick(f, v, ev));
 	},
 
 	collectIpsFromEntries(entries) {
@@ -1315,57 +1160,20 @@ return view.extend({
 	},
 
 	ruleAdminPath(hint) {
-		if (hint === 'fw4')
-			return 'admin/network/firewall/rules';
-
-		if (this.firewallBackend === 'iptables')
-			return 'admin/status/iptables';
-
-		return 'admin/status/nftables';
+		return links.ruleAdminPath(hint, this.firewallBackend);
 	},
 
 	luciUrl(path) {
-		if (typeof L !== 'undefined' && L.url)
-			return L.url(path);
-
-		return '/cgi-bin/luci/' + path;
+		return links.luciUrl(path);
 	},
 
 	ruleAdminLink(hint, label) {
-		if (!hint)
-			return log.formatCell(hint);
-
-		const path = this.ruleAdminPath(hint);
-		const url = '%s#%s'.format(this.luciUrl(path), encodeURIComponent(hint));
-		const text = label || hint;
-
-		return E('a', {
-			'href': '#',
-			'class': 'fwlive-filter-link fwlive-rule-link',
-			'title': _('Filter logs by rule (hint: %s). Ctrl+click to open firewall settings.').format(hint),
-			'click': function(ev) {
-				if (ev && (ev.ctrlKey || ev.metaKey)) {
-					if (ev.preventDefault)
-						ev.preventDefault();
-					window.location = url;
-					return;
-				}
-
-				this.filterClick('q', hint, ev);
-			}.bind(this)
-		}, text);
+		return links.ruleAdminLink(hint, label, this.firewallBackend,
+			(f, v, ev) => this.filterClick(f, v, ev));
 	},
 
 	ifaceLink(value) {
-		if (!value)
-			return log.formatCell(value);
-
-		return E('a', {
-			'href': '#',
-			'class': 'fwlive-filter-link fwlive-iface-badge',
-			'title': _('Filter by interface'),
-			'click': this.filterClick.bind(this, 'interface', value)
-		}, value);
+		return links.ifaceLink(value, (f, v, ev) => this.filterClick(f, v, ev));
 	},
 
 	setFilterFieldValue(field, value) {
@@ -1420,56 +1228,14 @@ return view.extend({
 		if (!bar)
 			return;
 
-		const filters = this.readFilters();
-		const chips = [];
-
-		for (let i = 0; i < this.FILTER_CHIP_FIELDS.length; i++) {
-			const spec = this.FILTER_CHIP_FIELDS[i];
-			const val = filters[spec.key];
-			if (!val)
-				continue;
-
-			const parsed = log.parseFilterValue(val);
-			const negated = parsed.negate;
-
-			chips.push(E('span', {
-				'class': 'fwlive-chip' + (negated ? ' fwlive-chip-negated' : '')
-			}, [
-				E('span', { 'class': 'fwlive-chip-label' }, this.filterChipLabelNodes(spec.label, val)),
-				E('span', {
-					'class': 'fwlive-chip-invert-wrap',
-					'data-tip': negated ? _('Include instead') : _('Exclude instead')
-				}, [
-					E('button', {
-						'type': 'button',
-						'class': 'fwlive-chip-invert',
-						'click': this.invertFilter.bind(this, spec.key)
-					}, '≠')
-				]),
-				E('a', {
-					'href': '#',
-					'class': 'fwlive-chip-remove',
-					'title': _('Remove filter'),
-					'click': this.clearFilter.bind(this, spec.key)
-				}, '×')
-			]));
-		}
-
-		bar.innerHTML = '';
-		if (!chips.length) {
-			bar.style.display = 'none';
-			return;
-		}
-
-		bar.style.display = 'flex';
-		for (let i = 0; i < chips.length; i++)
-			bar.appendChild(chips[i]);
-
-		bar.appendChild(E('a', {
-			'href': '#',
-			'class': 'fwlive-chip-clear',
-			'click': this.clearAllFilters.bind(this)
-		}, _('Clear all')));
+		chips.renderFilterChips(bar, {
+			filters: Object.assign({}, this.readFilters()),
+			chipFields: this.FILTER_CHIP_FIELDS
+		}, {
+			onInvert: (field, ev) => this.invertFilter(field, ev),
+			onClear: (field, ev) => this.clearFilter(field, ev),
+			onClearAll: (ev) => this.clearAllFilters(ev)
+		});
 	},
 
 	readMessageLayout() {
@@ -1790,7 +1556,7 @@ return view.extend({
 					E('li', {}, _('The table updates automatically when your firewall logs traffic. Use Enable logging if the table is empty on a stock config.')),
 					E('li', {}, _('Enable logging turns on WAN zone drop/reject logging (same as Network → Firewall). LAN browsing is not logged by default.')),
 					E('li', {}, _('The rate shown next to WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap.')),
-					this.manualLoggingTestNodes(),
+					E('li', { 'id': 'fwlive-manual-test' }, []),
 					E('li', {}, _('Click a row to see the full log line (Simple view).')),
 					E('li', {}, _('Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead.')),
 					E('li', {}, _('Use Show Detail for all columns (flags, length, raw message).')),
@@ -1819,6 +1585,9 @@ return view.extend({
 		this.updateBackendUi();
 		this.updateTintWarnUi();
 		this.renderRows(true);
+		const testLi = document.getElementById('fwlive-manual-test');
+		if (testLi)
+			logging.renderManualTestNodes(testLi, { firewallBackend: this.firewallBackend }, {});
 		if (this.showHostnames)
 			this.resolveHostnamesForEntries(this.filteredRows());
 	}


### PR DESCRIPTION
## Summary
- Add `fwlive/links.js`, `fwlive/chips.js`, `fwlive/logging.js` with Design lock B1 contracts.
- View delegates via thin wrappers; contiguous `'require'` block; README updated.
- Entry `wc -l`: 1594 (guideline ~1200 — soft).

Part of #23.

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [ ] QEMU install + smoke
- [ ] Filters / negate / logging toolbar on LuCI page


Made with [Cursor](https://cursor.com)