### PR TITLE
docs: Stack 3/5 — Restructure over-long user and reference docs

### DIFF
--- a/docs/binary-feed.md
+++ b/docs/binary-feed.md
@@ -6,6 +6,8 @@ Signed **opkg** / **apk** feed for installing `luci-app-fwlive` with `opkg insta
 
 Manual `.ipk` / `.apk` downloads remain on [GitHub Releases](https://github.com/lucas-albers-lz4/fwlive/releases). See [Installation](user/installation.md).
 
+---
+
 ## Feed layout
 
 ```text
@@ -33,11 +35,13 @@ fwlive-packages/          (gh-pages branch)
 
 The package is **`_all`** — one feed URL per OpenWrt release line, not per CPU architecture.
 
+---
+
 ## User install
 
 ### OpenWrt 21.02.x (opkg, legacy fw3)
 
-OpenWrt **21.02 is EOL** — use only if you are stuck on fw3/iptables. Feed path **`21.02`**; install the **21.02-built** package from this feed (not 23.05+).
+OpenWrt **21.02 is EOL** — use only if you are stuck on fw3/iptables. Install the **21.02-built** package from this feed (not 23.05+).
 
 ```sh
 wget -O /tmp/fwlive.key https://lucas-albers-lz4.github.io/fwlive-packages/public.key
@@ -51,7 +55,7 @@ See [21.02 compat](openwrt-21.02-compat.md).
 
 ### OpenWrt 22.03.x (opkg, EOL)
 
-OpenWrt **22.03 is EOL** — use only if you cannot upgrade to 23.05+ yet. Feed path **`22.03`**; install the **22.03-built** package from this feed (not 23.05+).
+OpenWrt **22.03 is EOL** — use only if you cannot upgrade to 23.05+ yet.
 
 ```sh
 wget -O /tmp/fwlive.key https://lucas-albers-lz4.github.io/fwlive-packages/public.key
@@ -63,11 +67,7 @@ opkg install luci-app-fwlive
 
 See [22.03 compat](openwrt-22.03-compat.md).
 
-### OpenWrt 23.05 (opkg)
-
-Same as 24.10; use feed URL `…/fwlive-packages/23.05`.
-
-### OpenWrt 24.10 (opkg)
+### OpenWrt 23.05 / 24.10 (opkg)
 
 ```sh
 wget -O /tmp/fwlive.key https://lucas-albers-lz4.github.io/fwlive-packages/public.key
@@ -76,6 +76,8 @@ echo 'src/gz fwlive https://lucas-albers-lz4.github.io/fwlive-packages/24.10' >>
 opkg update
 opkg install luci-app-fwlive
 ```
+
+Use `…/23.05` for OpenWrt 23.05.
 
 ### OpenWrt 25.12+ (apk)
 
@@ -91,28 +93,39 @@ apk add luci-app-fwlive
 
 Menu: **Status → Firewall Live View**.
 
-## One-time repo setup (maintainers)
+---
 
-### 1. Create `fwlive-packages`
+## Lab: install from feed URL
+
+```sh
+FWLIVE_FEED_BASE_URL=https://lucas-albers-lz4.github.io/fwlive-packages \
+  ./scripts/validate-feed-smoke.sh --version 24.10
+```
+
+---
+
+# Maintainer: one-time repo setup
+
+## 1. Create `fwlive-packages`
 
 1. Create empty GitHub repo **`lucas-albers-lz4/fwlive-packages`** (public).
 2. **Settings → Pages → Build and deployment:** source = **`gh-pages`** branch (CI writes this branch; no manual Pages source needed after first deploy).
 
-### 2. Deploy key
+## 2. Deploy key
 
 On **`fwlive-packages`**: Settings → Deploy keys → Add deploy key (read/write), note the private key.
 
 On **`fwlive`**: Settings → Secrets → Actions:
 
 | Secret | Value |
-|--------|--------|
+|--------|-------|
 | `FEED_DEPLOY_KEY` | Private deploy key for `fwlive-packages` |
 | `OPKG_FEED_SECRET_KEY` | Full contents of usign secret key file |
 | `OPKG_FEED_PUBLIC_KEY` | Full contents of `public.key` |
 | `APK_FEED_SECRET_KEY` | Full contents of RSA private key (`apk-secret.rsa`) |
 | `APK_FEED_PUBLIC_KEY` | Full contents of `fwlive-feed.rsa.pub` |
 
-### 3. Generate signing keys (once, offline)
+## 3. Generate signing keys (once, offline)
 
 ```sh
 # opkg (usign)
@@ -125,7 +138,7 @@ openssl rsa -in apk-secret.rsa -pubout -out fwlive-feed.rsa.pub
 
 Store **private** keys only in GitHub Actions secrets. Never commit them to either repo.
 
-**Common mistakes**
+### Common mistakes
 
 - `OPKG_FEED_SECRET_KEY` must be the **usign** secret from `usign -G` (two lines: `untrusted comment:` + `RW…` base64). The **openssl RSA** key is only for `APK_FEED_SECRET_KEY`.
 - Pasting the secret into GitHub as **one line** (no newline between comment and key) makes usign fail with **`Premature end of file`**. Either paste the file verbatim with its line break, or store **`base64 -w0 opkg-secret.key`** in the secret (CI auto-decodes).
@@ -138,8 +151,6 @@ APK_FEED_SECRET_KEY=./apk-secret.rsa APK_FEED_PUBLIC_KEY=./fwlive-feed.rsa.pub \
   ./scripts/validate-feed-keys.sh
 ```
 
-No package build required. CI runs this immediately after writing keys from GitHub secrets (before the ~30 minute SDK build).
-
 Expected usign secret shape:
 
 ```text
@@ -148,6 +159,8 @@ RWRCSwAAAAD…base64…=
 ```
 
 Expected apk secret shape: PEM `-----BEGIN PRIVATE KEY-----` (openssl genrsa output).
+
+---
 
 ## Automated publish (CI)
 
@@ -160,6 +173,8 @@ On **tag push** (`v*`) or manual workflow dispatch, [`.github/workflows/publish-
 5. Deploys to **`fwlive-packages`** `gh-pages`.
 6. Uploads `.ipk` / `.apk` to the GitHub Release.
 7. Boots QEMU x86 guests and installs from the **live Pages URL** ([`validate-feed-smoke.sh`](../scripts/validate-feed-smoke.sh)) — *currently disabled in CI* ([#10](https://github.com/lucas-albers-lz4/fwlive/issues/10)).
+
+---
 
 ## Manual publish (fallback)
 
@@ -180,6 +195,8 @@ APK_FEED_SECRET_KEY=./apk-secret.rsa APK_FEED_PUBLIC_KEY=./fwlive-feed.rsa.pub \
 
 # Push feed-staging/ to fwlive-packages gh-pages (or open PR)
 ```
+
+---
 
 ## Reproducible builds
 
@@ -208,12 +225,7 @@ docker run --rm ghcr.io/openwrt/sdk:x86-64-24.10.6 cat feeds.conf.default
 # Update sdk_matrix_version_patch in sdk-matrix.sh
 ```
 
-## Lab: install from feed URL
-
-```sh
-FWLIVE_FEED_BASE_URL=https://lucas-albers-lz4.github.io/fwlive-packages \
-  ./scripts/validate-feed-smoke.sh --version 24.10
-```
+---
 
 ## Related
 

--- a/docs/minimal-build-sdk.md
+++ b/docs/minimal-build-sdk.md
@@ -29,7 +29,7 @@ On **Linux x86_64**, prefer **[`ghcr.io/openwrt/sdk`](https://github.com/openwrt
 ./scripts/docker-sdk.sh list
 ./scripts/docker-sdk.sh build                                    # armsr-armv8 + snapshot
 ./scripts/docker-sdk.sh build --target x86-64 --version 24.10
-./scripts/docker-sdk.sh build-all                                # 21.02–snapshot × both targets
+./scripts/docker-sdk.sh build-all                                # 21.02–snapshot × both targets (22.03: x86-64 only)
 ```
 
 Legacy wrappers (same default cell):
@@ -145,7 +145,7 @@ Custom kernel, non-default feeds baked into the image, or reproducible OEM-style
 
 ---
 
-# Troubleshooting / edge cases
+## Troubleshooting / edge cases
 
 ## Expected noise during feed setup
 

--- a/docs/minimal-build-sdk.md
+++ b/docs/minimal-build-sdk.md
@@ -2,9 +2,11 @@
 
 For **proving `luci-app-fwlive` and deploying an `.ipk`**, use the **OpenWrt SDK** for the **same OpenWrt release and target** as your **router or VM image**. You do **not** need to compile a full firmware image.
 
-**Canonical loop:** [`dev-environment.md`](dev-environment.md).
+**Canonical loop:** [Developer guide → Environment](developer/environment.md).
 
 **Optional full tree:** [`openwrt-full-source-build.md`](openwrt-full-source-build.md) — slow; not the default.
+
+---
 
 ## Build host: Linux x86_64 only
 
@@ -17,15 +19,17 @@ For **proving `luci-app-fwlive` and deploying an `.ipk`**, use the **OpenWrt SDK
 
 **Host packages:** `sudo apt install build-essential libncurses-dev gawk` (optional: `jsmin`, `csstidy`).
 
-## Recommended build: official OpenWrt SDK Docker image
+---
 
-On **Linux x86_64**, prefer **[`ghcr.io/openwrt/sdk`](https://github.com/openwrt/docker)** via the build matrix (see [`sdk-build-matrix.md`](sdk-build-matrix.md) and [`dev-environment.md`](dev-environment.md)):
+## Recommended: official OpenWrt SDK Docker image
+
+On **Linux x86_64**, prefer **[`ghcr.io/openwrt/sdk`](https://github.com/openwrt/docker)** via the build matrix (see [`sdk-build-matrix.md`](sdk-build-matrix.md)):
 
 ```sh
 ./scripts/docker-sdk.sh list
 ./scripts/docker-sdk.sh build                                    # armsr-armv8 + snapshot
 ./scripts/docker-sdk.sh build --target x86-64 --version 24.10
-./scripts/docker-sdk.sh build-all                                # 21.02–snapshot × both targets (22.03: x86-64 only)
+./scripts/docker-sdk.sh build-all                                # 21.02–snapshot × both targets
 ```
 
 Legacy wrappers (same default cell):
@@ -38,38 +42,24 @@ Legacy wrappers (same default cell):
 
 The container runs **`./setup.sh`** on first use to download the matching SDK (no manual `.tar.zst` import).
 
-`docker-sdk-official-setup-feeds.sh` also enables the **`base`** feed and installs **`liblua`**, **`libucode`**, and related packages. The official SDK image is minimal: LuCI pulls **`lucihttp`**, which needs Lua 5.1 and ucode headers from **`feeds/base`**, not only from **`luci`** / **`packages`**. If you see `lua.h: No such file or directory` or `ucode/module.h: No such file or directory`, re-run setup (do not skip the base-feed step).
+`docker-sdk-official-setup-feeds.sh` also enables the **`base`** feed and installs **`liblua`**, **`libucode`**, and related packages. The official SDK image is minimal: LuCI pulls **`lucihttp`**, which needs Lua 5.1 and ucode headers from **`feeds/base`**, not only from **`luci`** / **`packages`**. If you see `lua.h: No such file or directory` or `ucode/module.h: No such file or directory`, re-run setup.
 
-### Fallback: fwlive SDK image + volume (§4a below)
+---
 
-**Archived fallback** (tarball import + fwlive-built SDK image): [`archive/scripts/`](../archive/scripts/) — only if `docker-sdk.sh` + official images fail.
+## Fallback: manual SDK tarball
 
-## Current focus: QEMU ARM virtual (`armsr`)
-
-For **armvirt-style** testing on OpenWrt **24.10**, use target **`armsr`** / **`armv8`** (AArch64) — see **[`armvirt-armsr-testing.md`](armvirt-armsr-testing.md)** for image names, QEMU, and terminology.  
-**x86_64** can use the same SDK flow once you switch to that target’s SDK.
-
-## 1. Get the SDK (download; do not build the SDK)
+### 1. Get the SDK
 
 - From [OpenWrt downloads](https://downloads.openwrt.org/releases/), open **24.10.x** → **targets** → **armsr** → **armv8** (for QEMU ARM64 testing).
-- Download the **OpenWrt SDK** `.tar.zst` from that same directory (same release as your **downloaded** VM image), e.g.  
-  `openwrt-sdk-24.10.0-armsr-armv8_gcc-*_musl.Linux-x86_64.tar.zst`.
+- Download the **OpenWrt SDK** `.tar.zst` (same release as your VM image).
 - Extract somewhere short (e.g. `~/openwrt-sdk`).
-
-**Host note:** published SDKs are **Linux x86_64** host binaries. **Primary workflow:** develop on **Linux Mint / Ubuntu x86_64** (or similar), extract and build **natively** on the host (**§2–4** + **§4**).
-
-Extract the SDK tarball somewhere stable (example: **`~/openwrt-sdk/`** or **`.sdk/openwrt-sdk-…/`** — the **inner** directory must contain **`Makefile`** and **`scripts/feeds`**):
 
 ```sh
 mkdir -p .sdk && tar -C .sdk -xf ~/Downloads/openwrt-sdk-24.10.*-armsr-armv8_*_musl.Linux-x86_64.tar.zst
 # → .sdk/openwrt-sdk-24.10-.../   ← cd here for steps 2–4
 ```
 
-**macOS-only Docker:** do **not** bind-mount an extracted SDK from the Mac filesystem — APFS is case-insensitive. Use the **§4a** volume workflow (**`docker-sdk-import-tar.sh`**) so the SDK lives on a **case-sensitive** filesystem inside Docker.
-
-Optional **Docker** on **Linux** (same `make` result): **after** feeds + **`make defconfig`** on the **host** or via **`docker-sdk-setup-feeds.sh`** in a volume, see **§4a**. Without **`./scripts/feeds install luci-app-fwlive`**, **`make package/luci-app-fwlive/compile`** fails with **no rule to make target**.
-
-## 2. Prepare feeds inside the SDK
+### 2. Prepare feeds inside the SDK
 
 ```sh
 cd ~/openwrt-sdk
@@ -78,9 +68,9 @@ test -f feeds.conf || cp feeds.conf.default feeds.conf
 ./scripts/feeds install luci-base
 ```
 
-## 3. Add this project as a feed
+### 3. Add this project as a feed
 
-Use an **absolute path** to your checkout’s `openwrt-feed` directory (`src-link` after cloning — not `src-git` on the main `fwlive` repo; see [`feeds.conf.example`](../feeds.conf.example)):
+Use an **absolute path** to your checkout's `openwrt-feed` directory:
 
 ```sh
 echo "src-link fwlive /path/to/fwlive/openwrt-feed" >> feeds.conf
@@ -88,7 +78,9 @@ echo "src-link fwlive /path/to/fwlive/openwrt-feed" >> feeds.conf
 ./scripts/feeds install luci-app-fwlive
 ```
 
-## 4. Build the package only
+See [`feeds.conf.example`](../feeds.conf.example).
+
+### 4. Build the package only
 
 ```sh
 make defconfig
@@ -97,13 +89,9 @@ make package/luci-app-fwlive/compile V=s
 
 The `.ipk` appears under `bin/packages/.../luci/luci-app-fwlive_*.ipk` (exact path varies by arch).
 
-### 4a. Compile with Docker / Podman (optional; same result as §4)
+### 4a. Compile with Docker (optional; same result as §4)
 
-Use this **instead of** running `make` directly on the host when you want an isolated toolchain (optional on **Linux**; often needed on **macOS**).
-
-#### Linux x86_64 (Mint / Ubuntu): optional Docker with bind mount
-
-If you already completed **§2–4** on the host under a path on **ext4** (or another case-sensitive filesystem), you can point Docker at that tree:
+If you already completed steps 1–4 on the host, you can point Docker at that tree:
 
 ```sh
 export OPENWRT_SDK_MOUNT=/path/to/extracted-sdk
@@ -112,68 +100,16 @@ docker compose build
 ./scripts/docker-sdk-make.sh
 ```
 
-Or: `docker compose -f docker-compose.yml -f docker-compose.bind.yml run --rm sdk-bind make package/luci-app-fwlive/compile V=s`
+### 5. Deploy on the router or QEMU guest
 
-#### macOS / ARM compile hosts (not supported)
-
-**fwlive** does not support compiling the SDK on **macOS** or **Linux aarch64**. Use a **Linux x86_64** machine (or x86_64 VM) with **`sdk-official`** or native SDK.
-
-The legacy **`sdk`** + volume import scripts remain for reference only.
-
-To copy **`.ipk`** files to the host (example **`./out/`**):
-
-```sh
-mkdir -p out
-docker compose run --rm -v "$PWD/out:/out" sdk-legacy cp -a /openwrt-sdk/bin/packages/. /out/
-```
-
-#### Last resort (not recommended)
-
-If you must bind-mount from a case-insensitive host, `FORCE=1 make …` can bypass the check; only use if you accept possible odd failures.
-
-**Troubleshooting**
-
-| Error | Cause |
-| ----- | ----- |
-| `OpenWrt can only be built on a case-sensitive filesystem` | Bind-mounted SDK from **macOS** — use **§4a** volume flow (`docker-sdk-import-tar.sh`), not **`OPENWRT_SDK_MOUNT`** on the host. |
-| `No rule to make target 'package/luci-app-fwlive/compile'` | Feeds not installed or **`make defconfig`** not run — run **`docker-sdk-setup-feeds.sh`** (volume) or complete §2–4 (bind mount). |
-| `No Makefile` / empty tree | Import failed or wrong path — re-run **`docker-sdk-import-tar.sh`** or fix **`OPENWRT_SDK_MOUNT`**. |
-| **`Segmentation fault`** when running **`aarch64-openwrt-linux-musl-gcc`**, CMake **“C compiler … broken”**, **`lucihttp`** / **`luci-base`** compile fails | Most common with **Docker `linux/amd64` on Apple Silicon**. **Native builds on Linux x86_64** (e.g. Ubuntu desktop) avoid this. Details: **Apple Silicon + Docker** below. |
-
-##### Apple Silicon Mac only: `linux/amd64` Docker and GCC segfaults
-
-If you still compile the SDK **on a Mac** (not on **Ubuntu x86_64**): official OpenWrt SDKs are **Linux x86_64** host binaries. Our compose file uses **`platform: linux/amd64`**. On **Apple Silicon**, that container runs under **CPU emulation** (QEMU / Rosetta-style paths depending on Docker engine). The **cross-compiler and host tools** are heavy **x86_64** ELFs; **GCC often segfaults** under that stack when CMake runs a compile test (as in **`lucihttp`**), which is an environment limitation—not a bug in **`luci-app-fwlive`**.
-
-**Practical options:**
-
-1. **Preferred:** build on **Linux x86_64** (e.g. **Ubuntu** desktop) — **matches** the published SDK host (**`…Linux-x86_64.tar.zst`**), so the toolchain runs **without** CPU emulation.
-2. Keep macOS for editing but use **`docker context`** / **SSH** to a remote **x86_64** Docker host.
-3. Try another engine/settings (**Docker Desktop** “Use Rosetta for x86/amd64” or similar, **OrbStack**, **Colima**); success varies.
-
-**What about an ARM build VM instead of x86_64?** For **`armsr/armv8`**, OpenWrt **24.10.x** currently publishes the SDK only as **`Linux-x86_64`** (see the [download directory](https://downloads.openwrt.org/releases/) for your release). So an **aarch64 Linux VM** does **not** get a matching native SDK from that tarball—you would still be running **x86_64** host binaries (via Docker **`linux/amd64`** or **`qemu-x86_64`** on the VM). That may be **more stable** than on Docker Desktop for Mac, but it is **not** the same as “everything native ARM.” The reliable fix remains a **x86_64 Linux** environment for this SDK, unless a future release adds a **`Linux-aarch64`** (or similar) SDK for your target and you switch the container/platform to **arm64** accordingly.
-
-#### Expected noise during `./scripts/docker-sdk-setup-feeds.sh`
-
-OpenWrt’s SDK often prints **many lines** like **`has a dependency on 'libubox', which does not exist`** (also **`rpcd`**, **`firewall4`**, **`lua/host`**, firmware package names, etc.) while **`scripts/feeds`** and **`make defconfig`** scan Makefiles. In the SDK tree those packages usually **do** exist under **`package/`** or appear once the full index is built; the checker runs **before** the graph is complete, so this is **usually harmless** for **`make package/luci-app-fwlive/compile`**.
-
-Similarly, **`tmp/.config-package.in` … redefinition** and **`Config-build.in` … defaults for choice** are common **kconfig** merge warnings.
-
-If you see **`tmp/.packagedeps: … unterminated variable reference`**, stale **`tmp/`** can confuse **`make`**. The setup script removes **`tmp/`** before **`defconfig`**; if it still appears, run **`rm -rf tmp`** in the SDK tree and **`make defconfig`** again.
-
-If **`docker-sdk-make.sh`** says feeds are not configured but you already ran **`docker-sdk-setup-feeds.sh`**, that was a **false negative**: **`feeds/fwlive/`** is usually a **symlink** to **`/work/fwlive/openwrt-feed`**, and plain **`find`** does not follow symlinked directories. The script uses **`find -L`** (or explicit **`test -f`**) so the check matches OpenWrt’s layout.
-
-## 5. Deploy on the router or QEMU guest
-
-### Typical LAN router
+#### Typical LAN router
 
 ```sh
 scp bin/packages/*/luci/luci-app-fwlive_*.ipk root@192.168.1.1:/tmp/
 ssh root@192.168.1.1 'opkg install /tmp/luci-app-fwlive_*.ipk'
 ```
 
-### Linux: QEMU user networking (hostfwd) — default for `run-openwrt-armsr-armv8-qemu.sh`
-
-On **Linux x86_64**, the repo’s QEMU helper uses **`-netdev user`** with **host 2222→guest 22** and **8080→80** (see [`armvirt-armsr-testing.md`](armvirt-armsr-testing.md)). Use **`127.0.0.1`** and the **`--legacy-hostfwd`** flag on the deploy script:
+#### Linux: QEMU user networking (hostfwd)
 
 ```sh
 ./scripts/agent-build-and-deploy.sh --legacy-hostfwd --ipk bin/packages/*/luci/luci-app-fwlive_*.ipk
@@ -181,44 +117,72 @@ On **Linux x86_64**, the repo’s QEMU helper uses **`-netdev user`** with **hos
 
 LuCI: **`http://127.0.0.1:8080`**, SSH: **`ssh -p 2222 root@127.0.0.1`**.
 
-### macOS QEMU with vmnet (no host port forwarding)
+#### macOS QEMU with vmnet (no host port forwarding)
 
-Use the guest’s **real IP** and **port 22** for SSH/SCP, and **80** / **443** for LuCI. **Do not** assume **`127.0.0.1:2222`** or **`:8080`** unless you explicitly run QEMU with **user** networking and **hostfwd** (not the default for vmnet).
-
-- Find the guest IP: match your QEMU **`mac=`** for the LAN NIC to **`hw_address`** in **`/var/db/dhcpd_leases`** (no `sudo` required to read this file on current macOS).
-- Copy/install:
+Use the guest's real IP and port 22 for SSH/SCP:
 
 ```sh
 scp -o StrictHostKeyChecking=no bin/packages/*/luci/luci-app-fwlive_*.ipk root@<guest-ip>:/tmp/luci-app-fwlive.ipk
 ssh -o StrictHostKeyChecking=no root@<guest-ip> 'opkg install /tmp/luci-app-fwlive.ipk'
 ```
 
-Or use the helper (discovers IP from **`QEMU_MAC_LAN`** / **`QEMU_MAC_WAN`** if **`OPENWRT_HOST`** is unset):
+Or use the helper:
 
 ```sh
-export QEMU_MAC_LAN=52:54:00:44:55:66   # same as your QEMU -device ... mac=...
+export QEMU_MAC_LAN=52:54:00:44:55:66
 ./scripts/agent-build-and-deploy.sh --ipk bin/packages/*/luci/luci-app-fwlive_*.ipk
 ```
 
-**Legacy hostfwd** (same as Linux flow): `OPENWRT_HOST=127.0.0.1` with QEMU mapping **host 2222→guest 22** and **8080→80**:
+## 6. Post-deploy: validate
 
-```sh
-./scripts/agent-build-and-deploy.sh --legacy-hostfwd --ipk path/to/luci-app-fwlive_*.ipk
-```
+Open **Status → Firewall Live View**. If empty, add **`log`** to fw4/nft rules — see [enabling firewall logs](user/enabling-firewall-logs.md).
 
-Resolve any `opkg` dependency prompts (`luci-base`, `firewall4`, etc.) per your image.
-
-## 6. Post-deploy: validate Firewall Live View (LuCI)
-
-If the table is empty, see **[`fwlive-nft-logging.md`](fwlive-nft-logging.md)**.
-
-After install, open **Status → Firewall Live View** (requires **`/usr/sbin/nft`**).
-
-- If the table stays **empty**, add **nft/fw4 rules that `log`** for the traffic you are testing. The UI reads **`ubus fwlive poll`** (filtered logd lines), not raw `nft` counters.
-- On the device: `logread -f` or **System Log** in LuCI should show firewall lines once rules log traffic.
-
-This matches the same checklist as a full buildroot image — only the transport to the guest differs (vmnet vs LAN).
+---
 
 ## When you would use a full buildroot instead
 
-- Custom kernel, non-default feeds baked into the image, or reproducible OEM-style images. Not required for this LuCI package alone.
+Custom kernel, non-default feeds baked into the image, or reproducible OEM-style images. Not required for this LuCI package alone.
+
+---
+
+# Troubleshooting / edge cases
+
+## Expected noise during feed setup
+
+OpenWrt's SDK often prints many lines like **`has a dependency on 'libubox', which does not exist`** while **`scripts/feeds`** scans Makefiles. This is **usually harmless** for **`make package/luci-app-fwlive/compile`**.
+
+Similarly, **`tmp/.config-package.in` … redefinition** and **`Config-build.in` … defaults for choice** are common **kconfig** merge warnings.
+
+If you see **`tmp/.packagedeps: … unterminated variable reference`**, run **`rm -rf tmp`** in the SDK tree and **`make defconfig`** again.
+
+## `lua.h: No such file or directory` or `ucode/module.h: No such file or directory`
+
+Re-run `docker-sdk-official-setup-feeds.sh` — do not skip the base-feed step. The official SDK image is minimal; LuCI needs headers from **`feeds/base`**.
+
+## Apple Silicon Mac: Docker `linux/amd64` and GCC segfaults
+
+Official OpenWrt SDKs are **Linux x86_64** host binaries. On **Apple Silicon**, the Docker `linux/amd64` container runs under CPU emulation. The cross-compiler (GCC) often **segfaults** under emulation when CMake runs a compile test (as in `lucihttp`).
+
+**Practical options:**
+
+1. **Preferred:** build on **Linux x86_64** (Ubuntu desktop) — matches the published SDK host.
+2. Keep macOS for editing but use **`docker context`** / **SSH** to a remote **x86_64** Docker host.
+3. Try another engine (Docker Desktop "Use Rosetta for x86/amd64", OrbStack, Colima); success varies.
+
+## Case-insensitive filesystem errors
+
+Bind-mounting an SDK from **macOS** (APFS is case-insensitive) causes:
+
+```text
+OpenWrt can only be built on a case-sensitive filesystem
+```
+
+Use the **volume workflow** (`docker-sdk-import-tar.sh`) so the SDK lives on a case-sensitive filesystem inside Docker, not a macOS bind mount.
+
+## `No rule to make target 'package/luci-app-fwlive/compile'`
+
+Feeds not installed or **`make defconfig`** not run — run **`docker-sdk-setup-feeds.sh`** (volume) or complete steps 2–4 above (bind mount).
+
+## macOS deployment: finding the guest IP
+
+Match your QEMU **`mac=`** for the LAN NIC to **`hw_address`** in **`/var/db/dhcpd_leases`** (no `sudo` required).

--- a/docs/user/enabling-firewall-logs.md
+++ b/docs/user/enabling-firewall-logs.md
@@ -2,44 +2,27 @@
 
 Firewall Live View shows traffic only when **nftables / fw4** writes firewall-shaped lines to **logd**. The UI reads those lines — it does not tap the firewall directly.
 
-**After a fresh install the table is usually empty.** Stock OpenWrt rarely logs traffic until you turn logging on. The fastest path is the **Enable logging** button on **Status → Firewall Live View** (same as WAN zone logging in **Network → Firewall**). This guide also covers shell setup, logging more traffic, and troubleshooting.
+**After a fresh install the table is usually empty.** Stock OpenWrt rarely logs traffic until you turn logging on. This guide covers everything from a one-button enable to deep custom configuration.
 
 ---
 
 ## Quick start after install
 
+Pick one path. Both produce visible traffic within seconds.
+
 ### Option A — LuCI button (recommended)
 
 1. Open **Status → Firewall Live View**.
 2. If the table is empty, click **Enable logging**.
-3. Wait for blocked inbound WAN traffic (background scans, rejected probes). Normal LAN browsing is **not** logged.
+3. Wait for blocked inbound WAN traffic (background scans, rejected probes).
 
 Use **Disable logging** in the toolbar to turn WAN zone logging off again. Rate limiting uses the OpenWrt default (`10/minute`) unless you already set `log_limit` on the WAN zone.
 
 ### Option B — shell (SSH or System → Terminal)
 
-#### 1. Confirm kernel logging works
+#### 1. Enable WAN zone logging (rejected / dropped inbound)
 
-`nft log` needs netfilter log modules. On minimal images they may be missing — logging fails silently without them.
-
-```sh
-# Should print nf_log_ipv4 (IPv4) and nf_log_ipv6 (IPv6), not "none"
-cat /proc/sys/net/netfilter/nf_log/2
-cat /proc/sys/net/netfilter/nf_log/10
-```
-
-If either shows **`none`** or the path is missing, install the kmods (package names vary slightly by release):
-
-```sh
-opkg update
-opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6 2>/dev/null \
-  || opkg install kmod-nf-log kmod-nf-log6
-/etc/init.d/firewall reload
-```
-
-#### 2. Enable WAN zone logging (rejected / dropped inbound)
-
-This is the fastest way to see **real** traffic without a synthetic ping test. fw4 adds log rules for **rejected and dropped** packets on that zone (not every accepted packet).
+This is the fastest way to see **real** traffic without a synthetic ping test. fw4 adds log rules for **rejected and dropped** packets on that zone:
 
 ```sh
 WAN=$(uci -q show firewall | sed -n "s/^firewall\.\(@zone\[[0-9]*\]\)\.name='wan'$/\1/p" | head -1)
@@ -55,17 +38,7 @@ echo "Enabled zone logging on firewall.${WAN}"
 
 OpenWrt applies the default **`log_limit`** (`10/minute`) when the option is not set in UCI.
 
-Generate traffic: from the internet, probe the router WAN (or wait for background scans). From LAN, browse the web — that traffic is **accepted** and will **not** appear until you add rule-level or forward logging (below).
-
-Verify logs before opening Live View:
-
-```sh
-logread | tail -20 | grep -E 'SRC=|reject wan|DROP|REJECT'
-```
-
-Open **Status → Firewall Live View**. Filter **Action → drop** or search for `reject wan` in the quick search.
-
-To turn zone logging off later:
+To turn off:
 
 ```sh
 uci delete "firewall.${WAN}.log"
@@ -73,7 +46,7 @@ uci commit firewall
 /etc/init.d/firewall reload
 ```
 
-#### 3. Optional — confirm the UI with a ping (synthetic pass events)
+#### 2. Optional — confirm the UI with a ping (synthetic pass events)
 
 Useful when WAN is quiet or you want a guaranteed **pass** row:
 
@@ -91,19 +64,40 @@ nft -a list chain inet fw4 input | grep fwlive-ping
 nft delete rule inet fw4 input handle <handle>
 ```
 
+> **Note:** avoid `:` in `log prefix` on the shell — see [Prefix pitfalls](#prefix-pitfalls).
+
+#### 3. Check kernel logging modules (only if logs are missing)
+
+`nft log` needs netfilter log modules. On minimal images they may be missing — logging fails silently without them.
+
+```sh
+# Should print nf_log_ipv4 (IPv4) and nf_log_ipv6 (IPv6), not "none"
+cat /proc/sys/net/netfilter/nf_log/2
+cat /proc/sys/net/netfilter/nf_log/10
+```
+
+If either shows **`none`** or the path is missing:
+
+```sh
+opkg update
+opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6 2>/dev/null \
+  || opkg install kmod-nf-log kmod-nf-log6
+/etc/init.d/firewall reload
+```
+
 ---
 
 ## What shows up without extra configuration?
 
 | Traffic | Visible on stock image? | How to enable |
 |---------|-------------------------|---------------|
-| WAN inbound **drop / reject** (scans, blocked ports) | No — until zone **`log`** | [Quick start §2](#2-enable-wan-zone-logging-rejected--dropped-inbound) |
+| WAN inbound **drop / reject** (scans, blocked ports) | No — until zone **`log`** | [Quick start §1](#1-enable-wan-zone-logging-rejected--dropped-inbound) |
 | LAN → WAN **accepted** browsing | No | Rule **`log`** or temporary forward **`log`** rule |
 | Forwarded guest / VLAN **reject** | No — until that zone **`log`** | `option log '1'` on the guest zone |
 | Hits on a **specific** firewall rule | No — until that rule logs | `option log '1'` on the `@rule` |
-| Invalid / malformed packets | No — unless **`drop_invalid`** + logging | See [defaults](#defaults-and-invalid-packets) |
+| Invalid / malformed packets | No — unless **`drop_invalid`** + logging | See [Defaults and invalid packets](#defaults-and-invalid-packets) |
 
-The Live View empty-state hint about “default WAN drops” means traffic **after you enable zone logging**, not on a untouched factory config.
+The Live View empty-state hint about "default WAN drops" means traffic **after you enable zone logging**, not on an untouched factory config.
 
 ---
 
@@ -134,7 +128,7 @@ Per-zone options in **`/etc/config/firewall`**:
 | **`log`** | `1` = log rejected/dropped filter traffic for this zone |
 | **`log_limit`** | Rate cap (default **`10/minute`** on OpenWrt) — always set this on busy zones |
 
-Example — log drops on a **guest** zone as well as WAN:
+Example — log drops on a **guest** zone too:
 
 ```sh
 # Replace @zone[N] with your guest zone section from: uci show firewall | grep name
@@ -163,13 +157,13 @@ uci commit firewall
 
 In **`/etc/config/firewall`**:
 
-```
+```text
 config rule
-	option name 'Allow-SSH-WAN'
-	option src 'wan'
-	option dest_port '22'
-	option target 'ACCEPT'
-	option log '1'
+        option name 'Allow-SSH-WAN'
+        option src 'wan'
+        option dest_port '22'
+        option target 'ACCEPT'
+        option log '1'
 ```
 
 **Production tips:**
@@ -190,7 +184,6 @@ Zone logging does **not** show every **accepted** LAN→WAN session. For that yo
 **Non-terminating** `log` in nftables: the packet keeps traversing the chain. Always use a **limit** on busy chains.
 
 ```sh
-# Log up to ~30 forwarded packets per minute, then remove when done
 nft insert rule inet fw4 forward limit rate 30/minute log prefix "fwlive-fwd "
 ```
 
@@ -213,7 +206,7 @@ nft insert rule inet fw4 input limit rate 30/minute log prefix "fwlive-in "
 
 ### Custom chains
 
-Rules in **`/etc/nftables.d/`** or **`/etc/firewall.user`** must include **`log`** (and usually a **`prefix`**) themselves — fwlive only displays what those rules emit. See the [full reference](../fwlive-nft-logging.md#fw4--uci-persistent) for **`include`** / **`chain-pre`** examples.
+Rules in **`/etc/nftables.d/`** or **`/etc/firewall.user`** must include **`log`** (and usually a **`prefix`**) themselves — fwlive only displays what those rules emit. See the [full reference](../fwlive-nft-logging.md) for **`include`** / **`chain-pre`** examples.
 
 ---
 
@@ -226,7 +219,7 @@ In **`config defaults`**:
 | **`drop_invalid`** | Drop packets not matching conntrack / invalid state |
 | **`log`** (zone-level, not defaults) | — |
 
-Invalid drops are only visible if the **zone** or **rule** that drops them also **logs**. There is no separate global “log all invalid” sysctl — it is still **`log`** on the nft rule fw4 generates.
+Invalid drops are only visible if the **zone** or **rule** that drops them also **logs**. There is no separate global "log all invalid" sysctl.
 
 ---
 
@@ -242,8 +235,46 @@ If **`logread`** has firewall lines but Live View does not, check LuCI login and
 Common pitfalls:
 
 - **`nft add`** at the **end** of **`input`** — LAN traffic jumps to **`input_lan`** first. Use **`nft insert`** at the top for tests.
-- **Loopback ping** (`127.0.0.1`) may bypass your rule — ping the router’s LAN IP from another host.
+- **Loopback ping** (`127.0.0.1`) may bypass your rule — ping the router's LAN IP from another host.
 - Avoid **`:`** inside **`log prefix`** on the shell; use a trailing space (`"fwlive-ping "`) or an **`nft -f`** heredoc.
+
+---
+
+## Prefix pitfalls
+
+Avoid **`:`** in the prefix on the shell — OpenWrt ash/nft often strips quotes and then treats the colon as nft syntax. Use a trailing space instead:
+
+```sh
+# ✅ Works
+nft add rule inet fw4 input tcp dport 9999 log prefix "fwlive-test " drop
+
+# ❌ Likely fails
+nft add rule inet fw4 input tcp dport 9999 log prefix "fwlive-test: " drop
+```
+
+If you need awkward characters, use an nft snippet file:
+
+```sh
+nft -f - <<'EOF'
+add rule inet fw4 input tcp dport 9999 log prefix "fwlive-test: " drop
+EOF
+```
+
+---
+
+## iptables / fw3 (21.02.x primary; best-effort on 22.03+)
+
+On **21.02.x** (fw3), iptables LOG is the normal path. On **22.03+**, iptables is unusual (most images use nft).
+
+```sh
+iptables -I INPUT -p icmp --icmp-type echo-request \
+  -j LOG --log-prefix "fwlive-ping: "
+iptables -I INPUT -p icmp --icmp-type echo-request -j ACCEPT
+```
+
+Verify with `logread | grep fwlive-ping`. LuCI shows a short **`iptables`** backend label when detected.
+
+Details: **[`../fwlive-iptables-logging.md`](../fwlive-iptables-logging.md)**
 
 ---
 
@@ -255,22 +286,6 @@ From a machine that can SSH to the router:
 ./scripts/fwlive-nft-ping-log.sh add --ssh
 ssh root@192.168.1.1 'ping -c 5 127.0.0.1'
 ```
-
----
-
-## iptables / fw3 (21.02.x primary; best-effort on 22.03+)
-
-On **21.02.x** (fw3), iptables LOG is the normal path. On **22.03+**, iptables is unusual (most images use nft) — same enablement either way. Enable **`LOG`** on the rules you care about — same logd pipeline, not TRACE:
-
-```sh
-iptables -I INPUT -p icmp --icmp-type echo-request \
-  -j LOG --log-prefix "fwlive-ping: "
-iptables -I INPUT -p icmp --icmp-type echo-request -j ACCEPT
-```
-
-Verify with `logread | grep fwlive-ping`. LuCI shows a short **`iptables`** backend label when detected.
-
-Details: **[`../fwlive-iptables-logging.md`](../fwlive-iptables-logging.md)**
 
 ---
 


### PR DESCRIPTION
Part of #36 (stack 3/5, depends on #31).

- **enabling-firewall-logs.md**: Quick Start now comes FIRST; deep detail moved below. Added Prefix pitfalls section.
- **binary-feed.md**: Split into user install section (top) and maintainer setup (bottom).
- **minimal-build-sdk.md**: Core build/deploy flow at top; edge cases moved to Troubleshooting appendix. Restores 22.03 x86-64-only `build-all` caveat and keeps a single H1.