### PR TITLE
fix(ui): preserve pause buffer on resume (#43)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -16,6 +16,7 @@ LuCI **Firewall Live View** — client-side JS view polling `ubus fwlive poll` (
 | `htdocs/luci-static/resources/fwlive/chips.js` | Filter-chip DOM renderer (`renderFilterChips`) |
 | `htdocs/luci-static/resources/fwlive/logging.js` | Logging toolbar and empty-state DOM renderers |
 | `htdocs/luci-static/resources/fwlive/table.js` | Table thead/rows DOM renderer (`renderThead`, `renderRows`) |
+| `htdocs/luci-static/resources/fwlive/buffer.js` | Ring-buffer apply/merge helpers (pause ingest + resume merge) |
 | `root/usr/share/luci/menu.d/*.json` | Menu entry (`admin/status/fwlive`) |
 | `root/usr/share/rpcd/acl.d/*.json` | ubus ACL (read + write for logging enable/disable) |
 | `root/usr/libexec/rpcd/fwlive` | rpcd plugin (`rules`, `poll`, `resolve`, `logging_status`, `enable_wan_logging`, `disable_wan_logging`) |

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
@@ -1,0 +1,76 @@
+'use strict';
+'require baseclass';
+
+/**
+ * Ring-buffer helpers for luci-app-fwlive poll ingest.
+ * LuCI modules must return baseclass.extend(...) — plain objects fail Class.isSubclass.
+ *
+ * While paused, ingest grows up to fetchLinesMax. Live mode caps at rowLimit.
+ * On resume, merge (do not replace) so pause-accumulated rows survive the first
+ * live poll — see issue #43 pause→resume data loss.
+ */
+
+function ingestCap(paused, rowLimit, fetchLinesMax) {
+	return paused ? fetchLinesMax : rowLimit;
+}
+
+function mergeById(entries, normalized, cap) {
+	if (!normalized || !normalized.length) {
+		if (!entries || !entries.length)
+			return [];
+		return entries.slice(-cap);
+	}
+
+	const byId = {};
+	let i;
+	if (entries) {
+		for (i = 0; i < entries.length; i++)
+			byId[entries[i].id] = entries[i];
+	}
+	for (i = 0; i < normalized.length; i++)
+		byId[normalized[i].id] = normalized[i];
+
+	const merged = Object.keys(byId).map(function(id) { return byId[id]; });
+	merged.sort(function(a, b) {
+		const ta = a.timestamp || 0;
+		const tb = b.timestamp || 0;
+		if (ta !== tb)
+			return ta - tb;
+		return (a.log_id || 0) - (b.log_id || 0);
+	});
+	return merged.slice(-cap);
+}
+
+/**
+ * Apply a poll batch onto the current buffer.
+ *
+ * @param {object[]} entries - current buffer (oldest-first)
+ * @param {object[]} normalized - newly polled rows (oldest-first)
+ * @param {{ paused: boolean, resumeMerge: boolean, rowLimit: number, fetchLinesMax: number }} opts
+ * @returns {object[]} next buffer
+ */
+function applyFetchedEntries(entries, normalized, opts) {
+	const paused = !!(opts && opts.paused);
+	const resumeMerge = !!(opts && opts.resumeMerge);
+	const rowLimit = (opts && opts.rowLimit) || 0;
+	const fetchLinesMax = (opts && opts.fetchLinesMax) || rowLimit;
+	const cap = ingestCap(paused, rowLimit, fetchLinesMax);
+	const merge = paused || resumeMerge;
+
+	let next;
+	if (merge)
+		next = mergeById(entries, normalized, cap);
+	else
+		next = (normalized || []).slice(-cap);
+
+	if (!paused && next.length > rowLimit)
+		next = next.slice(-rowLimit);
+
+	return next;
+}
+
+return baseclass.extend({
+	ingestCap: ingestCap,
+	mergeById: mergeById,
+	applyFetchedEntries: applyFetchedEntries
+});

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -14,6 +14,7 @@
 'require fwlive.chips as chips';
 'require fwlive.logging as logging';
 'require fwlive.table as table';
+'require fwlive.buffer as buffer';
 
 const callFwlivePoll = rpc.declare({
 	object: 'fwlive',
@@ -72,6 +73,8 @@ return view.extend({
 	sessionAtPause: 0,
 	pauseBufferLoading: false,
 	paused: false,
+	/* One-shot: first live poll after unpause merges instead of replacing (#43). */
+	resumeMerge: false,
 	messageLayout: 'wrap',
 	renderBucket: constants.RENDER_CAP_PER_SEC,
 	renderBucketMs: 0,
@@ -660,36 +663,24 @@ return view.extend({
 		this.lastPollNewEvents = pollNew;
 
 		/* Oldest-first ring buffer; filteredRows() reverses for newest-first display. */
-		if (this.paused)
-			this.mergeEntries(normalized);
-		else
-			this.entries = normalized.slice(-this.ingestCap());
-		this.trimEntriesToLiveCap();
+		this.entries = buffer.applyFetchedEntries(this.entries, normalized, {
+			paused: this.paused,
+			resumeMerge: this.resumeMerge,
+			rowLimit: this.rowLimit,
+			fetchLinesMax: constants.FETCH_LINES_MAX
+		});
 	},
 
 	mergeEntries(normalized) {
-		if (!normalized.length)
-			return;
-
-		const byId = {};
-		for (let i = 0; i < this.entries.length; i++)
-			byId[this.entries[i].id] = this.entries[i];
-		for (let i = 0; i < normalized.length; i++)
-			byId[normalized[i].id] = normalized[i];
-
-		const merged = Object.keys(byId).map((id) => byId[id]);
-		merged.sort((a, b) => {
-			const ta = a.timestamp || 0;
-			const tb = b.timestamp || 0;
-			if (ta !== tb)
-				return ta - tb;
-			return (a.log_id || 0) - (b.log_id || 0);
-		});
-		this.entries = merged.slice(-this.ingestCap());
+		this.entries = buffer.mergeById(
+			this.entries,
+			normalized,
+			this.ingestCap()
+		);
 	},
 
 	ingestCap() {
-		return this.paused ? constants.FETCH_LINES_MAX : this.rowLimit;
+		return buffer.ingestCap(this.paused, this.rowLimit, constants.FETCH_LINES_MAX);
 	},
 
 	trimEntriesToLiveCap() {
@@ -926,12 +917,15 @@ return view.extend({
 			return;
 		}
 
-		if (wasPaused && !this.paused)
-			this.followLive = true;
-
 		if (wasPaused && !this.paused) {
-			this.trimEntriesToLiveCap();
-			this.fetchEntries().then(() => this.renderRows(true));
+			this.followLive = true;
+			/* Merge pause buffer with the first live poll — do not replace (#43). */
+			this.resumeMerge = true;
+			this.fetchEntries()
+				.then(() => this.renderRows(true))
+				.finally(function() {
+					this.resumeMerge = false;
+				}.bind(this));
 			return;
 		}
 

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -44,6 +44,9 @@ echo "== fwlive theme tint helpers ==" >&2
 echo "== fwlive extracted modules smoke ==" >&2
 "$NODE" tests/fwlive-modules-smoke.test.js
 
+echo "== fwlive pause/resume buffer ==" >&2
+"$NODE" tests/fwlive-pause-resume-buffer.test.js
+
 echo "== fwlive filter negate toggle ==" >&2
 "$NODE" tests/fwlive-filter-negate.test.js
 

--- a/tests/fwlive-modules-smoke.test.js
+++ b/tests/fwlive-modules-smoke.test.js
@@ -176,4 +176,11 @@ assert.strictEqual(body.innerHTML, '');
 assert.ok(body._n >= 1);
 console.log('fwlive-modules smoke: table OK');
 
+/* --- buffer --- */
+const buffer = loadFwliveModule('buffer');
+assert.strictEqual(typeof buffer.applyFetchedEntries, 'function');
+assert.strictEqual(buffer.ingestCap(true, 100, 2000), 2000);
+assert.strictEqual(buffer.ingestCap(false, 100, 2000), 100);
+console.log('fwlive-modules smoke: buffer OK');
+
 console.log('fwlive modules smoke tests passed');

--- a/tests/fwlive-pause-resume-buffer.test.js
+++ b/tests/fwlive-pause-resume-buffer.test.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Pause→resume buffer apply (#43): merge on resume, do not replace.
+ */
+
+const assert = require('assert');
+const { loadFwliveModule } = require('./lib/load-fwlive-module');
+
+const buffer = loadFwliveModule('buffer');
+const ROW = 100;
+const MAX = 2000;
+
+function row(id, ts) {
+	return { id: String(id), log_id: id, timestamp: ts || id };
+}
+
+function ids(entries) {
+	return entries.map(function(e) { return e.id; });
+}
+
+/* Live replace path still replaces. */
+assert.deepStrictEqual(
+	ids(buffer.applyFetchedEntries(
+		[ row(1), row(2) ],
+		[ row(10), row(11) ],
+		{ paused: false, resumeMerge: false, rowLimit: ROW, fetchLinesMax: MAX }
+	)),
+	[ '10', '11' ]
+);
+
+/* Paused: merge and grow toward fetchLinesMax. */
+const pausedBuf = [];
+for (let i = 1; i <= 150; i++)
+	pausedBuf.push(row(i));
+const afterPausePoll = buffer.applyFetchedEntries(
+	pausedBuf,
+	[ row(151), row(152) ],
+	{ paused: true, resumeMerge: false, rowLimit: ROW, fetchLinesMax: MAX }
+);
+assert.strictEqual(afterPausePoll.length, 152);
+assert.deepStrictEqual(ids(afterPausePoll.slice(-3)), [ '150', '151', '152' ]);
+
+/* Bug #43 scenario: large pause buffer + resume must keep recent pause rows. */
+const big = [];
+for (let i = 1; i <= 500; i++)
+	big.push(row(i));
+/* Poll returns only a short recent window that overlaps the end. */
+const poll = [ row(490), row(491), row(492), row(500), row(501) ];
+
+const brokenReplace = buffer.applyFetchedEntries(big, poll, {
+	paused: false,
+	resumeMerge: false,
+	rowLimit: ROW,
+	fetchLinesMax: MAX
+});
+assert.deepStrictEqual(ids(brokenReplace), [ '490', '491', '492', '500', '501' ],
+	'replace path (pre-fix) loses pause-only rows');
+
+const fixed = buffer.applyFetchedEntries(big, poll, {
+	paused: false,
+	resumeMerge: true,
+	rowLimit: ROW,
+	fetchLinesMax: MAX
+});
+assert.strictEqual(fixed.length, ROW);
+assert.ok(ids(fixed).indexOf('402') >= 0, 'keeps pause-only row before poll window');
+assert.ok(ids(fixed).indexOf('501') >= 0, 'includes new poll row');
+assert.deepStrictEqual(ids(fixed).slice(-5), [ '497', '498', '499', '500', '501' ]);
+assert.deepStrictEqual(ids(fixed)[0], '402');
+
+/* Empty poll on resume still keeps trimmed pause buffer. */
+const keep = buffer.applyFetchedEntries(big, [], {
+	paused: false,
+	resumeMerge: true,
+	rowLimit: ROW,
+	fetchLinesMax: MAX
+});
+assert.strictEqual(keep.length, ROW);
+assert.deepStrictEqual(ids(keep)[0], '401');
+assert.deepStrictEqual(ids(keep)[ROW - 1], '500');
+
+assert.strictEqual(buffer.ingestCap(true, ROW, MAX), MAX);
+assert.strictEqual(buffer.ingestCap(false, ROW, MAX), ROW);
+
+console.log('fwlive pause/resume buffer tests passed');


### PR DESCRIPTION
## Summary
- Fixes the critical [#43](https://github.com/lucas-albers-lz4/fwlive/issues/43) finding: pause→resume data loss.
- First live poll after unpause **merges** with the pause-accumulated buffer instead of replacing it, then trims to `rowLimit`.
- Extracts ring-buffer apply/merge into `fwlive/buffer.js` with unit coverage.

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [ ] Pause Live View, let ingest grow past row limit, resume — recent pause rows remain
- [ ] Confirm live mode still replaces on subsequent polls
- [ ] Toggle pause/resume a few times under load


Made with [Cursor](https://cursor.com)