### PR TITLE
Add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# Local secret scan before commit. Enable with: pre-commit install
+# Complements GitHub secret scanning / push protection.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary
- Add [gitleaks](https://github.com/gitleaks/gitleaks) via new `.pre-commit-config.yaml` (`v8.30.1`) so secrets are caught locally before push
- Complements GitHub secret scanning / push protection (defense in depth)

## Test plan
- [ ] `pip install pre-commit` (or equivalent) if needed
- [ ] `pre-commit install`
- [ ] `pre-commit run gitleaks --all-files`
- [ ] Optional: confirm hook blocks a staged fake AWS/GitHub token


Made with [Cursor](https://cursor.com)