### PR TITLE
docs: fix CHANGELOG compare links for v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,7 +273,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.27...HEAD
+[Unreleased]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.28...HEAD
+[v0.1.28]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.27...v0.1.28
 [v0.1.27]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.26...v0.1.27
 [v0.1.26]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.25...v0.1.26
 [v0.1.25]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.24...v0.1.25


### PR DESCRIPTION
## Summary
- Point Unreleased compare range at `v0.1.28...HEAD`
- Add the missing `[v0.1.28]` compare link

Follow-up to #51 (footer link update landed after that PR merged).


Made with [Cursor](https://cursor.com)