### PR TITLE
docs: update CHANGELOG for v0.1.28 and Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Selectable filter chip styles (Labels / Symbols / Tone) with localStorage persistence (#18, #38)
+- Row tint toggle (on/off) with Classic (green/red, default) and Accessible (teal/orange) palettes (#40, #47, #49)
+- Theme tint fallback when LuCI theme CSS variables do not paint pass/deny row backgrounds
+- Security-only Dependabot config for npm, Docker, and GitHub Actions (#42)
+- gitleaks pre-commit hook for local secret scanning (#41)
+
+### Fixed
+- Pause → resume no longer drops live events; pause buffer is merged on resume (#43, #44)
+- Parser version sync (v3), overlapping poll guard / `pagehide` cleanup, and filter input debounce (#43, #45)
+
+### Changed
+- CI workflows set explicit `GITHUB_TOKEN` permissions (#39)
+
+---
+
+## [v0.1.28] — 2026-07-27
+
 ### Documentation
 - Consolidated planning/spec docs into ROADMAP.md
 - Restructured over-long user docs (Quick Start first)
-- Added CHANGELOG.md, FAQ.md
-- Fixed cross-reference accuracy throughout
+- Added CHANGELOG.md, FAQ.md, and upgrade guide
+- Fixed cross-reference accuracy and MCR review findings throughout
 
 ---
 


### PR DESCRIPTION
## Summary
- Move the docs-stack notes into **[v0.1.28]** (matches the published release)
- Document post-`v0.1.28` work under **[Unreleased]** (chip styles, row tint, #43 fixes, Dependabot/gitleaks/CI permissions)
- Refresh compare links at the bottom of `CHANGELOG.md`

## Test plan
- [x] Skim `CHANGELOG.md` vs merged PRs `#38`–`#49` (exclude reverted i18n `#48`)


Made with [Cursor](https://cursor.com)