### PR TITLE
docs: Stack 2/5 — Fix accuracy and cross-references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,4 +41,4 @@ Build, test, and extend the package from this repository.
 | [opnsense-liveview-parity.md](opnsense-liveview-parity.md) | Parity matrix |
 | [github-publish-checklist.md](github-publish-checklist.md) | Pre-publish checks |
 
-Legacy paths (`dev-environment.md`) remains for existing links.
+`docs/dev-environment.md` is a legacy redirect — see the [Developer guide → Environment](developer/environment.md) instead.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -148,7 +148,7 @@ Production target remains **armsr**; x86 QEMU is the fast UI lab.
 
 | Doc | Purpose |
 | --- | ------- |
-| [dev-environment.md](dev-environment.md) | Host setup |
+| [Environment setup](developer/environment.md) | Host setup |
 | [fwlive-nft-logging.md](fwlive-nft-logging.md) | Enable firewall logs |
 | [opnsense-liveview-parity.md](opnsense-liveview-parity.md) | Feature matrix |
 | [openwrt-fwlive-schema.md](openwrt-fwlive-schema.md) | Event fields |

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,90 +1,10 @@
-# Development environment (Linux x86_64)
+# Development environment (legacy redirect)
 
-> **Prefer:** [Developer guide → Environment](developer/environment.md) · [Build & test](developer/build-and-test.md)
+> **This page is a legacy redirect.** The canonical developer environment docs are now in the [Developer guide → Environment](developer/environment.md).
 
-Canonical setup for **fwlive**: cross-build **`luci-app-fwlive`** on **Linux x86_64**, test on **OpenWrt `armsr` / `armv8`** in QEMU.
+This file is kept as a redirect for external links. All content previously here has been consolidated into the developer guide:
 
-## Build host vs OpenWrt target
-
-| Role | Architecture | Notes |
-|------|----------------|--------|
-| **Build host** | **Linux x86_64** only | OpenWrt publishes SDKs as **`…Linux-x86_64.tar.zst`**. Do not use Linux **aarch64**, **macOS**, or **ARM Mac** as the compile host. |
-| **OpenWrt targets** | **`armsr` / `armv8`** (AArch64), **`x86/64`** | Package dirs: **`aarch64_generic`**, **`x86_64`**. QEMU ARM guest uses TCG on x86_64. |
-| **OpenWrt versions** | **21.02**, **22.03**, **23.05**, **24.10**, **25.12**, **snapshot** | [`sdk-build-matrix.md`](sdk-build-matrix.md) · smoke: [`validation-matrix.md`](validation-matrix.md) |
-
-## Quick start
-
-### 1. Host packages (Mint / Ubuntu)
-
-```sh
-sudo apt install build-essential libncurses-dev gawk docker.io docker-compose-v2 \
-  qemu-system-arm curl git nodejs
-```
-
-Podman users: `podman` + `podman-compose` for [`lab/`](../lab/) instead of Docker where noted.
-
-### 2. Download QEMU disk image (runtime)
-
-```sh
-RELEASE=24.10.5 ./scripts/download-openwrt-armsr-armv8.sh
-```
-
-Uses official [downloads.openwrt.org](https://downloads.openwrt.org/releases/) **`armsr/armv8`** combined EFI + U-Boot under **`lab/images/`**.
-
-### 3. Build `.apk` / `.ipk` (official OpenWrt SDK container — recommended)
-
-```sh
-./scripts/docker-sdk.sh list
-./scripts/docker-sdk.sh build                              # armsr-armv8 + snapshot (default)
-./scripts/docker-sdk.sh build --target x86-64 --version 24.10
-./scripts/docker-sdk.sh build-all                          # all version × target cells (22.03: x86-64 only)
-```
-
-Legacy one-liners (same default cell):
-
-```sh
-./scripts/docker-sdk-official-setup-feeds.sh
-./scripts/docker-sdk-official-make.sh
-./scripts/docker-sdk-official-copy-out.sh
-```
-
-Uses **[`ghcr.io/openwrt/sdk`](https://github.com/openwrt/docker)** (`linux/amd64`). Artifacts: **`out/<arch>/<version>/fwlive/`** — see [`sdk-build-matrix.md`](sdk-build-matrix.md).
-
-**Fallback:** archived tarball SDK path — [`archive/scripts/`](../archive/scripts/) (prefer `docker-sdk.sh`).
-
-**Native (no Docker):** extract SDK on host — [`minimal-build-sdk.md`](minimal-build-sdk.md) §2–4.
-
-### 4. Run QEMU guest
-
-**Host QEMU (recommended for deploy script):**
-
-```sh
-./scripts/run-openwrt-armsr-armv8-qemu.sh
-```
-
-- LuCI: **http://127.0.0.1:8080**
-- SSH: **`ssh -p 2222 root@127.0.0.1`**
-- Two **user** netdevs (WAN + LAN); **hostfwd** on LAN only.
-
-**Lab (Podman Compose + `qemux/qemu`):** **armsr** service uses the **same** host ports (**8080** / **2222**) — see [`lab/README.md`](../lab/README.md).
-
-### 5. Install package and validate
-
-```sh
-./scripts/agent-build-and-deploy.sh --legacy-hostfwd \
-  --ipk out/aarch64_generic/snapshot/fwlive/luci-app-fwlive_*.ipk
-```
-
-Install **`luci-base`** ipk first if the image has no LuCI.
-
-Open **Status → Firewall Live View**. If empty, add **`log`** to fw4/nft rules — [`fwlive-nft-logging.md`](fwlive-nft-logging.md).
-
-Acceptance: [`fwlive-acceptance.md`](fwlive-acceptance.md) · OPNsense parity: [`opnsense-liveview-parity.md`](opnsense-liveview-parity.md).
-
-## What we do not support
-
-- **Compiling** OpenWrt on **ARM hosts** or **macOS**
-- **Full firmware** `make world` as the default loop — optional only: [`openwrt-full-source-build.md`](openwrt-full-source-build.md)
-- **Vagrant** full-build VMs (heavy; not maintained here)
-
-Legacy **macOS** QEMU (vmnet): [`archive/scripts/legacy/`](../archive/scripts/legacy/) — unmaintained. Builds require Linux x86_64.
+- **[Environment setup](developer/environment.md)** — host packages, Docker SDK, QEMU
+- **[Build & test](developer/build-and-test.md)** — SDK matrix, validation, smoke scripts
+- **[QEMU lab](developer/qemu-lab.md)** — image download, prepare, run, install
+- **[SDK build matrix](sdk-build-matrix.md)** — version × target matrix

--- a/docs/developer/environment.md
+++ b/docs/developer/environment.md
@@ -2,7 +2,7 @@
 
 Canonical setup: **Linux x86_64** build host, cross-compile for OpenWrt, test in **QEMU** (x86 KVM fast path or armsr production path).
 
-Full detail: [`../dev-environment.md`](../dev-environment.md) (legacy path — content summarized here).
+Full detail: [`../dev-environment.md`](../dev-environment.md) (legacy redirect — content consolidated here).
 
 ## Roles
 

--- a/docs/fwlive-acceptance.md
+++ b/docs/fwlive-acceptance.md
@@ -80,7 +80,7 @@ Build:
 
 ## Environment
 
-Full loop on **Linux x86_64**: [`dev-environment.md`](dev-environment.md). Enable firewall **`log`**: [`fwlive-nft-logging.md`](fwlive-nft-logging.md).
+Full loop on **Linux x86_64**: [Developer guide → Environment](developer/environment.md). Enable firewall **`log`**: [`fwlive-nft-logging.md`](fwlive-nft-logging.md).
 
 **QEMU lab (recommended):**
 


### PR DESCRIPTION
Part of #36 (stack 2/5, depends on #30). Replaces #31, which GitHub auto-closed when the intermediate base branch was deleted after #30 merged.

- Converts `docs/dev-environment.md` from a full-content duplicate into a clean redirect stub (canonical content lives in `docs/developer/environment.md`)
- Updates ROADMAP.md, fwlive-acceptance.md, docs/README.md, and developer/environment.md to point correctly
- Fixes table formatting in ROADMAP.md references

Made with [Cursor](https://cursor.com)