### PR TITLE
refactor: Phase 3 extract fwlive table (#23)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -15,6 +15,7 @@ LuCI **Firewall Live View** — client-side JS view polling `ubus fwlive poll` (
 | `htdocs/luci-static/resources/fwlive/links.js` | Link-builder helpers (pure + filter-aware; no host) |
 | `htdocs/luci-static/resources/fwlive/chips.js` | Filter-chip DOM renderer (`renderFilterChips`) |
 | `htdocs/luci-static/resources/fwlive/logging.js` | Logging toolbar and empty-state DOM renderers |
+| `htdocs/luci-static/resources/fwlive/table.js` | Table thead/rows DOM renderer (`renderThead`, `renderRows`) |
 | `root/usr/share/luci/menu.d/*.json` | Menu entry (`admin/status/fwlive`) |
 | `root/usr/share/rpcd/acl.d/*.json` | ubus ACL (read + write for logging enable/disable) |
 | `root/usr/libexec/rpcd/fwlive` | rpcd plugin (`rules`, `poll`, `resolve`, `logging_status`, `enable_wan_logging`, `disable_wan_logging`) |

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
@@ -1,0 +1,228 @@
+'use strict';
+'require fwlive.log as log';
+'require fwlive.links as links';
+
+/**
+ * Table thead/rows DOM renderer for luci-app-fwlive.
+ *
+ * renderThead(host, state, callbacks) → void
+ *   host      - <table id="fwlive-table"> (colgroup + thead tr cleared/rebuilt)
+ *   state     - shallow copy: { columns: [...] }
+ *   callbacks - {} (unused; present for API consistency)
+ *
+ * renderRows(host, state, callbacks) → void
+ *   host      - <tbody> element (cleared and rebuilt; element itself is kept)
+ *   state     - shallow copy: { rows, columns, viewMode, messageLayout,
+ *                               expandedRowId, rowTint, showHostnames,
+ *                               hostnameCache, firewallBackend }
+ *   callbacks - { onRowClick(rowId, ev), onFilterClick(field, value, ev),
+ *                 actionRowTintClass(action) }
+ *
+ * Internals (not a second public contract): columnLabel, columnCellClass,
+ * flowCell, buildColumnCell.
+ *
+ * Modules must not mutate state. host contents are cleared then rebuilt
+ * (idempotent replace). Does not touch #fwlive-scroll or #fwlive-empty.
+ */
+
+function columnLabel(col) {
+	const labels = {
+		time: _('Time'),
+		action: _('Action'),
+		rule: _('Rule'),
+		iface: _('Interface'),
+		iface_in: _('IN'),
+		iface_out: _('OUT'),
+		dir: _('Dir'),
+		proto: _('Proto'),
+		src: _('Source'),
+		dst: _('Destination'),
+		sport: _('SPort'),
+		dport: _('DPort'),
+		flags: _('Flags'),
+		len: _('Len'),
+		flow: _('Flow'),
+		message: _('Message')
+	};
+
+	return labels[col] || col;
+}
+
+function columnCellClass(col) {
+	switch (col) {
+	case 'time': return 'fwlive-time';
+	case 'action': return 'fwlive-action';
+	case 'rule': return 'fwlive-rule';
+	case 'iface':
+	case 'iface_in':
+	case 'iface_out': return 'fwlive-iface';
+	case 'dir': return 'fwlive-dir';
+	case 'proto': return 'fwlive-proto';
+	case 'src':
+	case 'dst': return 'fwlive-addr';
+	case 'sport':
+	case 'dport': return 'fwlive-port';
+	case 'flags': return 'fwlive-flags';
+	case 'len': return 'fwlive-len';
+	case 'flow': return 'fwlive-flow-cell';
+	case 'message': return 'fwlive-message fwlive-th-message';
+	default: return '';
+	}
+}
+
+function flowCell(row, state, callbacks) {
+	const parts = [];
+	const onFilterClick = callbacks.onFilterClick;
+	const pushAddr = (addr, port, addrField, portField) => {
+		if (!addr && !port)
+			return;
+
+		if (addr)
+			parts.push(links.addrFilterLink(addrField, addr,
+				!!state.showHostnames, state.hostnameCache, onFilterClick));
+		if (port) {
+			if (addr)
+				parts.push(':');
+			parts.push(links.filterLink(portField, port, port, onFilterClick));
+		}
+	};
+
+	pushAddr(row.src, row.sport, 'src', 'sport');
+	if (parts.length && (row.dst || row.dport))
+		parts.push(E('span', { 'class': 'fwlive-flow-arrow' }, ' → '));
+	pushAddr(row.dst, row.dport, 'dst', 'dport');
+
+	if (!parts.length)
+		return '—';
+
+	return E('span', { 'class': 'fwlive-flow' }, parts);
+}
+
+function buildColumnCell(col, row, state, callbacks) {
+	const onFilterClick = callbacks.onFilterClick;
+	const msgDisplay = log.formatMessageDisplay(row.message, state.messageLayout);
+	const actionCell = row.action && row.action !== 'unknown'
+		? links.filterLink('action', row.action, log.formatActionLabel(row.action), onFilterClick)
+		: log.formatActionLabel(row.action);
+
+	switch (col) {
+	case 'time':
+		return E('td', { 'class': columnCellClass(col) },
+			state.viewMode === 'simple'
+				? log.formatTimestampCompact(row.timestamp)
+				: log.formatTimestampLocal(row.timestamp));
+	case 'action':
+		return E('td', { 'class': log.actionRowClass(row.action) }, actionCell);
+	case 'rule':
+		return E('td', { 'class': columnCellClass(col) },
+			links.ruleAdminLink(row.rule_hint, row.rule_label, state.firewallBackend, onFilterClick));
+	case 'iface':
+		return E('td', { 'class': columnCellClass(col) },
+			links.ifaceLink(row.interface_in, onFilterClick));
+	case 'iface_in':
+	case 'iface_out':
+		return E('td', { 'class': columnCellClass(col) }, links.ifaceLink(
+			col === 'iface_in' ? row.interface_in : row.interface_out, onFilterClick));
+	case 'dir':
+		return E('td', { 'class': columnCellClass(col) }, log.formatCell(row.direction));
+	case 'proto':
+		return E('td', { 'class': columnCellClass(col) },
+			links.filterLink('proto', row.proto, null, onFilterClick));
+	case 'src':
+		return E('td', { 'class': columnCellClass(col) },
+			links.addrFilterLink('src', row.src, !!state.showHostnames, state.hostnameCache, onFilterClick));
+	case 'sport':
+		return E('td', { 'class': columnCellClass(col) },
+			links.filterLink('sport', row.sport, null, onFilterClick));
+	case 'dst':
+		return E('td', { 'class': columnCellClass(col) },
+			links.addrFilterLink('dst', row.dst, !!state.showHostnames, state.hostnameCache, onFilterClick));
+	case 'dport':
+		return E('td', { 'class': columnCellClass(col) },
+			links.filterLink('dport', row.dport, null, onFilterClick));
+	case 'flags':
+		return E('td', { 'class': columnCellClass(col) }, log.formatCell(row.flags));
+	case 'len':
+		return E('td', { 'class': columnCellClass(col) }, row.length != null ? String(row.length) : '');
+	case 'flow':
+		return E('td', { 'class': columnCellClass(col) }, flowCell(row, state, callbacks));
+	case 'message':
+		if (state.messageLayout === 'wrap') {
+			return E('td', {
+				'class': 'fwlive-message',
+				'title': msgDisplay || ''
+			}, E('div', { 'class': 'fwlive-message-wrap' }, msgDisplay || '—'));
+		}
+		return E('td', {
+			'class': 'fwlive-message',
+			'title': msgDisplay || ''
+		}, msgDisplay || '—');
+	default:
+		return E('td', {}, '');
+	}
+}
+
+function renderThead(host, state, callbacks) {
+	const columns = state.columns || [];
+	const tr = host.querySelector('thead tr');
+	if (!tr)
+		return;
+
+	let colgroup = host.querySelector('colgroup');
+
+	if (!colgroup) {
+		colgroup = E('colgroup', {});
+		host.insertBefore(colgroup, host.firstChild);
+	}
+
+	colgroup.innerHTML = '';
+	tr.innerHTML = '';
+
+	for (let i = 0; i < columns.length; i++) {
+		const col = columns[i];
+		colgroup.appendChild(E('col', { 'class': 'fwlive-col fwlive-col-' + col.replace(/_/g, '-') }));
+		tr.appendChild(E('th', { 'class': columnCellClass(col) }, columnLabel(col)));
+	}
+}
+
+function renderRows(host, state, callbacks) {
+	const rows = state.rows || [];
+	const columns = state.columns || [];
+
+	host.innerHTML = '';
+
+	for (let i = 0; i < rows.length; i++) {
+		const r = rows[i];
+		const rowClass = [
+			i % 2 ? 'fwlive-row-alt' : '',
+			state.viewMode === 'simple' ? 'fwlive-row-clickable' : '',
+			state.expandedRowId === r.id ? 'fwlive-row-expanded' : '',
+			state.rowTint ? callbacks.actionRowTintClass(r.action) : ''
+		].filter(Boolean).join(' ');
+		const cells = [];
+		for (let c = 0; c < columns.length; c++)
+			cells.push(buildColumnCell(columns[c], r, state, callbacks));
+
+		const tr = E('tr', {
+			'class': rowClass,
+			'click': state.viewMode === 'simple'
+				? (ev) => callbacks.onRowClick(r.id, ev) : null
+		}, cells);
+		host.appendChild(tr);
+
+		if (state.viewMode === 'simple' && state.expandedRowId === r.id) {
+			host.appendChild(E('tr', { 'class': 'fwlive-msg-expand' }, [
+				E('td', { 'colspan': String(columns.length) }, [
+					E('div', { 'class': 'fwlive-msg-expand-label' }, _('Message')),
+					E('pre', { 'class': 'fwlive-msg-expand-body' },
+						log.formatMessageDisplay(r.message, 'wrap') || '—')
+				])
+			]));
+		}
+	}
+}
+
+return {
+	renderThead: renderThead,
+	renderRows: renderRows
+};

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -14,6 +14,7 @@
 'require fwlive.links as links';
 'require fwlive.chips as chips';
 'require fwlive.logging as logging';
+'require fwlive.table as table';
 
 const callFwlivePoll = rpc.declare({
 	object: 'fwlive',
@@ -325,52 +326,6 @@ return view.extend({
 		return constants.COLUMN_SETS[this.viewMode] || constants.COLUMN_SETS.simple;
 	},
 
-	columnLabel(col) {
-		const labels = {
-			time: _('Time'),
-			action: _('Action'),
-			rule: _('Rule'),
-			iface: _('Interface'),
-			iface_in: _('IN'),
-			iface_out: _('OUT'),
-			dir: _('Dir'),
-			proto: _('Proto'),
-			src: _('Source'),
-			dst: _('Destination'),
-			sport: _('SPort'),
-			dport: _('DPort'),
-			flags: _('Flags'),
-			len: _('Len'),
-			flow: _('Flow'),
-			message: _('Message')
-		};
-
-		return labels[col] || col;
-	},
-
-	columnCellClass(col) {
-		switch (col) {
-		case 'time': return 'fwlive-time';
-		case 'action': return 'fwlive-action';
-		case 'rule': return 'fwlive-rule';
-		case 'iface':
-		case 'iface_in':
-		case 'iface_out': return 'fwlive-iface';
-		case 'dir': return 'fwlive-dir';
-		case 'proto': return 'fwlive-proto';
-		case 'src':
-		case 'dst': return 'fwlive-addr';
-		case 'sport':
-		case 'dport': return 'fwlive-port';
-		case 'flags': return 'fwlive-flags';
-		case 'len': return 'fwlive-len';
-		case 'flow': return 'fwlive-flow-cell';
-		case 'message': return 'fwlive-message fwlive-th-message';
-		default: return '';
-		}
-	},
-
-
 	setViewMode(mode) {
 		if (constants.VIEW_MODES.indexOf(mode) < 0 || mode === this.viewMode)
 			return;
@@ -435,113 +390,12 @@ return view.extend({
 		this.renderRows(true);
 	},
 
-	flowCell(row) {
-		const parts = [];
-		const pushAddr = (addr, port, addrField, portField) => {
-			if (!addr && !port)
-				return;
-
-			if (addr)
-				parts.push(this.addrFilterLink(addrField, addr));
-			if (port) {
-				if (addr)
-					parts.push(':');
-				parts.push(this.filterLink(portField, port, port));
-			}
-		};
-
-		pushAddr(row.src, row.sport, 'src', 'sport');
-		if (parts.length && (row.dst || row.dport))
-			parts.push(E('span', { 'class': 'fwlive-flow-arrow' }, ' → '));
-		pushAddr(row.dst, row.dport, 'dst', 'dport');
-
-		if (!parts.length)
-			return '—';
-
-		return E('span', { 'class': 'fwlive-flow' }, parts);
-	},
-
-	buildColumnCell(col, row) {
-		const msgDisplay = log.formatMessageDisplay(row.message, this.messageLayout);
-		const actionCell = row.action && row.action !== 'unknown'
-			? this.filterLink('action', row.action, log.formatActionLabel(row.action))
-			: log.formatActionLabel(row.action);
-
-		switch (col) {
-		case 'time':
-			return E('td', { 'class': this.columnCellClass(col) },
-				this.viewMode === 'simple'
-					? log.formatTimestampCompact(row.timestamp)
-					: log.formatTimestampLocal(row.timestamp));
-		case 'action':
-			return E('td', { 'class': log.actionRowClass(row.action) }, actionCell);
-		case 'rule':
-			return E('td', { 'class': this.columnCellClass(col) }, this.ruleAdminLink(row.rule_hint, row.rule_label));
-		case 'iface':
-			return E('td', { 'class': this.columnCellClass(col) }, this.ifaceLink(row.interface_in));
-		case 'iface_in':
-		case 'iface_out':
-			return E('td', { 'class': this.columnCellClass(col) }, this.ifaceLink(
-				col === 'iface_in' ? row.interface_in : row.interface_out));
-		case 'dir':
-			return E('td', { 'class': this.columnCellClass(col) }, log.formatCell(row.direction));
-		case 'proto':
-			return E('td', { 'class': this.columnCellClass(col) }, this.filterLink('proto', row.proto));
-		case 'src':
-			return E('td', { 'class': this.columnCellClass(col) }, this.addrFilterLink('src', row.src));
-		case 'sport':
-			return E('td', { 'class': this.columnCellClass(col) }, this.filterLink('sport', row.sport));
-		case 'dst':
-			return E('td', { 'class': this.columnCellClass(col) }, this.addrFilterLink('dst', row.dst));
-		case 'dport':
-			return E('td', { 'class': this.columnCellClass(col) }, this.filterLink('dport', row.dport));
-		case 'flags':
-			return E('td', { 'class': this.columnCellClass(col) }, log.formatCell(row.flags));
-		case 'len':
-			return E('td', { 'class': this.columnCellClass(col) }, row.length != null ? String(row.length) : '');
-		case 'flow':
-			return E('td', { 'class': this.columnCellClass(col) }, this.flowCell(row));
-		case 'message':
-			if (this.messageLayout === 'wrap') {
-				return E('td', {
-					'class': 'fwlive-message',
-					'title': msgDisplay || ''
-				}, E('div', { 'class': 'fwlive-message-wrap' }, msgDisplay || '—'));
-			}
-			return E('td', {
-				'class': 'fwlive-message',
-				'title': msgDisplay || ''
-			}, msgDisplay || '—');
-		default:
-			return E('td', {}, '');
-		}
-	},
-
 	renderThead() {
-		const table = document.getElementById('fwlive-table');
-		if (!table)
+		const el = document.getElementById('fwlive-table');
+		if (!el)
 			return;
 
-		const tr = table.querySelector('thead tr');
-		if (!tr)
-			return;
-
-		const cols = this.activeColumns();
-		let colgroup = table.querySelector('colgroup');
-
-		if (!colgroup) {
-			colgroup = E('colgroup', {});
-			table.insertBefore(colgroup, table.firstChild);
-		}
-
-		colgroup.innerHTML = '';
-		tr.innerHTML = '';
-
-		for (let i = 0; i < cols.length; i++) {
-			const col = cols[i];
-			colgroup.appendChild(E('col', { 'class': 'fwlive-col fwlive-col-' + col.replace(/_/g, '-') }));
-			tr.appendChild(E('th', { 'class': this.columnCellClass(col) }, this.columnLabel(col)));
-		}
+		table.renderThead(el, { columns: this.activeColumns().slice() }, {});
 	},
 
 	async loadRulesMap() {
@@ -1285,11 +1139,11 @@ return view.extend({
 	},
 
 	renderRows(force) {
-		const table = document.getElementById('fwlive-table');
-		if (!table)
+		const el = document.getElementById('fwlive-table');
+		if (!el)
 			return;
 
-		const body = table.querySelector('tbody');
+		const body = el.querySelector('tbody');
 		const empty = document.getElementById('fwlive-empty');
 		const scroll = document.getElementById('fwlive-scroll');
 		this.updateHash(this.readFilters());
@@ -1315,42 +1169,26 @@ return view.extend({
 
 		const prevScroll = scroll ? scroll.scrollTop : 0;
 
-		body.innerHTML = '';
 		if (empty)
 			empty.style.display = rows.length ? 'none' : 'block';
 		this.updateStatus(rows);
 		this.renderFilterChips();
 
-		const cols = this.activeColumns();
-		for (let i = 0; i < rows.length; i++) {
-			const r = rows[i];
-			const rowClass = [
-				i % 2 ? 'fwlive-row-alt' : '',
-				this.viewMode === 'simple' ? 'fwlive-row-clickable' : '',
-				this.expandedRowId === r.id ? 'fwlive-row-expanded' : '',
-				this.rowTint ? this.actionRowTintClass(r.action) : ''
-			].filter(Boolean).join(' ');
-			const cells = [];
-			for (let c = 0; c < cols.length; c++)
-				cells.push(this.buildColumnCell(cols[c], r));
-
-			const tr = E('tr', {
-				'class': rowClass,
-				'click': this.viewMode === 'simple'
-					? this.onRowClick.bind(this, r.id) : null
-			}, cells);
-			body.appendChild(tr);
-
-			if (this.viewMode === 'simple' && this.expandedRowId === r.id) {
-				body.appendChild(E('tr', { 'class': 'fwlive-msg-expand' }, [
-					E('td', { 'colspan': String(cols.length) }, [
-						E('div', { 'class': 'fwlive-msg-expand-label' }, _('Message')),
-						E('pre', { 'class': 'fwlive-msg-expand-body' },
-							log.formatMessageDisplay(r.message, 'wrap') || '—')
-					])
-				]));
-			}
-		}
+		table.renderRows(body, {
+			rows: rows.slice(),
+			columns: this.activeColumns().slice(),
+			viewMode: this.viewMode,
+			messageLayout: this.messageLayout,
+			expandedRowId: this.expandedRowId,
+			rowTint: !!this.rowTint,
+			showHostnames: !!this.showHostnames,
+			hostnameCache: this.hostnameCache,
+			firewallBackend: this.firewallBackend
+		}, {
+			onRowClick: (rowId, ev) => this.onRowClick(rowId, ev),
+			onFilterClick: (field, value, ev) => this.filterClick(field, value, ev),
+			actionRowTintClass: (action) => this.actionRowTintClass(action)
+		});
 
 		if (scroll) {
 			if (!this.paused && this.followLive)


### PR DESCRIPTION
## Summary
- Add `fwlive/table.js` with locked APIs `renderThead` / `renderRows` (internals: column cells, flow).
- View keeps orchestration, scrollTop save/restore, empty/chips/status/tint probe.
- Entry `wc -l`: 1432 (guideline ~600–800 orchestration — soft; remaining LOC is poll/prefs/logging glue).
- `table.js`: 228 LOC. Part of #23.

## Test plan
- [x] `./scripts/fwlive-test.sh` + `./scripts/validate-baseline.sh`
- [ ] QEMU install + smoke
- [ ] scrollTop save/restore when paused / scrolled up
- [ ] Detail toggle thead/columns; row expand in simple mode
- [ ] Filter links in cells; hostnames; row tint
- [ ] 10× re-render sanity (DevTools: toggle detail / filters)


Made with [Cursor](https://cursor.com)