### PR TITLE
chore(ci): explicit workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -5,6 +5,9 @@ on:
     branches: [master, main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -16,6 +16,9 @@ env:
   FWLIVE_PACKAGES_REPO: lucas-albers-lz4/fwlive-packages
   OWRT_VALIDATE_SSH_WAIT_X86: "600"
 
+permissions:
+  contents: read
+
 jobs:
   build-publish:
     runs-on: ubuntu-latest
@@ -147,6 +150,8 @@ jobs:
     if: false
     needs: build-publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       # GitHub-hosted runners expose /dev/kvm but deny KVM init; use TCG for feed smoke.
       OWRT_QEMU_ACCEL: tcg


### PR DESCRIPTION
## Summary
- Fixes open CodeQL alerts #5/#6 (`actions/missing-workflow-permissions`).
- `fwlive-test`: workflow-level `permissions: contents: read`.
- `publish-packages`: default `contents: read`; `build-publish` keeps `contents: write`; `smoke-from-feed` gets explicit `contents: read`.

## Test plan
- [ ] CI on this PR (fwlive-test) passes
- [ ] Confirm CodeQL alerts close after merge + rescan


Made with [Cursor](https://cursor.com)