### PR TITLE
Add security-only Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Security-only Dependabot (weekly). Pair with Dependabot security updates enabled.
+# See housekeeping/templates/dependabot.security-only.yml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+


### PR DESCRIPTION
## Summary
- Add or extend `.github/dependabot.yml` in the security-only pattern (weekly, `open-pull-requests-limit: 0`, ignore version updates)
- Relies on Dependabot **security updates** for bump PRs; keeps version-churn noise low
- Repo settings updated where applicable (delete head branches / push protection / CodeQL)

## Test plan
- [ ] Confirm Dependabot config validates in the PR checks / Dependabot UI
- [ ] After merge, glance at Settings → Code security for expected toggles

Made with [Cursor](https://cursor.com)