### PR TITLE
docs: Stack 5/5 — Add CHANGELOG, FAQ, and upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v0.1.17] — 2026-06-21
+## [v0.1.17] — 2026-06-20
 
 ### Added
 - 21.02.7 (fw3/iptables) lab sign-off
@@ -112,6 +112,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - 21.02 LuCI compatibility (lua prefix dispatcher)
+- Release asset publish and wrap bug from 21.02 support
+
+---
+
+## [v0.1.16] — 2026-06-20
+
+### Added
+- OpenWrt 21.02 fw3/iptables support in the SDK matrix and binary feed
+- `docs/openwrt-21.02-compat.md` and related install/requirements notes
 
 ---
 
@@ -122,7 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v0.1.14] — 2026-06-20
+## [v0.1.14] — 2026-06-19
 
 ### Added
 - Parameterized validation matrix (`validate-openwrt.sh`)
@@ -144,6 +153,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `matchesFilter()` AND logic for multi-field filtering
 - Row expand/collapse for raw message in Simple view
 - `qemu-smoke-fwlive.sh` headless checks
+
+---
+
+## [v0.1.12] — 2026-06-14
+
+### Changed
+- Package version bump for feed republish
+
+---
+
+## [v0.1.11] — 2026-06-14
+
+### Fixed
+- GitHub Actions publish workflow write permissions
 
 ---
 
@@ -190,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v0.1.5] — 2026-06-14
+## [v0.1.5] — 2026-06-13
 
 ### Added
 - Firewall-only feed (`isFirewallEvent` heuristic)
@@ -199,7 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v0.1.4] — 2026-06-14
+## [v0.1.4] — 2026-06-13
 
 ### Added
 - Initial working LuCI view (`view.extend`)
@@ -208,14 +231,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v0.1.3] — 2026-06-14
+## [v0.1.3] — 2026-06-13
 
 ### Fixed
 - GitHub Actions artifact copy-out (uid mismatch)
 
 ---
 
-## [v0.1.2] — 2026-06-14
+## [v0.1.2] — 2026-06-13
 
 ### Added
 - Reproducible build verification
@@ -223,7 +246,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [v0.1.1] — 2026-06-14
+## [v0.1.1] — 2026-06-13
 
 ### Added
 - Signed opkg/apk feed at GitHub Pages
@@ -242,10 +265,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.21]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.19...v0.1.21
 [v0.1.19]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.18...v0.1.19
 [v0.1.18]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.17...v0.1.18
-[v0.1.17]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.15...v0.1.17
+[v0.1.17]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.16...v0.1.17
+[v0.1.16]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.15...v0.1.16
 [v0.1.15]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.14...v0.1.15
 [v0.1.14]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.13...v0.1.14
-[v0.1.13]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.10...v0.1.13
+[v0.1.13]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.12...v0.1.13
+[v0.1.12]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.11...v0.1.12
+[v0.1.11]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.10...v0.1.11
 [v0.1.10]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.9...v0.1.10
 [v0.1.9]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.8...v0.1.9
 [v0.1.8]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.7...v0.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,258 @@
+# Changelog
+
+All notable changes to **fwlive** / **luci-app-fwlive** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Documentation
+- Consolidated planning/spec docs into ROADMAP.md
+- Restructured over-long user docs (Quick Start first)
+- Added CHANGELOG.md, FAQ.md
+- Fixed cross-reference accuracy throughout
+
+---
+
+## [v0.1.27] — 2026-07-24
+
+### Changed
+- Refactored `fwlive.js` into modular files: `constants.js`, `css.js`, `tint.js`, `links.js`, `chips.js`, `logging.js`, `table.js`
+- All modules now use `baseclass.extend` for proper LuCI lifecycle
+
+### Fixed
+- Firefox console errors from baseclass usage
+- `qemu-install-fwlive.sh` syncs all module files
+
+---
+
+## [v0.1.26] — 2026-07-23
+
+### Security
+- Removed session ACL grant for direct `ubus log.read` — poll now reads logd inside the rpcd plugin only
+- Hardened `resolve` reverse DNS: IPv4/IPv6 shape validation before lookup
+- JSON escaping for rpcd responses
+- MAC address redaction in UI display
+
+### Fixed
+- WAN zone logging disable: clear only filter-log bit 0, preserving other zone bits
+
+### Added
+- Po/i18n template (`luci-app-fwlive.pot`)
+- SPDX headers on shell scripts
+- Upstream publish checklist
+
+---
+
+## [v0.1.25] — 2026-07-21
+
+### Changed
+- Minor packaging fixes
+
+---
+
+## [v0.1.24] — 2026-07-18
+
+### Added
+- WAN zone enable/disable logging toolbar buttons on Live View page
+- `ubus fwlive.logging_status`, `enable_wan_logging`, `disable_wan_logging`
+- `fwlive-logging.sh` helper script
+- ACL grants for write operations
+
+---
+
+## [v0.1.23] — 2026-07-11
+
+### Changed
+- Backend and matrix improvements
+
+---
+
+## [v0.1.22] — 2026-07-03
+
+### Changed
+- CI and build improvements
+
+---
+
+## [v0.1.21] — 2026-07-03
+
+### Changed
+- Backend improvements
+
+---
+
+## [v0.1.19] — 2026-06-27
+
+### Added
+- 22.03.7 lab sign-off
+
+### Changed
+- Build and smoke infrastructure
+
+---
+
+## [v0.1.18] — 2026-06-27
+
+### Added
+- fw4 rule name resolve via `ubus fwlive rules`
+- **Show hostnames** checkbox (default off) with `ubus fwlive resolve`
+- Server-side firewall-only read via `ubus fwlive poll`
+
+---
+
+## [v0.1.17] — 2026-06-21
+
+### Added
+- 21.02.7 (fw3/iptables) lab sign-off
+- `fwlive-iptables-ping-log.sh`
+
+### Fixed
+- 21.02 LuCI compatibility (lua prefix dispatcher)
+
+---
+
+## [v0.1.15] — 2026-06-20
+
+### Added
+- 21.02.7 SDK build and x86 QEMU smoke sign-off
+
+---
+
+## [v0.1.14] — 2026-06-20
+
+### Added
+- Parameterized validation matrix (`validate-openwrt.sh`)
+- Baseline validation gate (`validate-baseline.sh`)
+- Full matrix validation (`validate-openwrt-all.sh`)
+
+---
+
+## [v0.1.13] — 2026-06-14
+
+### Added
+- Filter operators: `!` prefix for is-not / not-contains
+- Action dropdown includes **not pass**, **not drop**, etc.
+- Flood banner, token bucket render cap
+- **Simple / Detailed** view toggle with `localStorage` persistence
+- URL hash `view=detailed`
+- Click-to-filter on action, protocol, interface, address cells
+- Filter chip bar (show + clear active filters)
+- `matchesFilter()` AND logic for multi-field filtering
+- Row expand/collapse for raw message in Simple view
+- `qemu-smoke-fwlive.sh` headless checks
+
+---
+
+## [v0.1.10] — 2026-06-14
+
+### Fixed
+- Wrong CI sign path for package feed
+
+---
+
+## [v0.1.9] — 2026-06-14
+
+### Added
+- **Auto-refresh** checkbox (maps to `paused`)
+- **Limit** dropdown (25…2000, default 100)
+- `localStorage` persistence for view preferences
+- Status line: `shown/limit` while paused/live
+
+---
+
+## [v0.1.8] — 2026-06-14
+
+### Added
+- Pause/resume toolbar button
+- Buffer status line
+- Row message wrap/one-line toggle
+
+---
+
+## [v0.1.7] — 2026-06-14
+
+### Added
+- **Rule** column with `rule_hint` from nft log prefix
+- Deep link to firewall admin from Rule column
+- `ubus fwlive poll` server-side filter
+
+---
+
+## [v0.1.6] — 2026-06-14
+
+### Added
+- Stage 2 schema hardening: `interface_in`/`out` split, normalized `action` enum, `flags`/`length` parsing
+- Schema test fixtures and assertions
+
+---
+
+## [v0.1.5] — 2026-06-14
+
+### Added
+- Firewall-only feed (`isFirewallEvent` heuristic)
+- Normalized table columns and client-side filters
+- Live polling (~1s), URL hash filter persistence
+
+---
+
+## [v0.1.4] — 2026-06-14
+
+### Added
+- Initial working LuCI view (`view.extend`)
+- Basic JSON-RPC to `ubus log.read`
+- Quick search and field filters
+
+---
+
+## [v0.1.3] — 2026-06-14
+
+### Fixed
+- GitHub Actions artifact copy-out (uid mismatch)
+
+---
+
+## [v0.1.2] — 2026-06-14
+
+### Added
+- Reproducible build verification
+- SDK build matrix
+
+---
+
+## [v0.1.1] — 2026-06-14
+
+### Added
+- Signed opkg/apk feed at GitHub Pages
+- Initial GitHub Releases publishing
+- Basic CI pipeline
+
+---
+
+[Unreleased]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.27...HEAD
+[v0.1.27]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.26...v0.1.27
+[v0.1.26]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.25...v0.1.26
+[v0.1.25]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.24...v0.1.25
+[v0.1.24]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.23...v0.1.24
+[v0.1.23]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.22...v0.1.23
+[v0.1.22]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.21...v0.1.22
+[v0.1.21]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.19...v0.1.21
+[v0.1.19]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.18...v0.1.19
+[v0.1.18]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.17...v0.1.18
+[v0.1.17]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.15...v0.1.17
+[v0.1.15]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.14...v0.1.15
+[v0.1.14]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.13...v0.1.14
+[v0.1.13]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.10...v0.1.13
+[v0.1.10]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.9...v0.1.10
+[v0.1.9]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.8...v0.1.9
+[v0.1.8]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.7...v0.1.8
+[v0.1.7]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.6...v0.1.7
+[v0.1.6]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.5...v0.1.6
+[v0.1.5]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.4...v0.1.5
+[v0.1.4]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.3...v0.1.4
+[v0.1.3]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.2...v0.1.3
+[v0.1.2]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/lucas-albers-lz4/fwlive/releases/tag/v0.1.1

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Full paths: [Installation guide](docs/user/installation.md) · [Binary feed](doc
 | **Install and use** on my router | **[User guide](docs/user/README.md)** |
 | **Build, test, or contribute** | **[Developer guide](docs/developer/README.md)** |
 | Browse all docs | [docs/README.md](docs/README.md) |
+| Release history | [CHANGELOG.md](CHANGELOG.md) |
+| FAQ | [docs/FAQ.md](docs/FAQ.md) |
 
 ### User guide (highlights)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,117 @@
+# Frequently Asked Questions
+
+## Installation & Setup
+
+### The table is empty after install — what's wrong?
+
+**Nothing.** Stock OpenWrt images log almost no firewall traffic by default. You need to turn logging on.
+
+Fastest path: open **Status → Firewall Live View** and click the **Enable logging** button. This enables WAN zone drop/reject logging. See the full [Enabling firewall logs](user/enabling-firewall-logs.md) guide.
+
+### Can I install without the binary feed?
+
+Yes. Download the `.ipk` / `.apk` from [GitHub Releases](https://github.com/lucas-albers-lz4/fwlive/releases) and install manually. See the [Installation guide](user/installation.md#2-github-release-manual-download).
+
+### Which OpenWrt version should I use?
+
+**23.05+** for firewall4/nft (recommended). 22.03 works but is EOL. 21.02 works for fw3/iptables but is also EOL. See [Requirements](user/requirements.md).
+
+### Does this work on any router?
+
+Yes. The package is **`_all`** (architecture-independent LuCI JS + shell) — one build works on any OpenWrt-supported CPU architecture (ARM, MIPS, x86, etc.).
+
+---
+
+## Usage
+
+### Why don't I see my LAN browsing traffic?
+
+Zone logging only logs **rejected and dropped** traffic on that zone. Normal LAN→WAN accepted traffic doesn't appear unless you add explicit **`log`** rules. See [Rule-level logging](user/enabling-firewall-logs.md#rule-level-logging-specific-policies).
+
+### How do I see only dropped packets?
+
+Click a **drop** cell in the table, or use the **Action** filter → **drop**. You can also click the **pass** cell then click **≠** on the chip to exclude passes.
+
+### How do I share my current view with someone?
+
+The URL hash stores all active filters, limit, and view mode. Just copy the URL from your browser address bar.
+
+### Why do some rows have no Rule column data?
+
+Live View shows a **Rule** label only when the nft log line includes a **prefix** (e.g. `log prefix "my-rule "`) and fw4 can resolve it to a UCI rule name. Rules without `log prefix` don't carry enough metadata.
+
+### What does "Enable logging" on the page actually do?
+
+It sets `option log '1'` on your WAN firewall zone via UBIUS. This enables logging of rejected and dropped packets on the WAN interface. It does **not** log accepted LAN traffic.
+
+---
+
+## Troubleshooting
+
+### The UI stays empty but I see firewall lines in `logread`
+
+Check that:
+1. `luci-app-fwlive` and `luci-base` are installed
+2. You're logged into LuCI (the page shows live data only after authentication)
+3. The menu appears at **Status → Firewall Live View**
+4. `logread | grep SRC=` shows lines — if not, fix firewall logging first
+
+Run from SSH:
+```sh
+logread | grep -E 'SRC=|DST=|PROTO=' | tail
+ubus call fwlive poll '{"addresses":["20"]}' | head -c 500
+```
+
+### My `nft log` rule matches (counter increases) but `logread` stays empty
+
+Most common cause on Docker or minimal images: kernel logging modules are missing. Check:
+
+```sh
+cat /proc/sys/net/netfilter/nf_log/2    # should be nf_log_ipv4, not "none"
+```
+
+If missing, install `kmod-nf-log-ipv4` / `kmod-nf-log-ipv6`. See [Kernel module check](user/enabling-firewall-logs.md#3-check-kernel-logging-modules-only-if-logs-are-missing).
+
+### Docker rootfs experiment: `nft log` doesn't work
+
+Docker containers use the **host kernel**, not the OpenWrt kernel. `nft` counters and accept/drop work, but **`nft log` often never reaches `logread`** because kernel modules don't match.
+
+Workaround: inject a fake firewall line manually:
+```sh
+logger -t kernel -p kern.info "fwlive-test IN=br-lan SRC=172.17.0.1 DST=172.17.0.2 PROTO=ICMP ACCEPT"
+```
+
+For real `nft log` testing, use QEMU armsr or hardware.
+
+### "Premature end of file" when adding the opkg feed key
+
+The `OPKG_FEED_SECRET_KEY` GitHub secret must contain the full usign secret with its line break. If it was pasted as one line, usign fails. Store `base64 -w0 opkg-secret.key` in the secret and decode in CI. See [binary-feed.md](binary-feed.md#common-mistakes).
+
+### The flood banner appears but traffic is quiet
+
+The token bucket charges new events per poll. A sudden burst of logs (e.g. port scan) can briefly trigger it. If it persists, check for a noisy firewall rule and add a rate limit (`log_limit` on zones, `limit rate` on nft rules).
+
+---
+
+## Building & Contributing
+
+### Can I build this on macOS or Windows?
+
+**No.** OpenWrt SDKs are `Linux-x86_64` only. You can edit JS/docs on any platform and run parser tests (`./scripts/fwlive-test.sh`) locally with Node. SDK builds and QEMU labs need a Linux x86_64 machine (or VM).
+
+### Do I need a full OpenWrt buildroot?
+
+No. The [Docker SDK](developer/build-and-test.md#sdk-builds) or a [minimal SDK tarball](minimal-build-sdk.md) is enough to build the package. A full buildroot is only needed for custom firmware images.
+
+### I changed the parser — why is LuCI not showing my changes?
+
+The LuCI `log.js` is a mirror of `core/fwlive-log.js`. You must update **both** files. Run `./scripts/fwlive-test.sh` to verify sync, then `./scripts/qemu-install-fwlive.sh` to copy to the running guest.
+
+### How do I run tests without a router or QEMU?
+
+```sh
+./scripts/fwlive-test.sh
+./scripts/validate-baseline.sh
+```
+
+These run parser, schema, and filter tests against fixtures — no hardware needed.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -42,7 +42,7 @@ Live View shows a **Rule** label only when the nft log line includes a **prefix*
 
 ### What does "Enable logging" on the page actually do?
 
-It sets `option log '1'` on your WAN firewall zone via UBIUS. This enables logging of rejected and dropped packets on the WAN interface. It does **not** log accepted LAN traffic.
+It sets `option log '1'` on your WAN firewall zone via ubus. This enables logging of rejected and dropped packets on the WAN interface. It does **not** log accepted LAN traffic.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,5 +40,7 @@ Build, test, and extend the package from this repository.
 | [validation-matrix.md](validation-matrix.md) | QEMU validation scripts |
 | [opnsense-liveview-parity.md](opnsense-liveview-parity.md) | Parity matrix |
 | [github-publish-checklist.md](github-publish-checklist.md) | Pre-publish checks |
+| [CHANGELOG.md](../CHANGELOG.md) | Release history |
+| [FAQ.md](FAQ.md) | Common questions |
 
 `docs/dev-environment.md` is a legacy redirect — see the [Developer guide → Environment](developer/environment.md) instead.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -105,6 +105,22 @@ For a full QEMU lab loop (build → boot → install), see [Developer: QEMU lab]
 2. **[Enable logging — quick start](enabling-firewall-logs.md#quick-start-after-install)** — the table is empty on stock configs until you turn logging on. Run the WAN zone one-liner there to see real drop/reject traffic, or the ping test for a quick pass row.
 3. Read [Using the UI](using-the-ui.md)
 
+## Upgrading
+
+Re-install the new version over the existing one. No configuration migration is needed — the package makes no persistent firewall changes.
+
+**opkg (21.02 – 24.10):**
+```sh
+opkg update && opkg install luci-app-fwlive
+```
+
+**apk (25.12+):**
+```sh
+apk update && apk add luci-app-fwlive
+```
+
+After upgrade, refresh the LuCI page in your browser (may need a cache-busting hard refresh: Ctrl+Shift+R / Cmd+Shift+R).
+
 ## Uninstall
 
 ```sh


### PR DESCRIPTION
Part of #36 (stack 5/5, depends on #33). Closes #36 when the full stack including #35 is merged.

- **CHANGELOG.md**: Release history from v0.1.1 to v0.1.27 (including previously omitted tags), dates aligned to git tags.
- **docs/FAQ.md**: Common questions; `ubus` spelling corrected.
- **docs/user/installation.md**: Upgrading section with opkg/apk and cache-busting note.
- **README.md** / **docs/README.md**: Link to CHANGELOG and FAQ.