### PR TITLE
docs: apply MCR review findings — stale parity/schema doc, stub links

### DIFF
--- a/archive/README.md
+++ b/archive/README.md
@@ -9,7 +9,7 @@ Items kept for reference. **Do not use for production builds** — use [`scripts
 | `scripts/run-openwrt-rootfs-x86-docker.sh` | Deprecated wrapper | `scripts/run-openwrt-x86-experiment.sh` |
 | `scripts/docker-compose.bind.yml` | macOS case-sensitive bind mount | Linux native or Docker volume SDK |
 | `macos/set-build-env.sh` | Homebrew GNU PATH | Build on Linux x86_64 (VM/CI) |
-| `macos/install-depends.sh` | `brew install` one-liner | [`docs/dev-environment.md`](../docs/dev-environment.md) |
+| `macos/install-depends.sh` | `brew install` one-liner | [Developer guide → Environment](../docs/developer/environment.md) |
 | `docs/implementation-next.md` | One-time 2026-03 checklist | Done — see [`docs/ROADMAP.md`](../docs/ROADMAP.md) |
 
 **macOS development:** edit JS/docs locally; run `./scripts/fwlive-test.sh` with Node. SDK builds and QEMU labs require **Linux x86_64**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,4 +43,4 @@ Build, test, and extend the package from this repository.
 | [CHANGELOG.md](../CHANGELOG.md) | Release history |
 | [FAQ.md](FAQ.md) | Common questions |
 
-`docs/dev-environment.md` is a legacy redirect — see the [Developer guide → Environment](developer/environment.md) instead.
+`docs/dev-environment.md` is a stub note — see the [Developer guide → Environment](developer/environment.md) instead.

--- a/docs/armvirt-armsr-testing.md
+++ b/docs/armvirt-armsr-testing.md
@@ -33,7 +33,7 @@ Build the `.ipk` with the SDK that matches **the same release and `armsr/armv8` 
 | Topic | Note |
 |-------|------|
 | Typical toolchain triple | `aarch64-openwrt-linux-musl` (from SDK) |
-| SDK host | **`Linux-x86_64` only** — use [`dev-environment.md`](dev-environment.md) / official **`ghcr.io/openwrt/sdk:armsr-armv8`**. Not supported on ARM or macOS hosts. |
+| SDK host | **`Linux-x86_64` only** — use [Developer guide → Environment](developer/environment.md) / official **`ghcr.io/openwrt/sdk:armsr-armv8`**. Not supported on ARM or macOS hosts. |
 
 Then build **`luci-app-fwlive`** with the SDK ([`minimal-build-sdk.md`](minimal-build-sdk.md)) or a full OpenWrt tree ([`openwrt-full-source-build.md`](openwrt-full-source-build.md)).
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,10 +1,12 @@
-# Development environment (legacy redirect)
+# Development environment (stub note)
 
-> **This page is a legacy redirect.** The canonical developer environment docs are now in the [Developer guide → Environment](developer/environment.md).
+This page was previously a full development environment guide. The content has been consolidated into the developer guide:
 
-This file is kept as a redirect for external links. All content previously here has been consolidated into the developer guide:
+> **See:** [Developer guide → Environment](developer/environment.md) for host setup, Docker SDK, QEMU lab, and build instructions.
 
-- **[Environment setup](developer/environment.md)** — host packages, Docker SDK, QEMU
-- **[Build & test](developer/build-and-test.md)** — SDK matrix, validation, smoke scripts
-- **[QEMU lab](developer/qemu-lab.md)** — image download, prepare, run, install
-- **[SDK build matrix](sdk-build-matrix.md)** — version × target matrix
+### Related pages
+
+- [Environment setup](developer/environment.md) — host packages, canonical loop, theme tint matrix
+- [Build & test](developer/build-and-test.md) — SDK builds, parser tests, QEMU smoke
+- [QEMU lab](developer/qemu-lab.md) — image download, prepare, run, install
+- [SDK build matrix](sdk-build-matrix.md) — version × target matrix

--- a/docs/developer/environment.md
+++ b/docs/developer/environment.md
@@ -2,7 +2,7 @@
 
 Canonical setup: **Linux x86_64** build host, cross-compile for OpenWrt, test in **QEMU** (x86 KVM fast path or armsr production path).
 
-Full detail: [`../dev-environment.md`](../dev-environment.md) (legacy redirect — content consolidated here).
+See: [`../dev-environment.md`](../dev-environment.md) (stub note redirecting to this guide).
 
 ## Roles
 

--- a/docs/openwrt-full-source-build.md
+++ b/docs/openwrt-full-source-build.md
@@ -1,6 +1,6 @@
 # Full OpenWrt source: tools + toolchain (no SDK tarball)
 
-> **Optional / not the default.** For day-to-day **fwlive** work use the **SDK** on **Linux x86_64** — [`dev-environment.md`](dev-environment.md) and [`minimal-build-sdk.md`](minimal-build-sdk.md). Only use this doc if you need a custom firmware image or full buildroot.
+> **Optional / not the default.** For day-to-day **fwlive** work use the **SDK** on **Linux x86_64** — see [Developer guide → Environment](developer/environment.md) and [`minimal-build-sdk.md`](minimal-build-sdk.md). Only use this doc if you need a custom firmware image or full buildroot.
 
 If you prefer **not** to download the **SDK** `.tar.zst`, check out the **OpenWrt buildroot** for the same release as your image (e.g. **24.10**), wire in this repo’s feed, then build **host tools** and the **cross toolchain** inside the tree. The first run is **slow** and needs **disk space** (~15 GB+ is common), but setup is straightforward: one git clone, standard feed commands, then **`make tools/install`** and **`make toolchain/install`** before compiling the package.
 

--- a/docs/openwrt-fwlive-schema.md
+++ b/docs/openwrt-fwlive-schema.md
@@ -23,7 +23,7 @@ Shipped as feed package [`openwrt-feed/luci-app-fwlive`](../openwrt-feed/luci-ap
 - `action`: normalized enum: `pass`, `block`, `drop`, `reject`, or `unknown`.
 - `action_raw`: original token from the log line (`ACCEPT`, `DROP`, …).
 - `rule_hint`: tag parsed from log prefix / nft `log prefix` (e.g. `fwlive-ping`, `fw4`, `fwlive-test`); empty when unknown.
-- `rule_label`: display label derived from `rule_hint` (UCI name resolve deferred to stage 3.4+).
+- `rule_label`: display label derived from `rule_hint` (UCI name resolve via `ubus fwlive rules`).
 - `interface`: `IN` or `OUT` (legacy convenience).
 - `interface_in` / `interface_out`: from `IN=` / `OUT=`.
 - `direction`: `in`, `out`, `forward`, or `unknown`.

--- a/docs/opnsense-liveview-parity.md
+++ b/docs/opnsense-liveview-parity.md
@@ -25,16 +25,16 @@ See **[ROADMAP.md](ROADMAP.md)** for stages, CLI test commands, and exit criteri
 - Implemented: URL hash filter persistence for shareable troubleshooting context.
 - Implemented (stage 1): **firewall-only feed** — `isFirewallEvent()` drops dnsmasq/procd/etc.; CLI: `./scripts/fwlive-test.sh`.
 - Implemented (stage 2): **schema hardening** — unix `timestamp`, normalized `action` enum, `interface_in`/`out`, `flags`, `length`; tests: `tests/fwlive-schema.test.js`.
-- Implemented (stage 3, partial): `rule_hint` from log prefix; LuCI **Rule** column (click filters).
+- Implemented (stage 3): `rule_hint` from log prefix; LuCI **Rule** column (click filters).
 - Implemented (stage 3.3): Rule links to firewall admin (`fw4` → traffic rules; else nftables).
-- Deferred (stage 3): UCI rule name resolve (`rule_label`).
+- Implemented (stage 3.4b): UCI rule name resolve (`rule_label`) via `ubus fwlive rules`.
 - Implemented (stage 4): **pause/resume** — buffer ingests while table frozen; resume redraws; message wrap/one-line toggle.
 - Implemented (stage 4b): **auto-refresh** checkbox + **limit** dropdown (25…2000, default 100).
-- Deferred (stage 4): 250/s render cap + suppression banner.
+- Implemented (stage 4.5): 250/s render cap + suppression banner (token bucket).
 - Deferred: session running-total / rate counter (not in OPNsense limit spec).
 - Implemented (stage 5, partial): click-to-filter (src/dst/proto/iface/action); filter chip bar with clear.
 - **Deliberate difference:** **Simple / Detailed toggle** (single **Show Detail** button) — OPNsense uses one table layout; we default to a compact Simple grid and optional Detailed 14-column forensic view ([`fwlive-ui-design-target.md`](fwlive-ui-design-target.md) § View modes).
-- Deferred (stage 5): advanced filter operators (`is not`, `contains`); token array tests.
+- Implemented (stage 5.6): advanced filter operators (`!` prefix for is-not/not-contains); token array tests.
 - Implemented (stage 6, partial): **Show hostnames** checkbox (default off) + `ubus fwlive resolve`.
 - Deferred (stage 6): rule overlay / modal details.
 - Implemented (stage 7, partial): server-side firewall-only read via `ubus fwlive poll`.

--- a/docs/sdk-build-matrix.md
+++ b/docs/sdk-build-matrix.md
@@ -119,6 +119,6 @@ Setup enables the **`base`** feed and installs **`liblua`**, **`libucode`**, and
 
 ## Related docs
 
-- [`dev-environment.md`](dev-environment.md) — QEMU + default build loop
+- [`dev-environment.md`](dev-environment.md) — stub note redirecting to the [developer guide → Environment](developer/environment.md)
 - [`minimal-build-sdk.md`](minimal-build-sdk.md) — native SDK / fallback image
 - [`openwrt-rootfs-x86-docker.md`](openwrt-rootfs-x86-docker.md) — x86 LuCI smoke test

--- a/lab/README.md
+++ b/lab/README.md
@@ -32,4 +32,4 @@
 - OpenWrt armsr (ARM64 virt) LuCI: `http://localhost:8080` (SSH host **2222** — same as [`run-openwrt-armsr-armv8-qemu.sh`](../scripts/run-openwrt-armsr-armv8-qemu.sh))
 - OPNsense Web UI: `https://localhost:8443`
 
-See [`docs/dev-environment.md`](../docs/dev-environment.md) for the full loop.
+See [Developer guide → Environment](../docs/developer/environment.md) for the full loop.


### PR DESCRIPTION
Part of #36. Follow-up from MCR review after the #30–#34 documentation stack.

### Changes
| File | What changed |
|------|-------------|
| `opnsense-liveview-parity.md` | 3 stale Deferred items → Implemented |
| `openwrt-fwlive-schema.md` | UCI name resolve deferred → via ubus fwlive rules |
| `docs/dev-environment.md` | Align stub-note wording with stack |
| `armvirt-armsr-testing.md` and related | Point at `developer/environment.md` (fixed relative path) |
| `docs/README.md` / `developer/environment.md` | Stub-note terminology |

Rebased onto master after #30–#34. Closes #36.