### PR TITLE
fix: #43 MCR majors — parser sync, poll guard, debounce

### DIFF
--- a/core/fwlive-log.js
+++ b/core/fwlive-log.js
@@ -3,7 +3,7 @@
 /**
  * Shared firewall log parsing and filtering (Node CLI + unit tests).
  * Keep in sync with openwrt-feed/.../fwlive/log.js (LuCI baseclass wrapper).
- * PARSER_SYNC_VERSION: 2
+ * PARSER_SYNC_VERSION: 3
  */
 
 const NON_FIREWALL_PREFIX = /^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)\b/i;
@@ -126,7 +126,7 @@ function timestampUnix(entry) {
 	if (!entry || entry.time == null || entry.time === '')
 		return null;
 
-	if (typeof entry.time === 'string' && entry.time.includes('T'))
+	if (typeof entry.time === 'string' && entry.time.indexOf('T') !== -1)
 		return Math.floor(new Date(entry.time).getTime() / 1000);
 
 	const n = Number(entry.time);
@@ -258,7 +258,7 @@ function matchesTextField(haystack, spec) {
 	if (!p.value)
 		return true;
 
-	const hit = (haystack || '').includes(p.value);
+	const hit = (haystack || '').indexOf(p.value) !== -1;
 	return p.negate ? !hit : hit;
 }
 
@@ -277,8 +277,12 @@ function matchesFilter(row, filters) {
 	if (filters.q) {
 		const p = parseFilterValue(filters.q);
 		if (p.value) {
-			const blob = Object.values(row).join(' ').toLowerCase();
-			const hit = blob.includes(p.value.toLowerCase());
+			const keys = Object.keys(row);
+			const parts = [];
+			for (let i = 0; i < keys.length; i++)
+				parts.push(row[keys[i]]);
+			const blob = parts.join(' ').toLowerCase();
+			const hit = blob.indexOf(p.value.toLowerCase()) !== -1;
 			if (p.negate ? hit : !hit)
 				return false;
 		}
@@ -323,10 +327,10 @@ function matchesFilter(row, filters) {
 function actionRowClass(action) {
 	const a = (action || '').toLowerCase();
 	if (a === 'drop' || a === 'reject' || a === 'block')
-		return 'fwlive-deny';
+		return 'fwlive-action fwlive-deny';
 	if (a === 'pass')
-		return 'fwlive-pass';
-	return '';
+		return 'fwlive-action fwlive-pass';
+	return 'fwlive-action fwlive-unknown';
 }
 
 function filterLogEntries(entries, options) {

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
@@ -3,7 +3,7 @@
 
 /**
  * LuCI wrapper — keep logic aligned with core/fwlive-log.js (see scripts/fwlive-test.sh).
- * PARSER_SYNC_VERSION: 2
+ * PARSER_SYNC_VERSION: 3
  */
 return baseclass.extend({
 	NON_FIREWALL_PREFIX: /^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)\b/i,
@@ -332,7 +332,7 @@ return baseclass.extend({
 		if (!p.value)
 			return true;
 
-		const hit = (haystack || '').includes(p.value);
+		const hit = (haystack || '').indexOf(p.value) !== -1;
 		return p.negate ? !hit : hit;
 	},
 
@@ -351,8 +351,12 @@ return baseclass.extend({
 		if (filters.q) {
 			const p = this.parseFilterValue(filters.q);
 			if (p.value) {
-				const blob = Object.values(row).join(' ').toLowerCase();
-				const hit = blob.includes(p.value.toLowerCase());
+				const keys = Object.keys(row);
+				const parts = [];
+				for (let i = 0; i < keys.length; i++)
+					parts.push(row[keys[i]]);
+				const blob = parts.join(' ').toLowerCase();
+				const hit = blob.indexOf(p.value.toLowerCase()) !== -1;
 				if (p.negate ? hit : !hit)
 					return false;
 			}

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -75,6 +75,9 @@ return view.extend({
 	paused: false,
 	/* One-shot: first live poll after unpause merges instead of replacing (#43). */
 	resumeMerge: false,
+	pollFn: null,
+	pollDataInFlight: false,
+	filterInputTimer: null,
 	messageLayout: 'wrap',
 	renderBucket: constants.RENDER_CAP_PER_SEC,
 	renderBucketMs: 0,
@@ -1226,6 +1229,15 @@ return view.extend({
 		this.renderRows(true);
 	},
 
+	onFilterInputDebounced() {
+		if (this.filterInputTimer)
+			clearTimeout(this.filterInputTimer);
+		this.filterInputTimer = setTimeout(function() {
+			this.filterInputTimer = null;
+			this.onFilterInput();
+		}.bind(this), 100);
+	},
+
 	onScrollArea(ev) {
 		const scroll = ev && ev.target;
 		if (!scroll || this.paused)
@@ -1245,9 +1257,11 @@ return view.extend({
 			const el = document.getElementById('fwlive-' + ids[i]);
 			if (!el)
 				continue;
-			el.addEventListener('input', this.onFilterInput.bind(this));
+			/* Text inputs: debounce rebuilds. Selects: apply immediately. */
 			if (el.tagName === 'SELECT')
 				el.addEventListener('change', this.onFilterInput.bind(this));
+			else
+				el.addEventListener('input', this.onFilterInputDebounced.bind(this));
 		}
 
 		const refreshCb = document.getElementById('fwlive-autorefresh');
@@ -1272,26 +1286,50 @@ return view.extend({
 	},
 
 	async pollData() {
-		try {
-			await this.fetchEntries();
-		} catch (e) {
-			/* keep existing buffer on poll errors */
-		}
+		if (this.pollDataInFlight)
+			return;
 
-		if (this.paused)
-			this.updateStatus();
-		else
-			this.renderRows(false);
-
+		this.pollDataInFlight = true;
 		try {
-			await this.resolveHostnamesForEntries(this.filteredRows());
-		} catch (e) {
-			/* resolve unavailable — show IPs */
+			try {
+				await this.fetchEntries();
+			} catch (e) {
+				/* keep existing buffer on poll errors */
+			}
+
+			if (this.paused)
+				this.updateStatus();
+			else
+				this.renderRows(false);
+
+			try {
+				await this.resolveHostnamesForEntries(this.filteredRows());
+			} catch (e) {
+				/* resolve unavailable — show IPs */
+			}
+		} finally {
+			this.pollDataInFlight = false;
 		}
 	},
 
 	load() {
-		poll.add(this.pollData.bind(this), 1);
+		if (!this.pollFn) {
+			this.pollFn = this.pollData.bind(this);
+			poll.add(this.pollFn, 1);
+			/* Best-effort teardown when leaving the page (LuCI SPA may full-reload). */
+			if (typeof window !== 'undefined' && window.addEventListener) {
+				window.addEventListener('pagehide', function() {
+					if (this.pollFn) {
+						try { poll.remove(this.pollFn); } catch (e) { /* poll gone */ }
+						this.pollFn = null;
+					}
+					if (this.filterInputTimer) {
+						clearTimeout(this.filterInputTimer);
+						this.filterInputTimer = null;
+					}
+				}.bind(this));
+			}
+		}
 		return Promise.all([
 			this.loadRulesMap(),
 			this.loadLoggingStatus()

--- a/tests/fwlive-parser-sync.test.js
+++ b/tests/fwlive-parser-sync.test.js
@@ -4,10 +4,13 @@
 /**
  * Guard: Node parser (core/fwlive-log.js) and LuCI mirror (fwlive/log.js) stay aligned.
  * Bump PARSER_SYNC_VERSION in both files when you intentionally change parser logic.
+ * Also asserts shared presentation helpers (actionRowClass) match behaviorally.
  */
 
+const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const { loadFwliveModule } = require('./lib/load-fwlive-module');
 
 const ROOT = path.join(__dirname, '..');
 const CORE = path.join(ROOT, 'core/fwlive-log.js');
@@ -33,5 +36,30 @@ if (coreV !== luciV) {
 	console.error(`parser sync mismatch: core=${coreV} luci=${luciV}`);
 	process.exit(1);
 }
+
+const core = require(CORE);
+const luci = loadFwliveModule('log');
+
+const samples = [ 'pass', 'drop', 'reject', 'block', 'accept', '', null, 'PASS' ];
+for (let i = 0; i < samples.length; i++) {
+	const a = samples[i];
+	assert.strictEqual(
+		core.actionRowClass(a),
+		luci.actionRowClass(a),
+		'actionRowClass mismatch for ' + JSON.stringify(a)
+	);
+}
+
+assert.strictEqual(core.actionRowClass('pass'), 'fwlive-action fwlive-pass');
+assert.strictEqual(core.actionRowClass('drop'), 'fwlive-action fwlive-deny');
+assert.strictEqual(core.actionRowClass('weird'), 'fwlive-action fwlive-unknown');
+
+/* 21.02-era APIs: no String.includes / Object.values in either mirror. */
+const coreSrc = fs.readFileSync(CORE, 'utf8');
+const luciSrc = fs.readFileSync(LUCI, 'utf8');
+assert.ok(coreSrc.indexOf('.includes(') < 0, 'core still uses String.includes');
+assert.ok(luciSrc.indexOf('.includes(') < 0, 'LuCI still uses String.includes');
+assert.ok(coreSrc.indexOf('Object.values') < 0, 'core still uses Object.values');
+assert.ok(luciSrc.indexOf('Object.values') < 0, 'LuCI still uses Object.values');
 
 console.log(`fwlive parser sync OK (version ${coreV})`);


### PR DESCRIPTION
## Summary
Addresses several high-confidence [#43](https://github.com/lucas-albers-lz4/fwlive/issues/43) major findings:

- **Parser mirror drift** — `actionRowClass` aligned in core + LuCI (`fwlive-action …`); sync test now asserts behavioral parity and bans `String.includes` / `Object.values`
- **21.02 compat** — filter matching uses `indexOf` / `Object.keys` loops
- **Poll overlap** — `pollDataInFlight` skips re-entry while a poll is running
- **Poll leak** — stable `pollFn` reference + `pagehide` `poll.remove`
- **Filter typing freeze** — 100ms debounce on text `input`; selects stay immediate

`PARSER_SYNC_VERSION` bumped to **3**.

## Not in this PR
Remaining #43 majors (shell `sh -c`, O(n) log-filter spawns, `inferActionRaw`, shellcheck, JSON escaping) and #40 row-tint a11y.

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [ ] Type in search filter — table rebuilds after brief pause, not every keystroke
- [ ] Change action/proto selects — immediate rebuild
- [ ] Leave/revisit Live View — no runaway duplicate polls (spot-check)


Made with [Cursor](https://cursor.com)