### PR TITLE
fix(menu): show Live View without requiring both nft and iptables

### DIFF
--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -30,8 +30,8 @@ No `luasrc/` — modern JS-only app.
 ## Dependencies
 
 - `luci-base`, `logd` (`rpcd` via `luci-base`; no hard `firewall4` dependency)
-- Menu visible when **`/usr/sbin/nft`** or **`/usr/sbin/iptables`** is executable
-- **fw4/nft** primary on **22.03+**; **iptables LOG** primary on legacy **21.02.x** (fw3), best-effort on 22.03+ when nft absent
+- Menu depends on ACL only (no `fs` AND of `nft`+`iptables` — that hid the entry on stock fw3 and fw4)
+- Runtime backend detection selects **fw4/nft** (22.03+) or **iptables LOG** (21.02 fw3); best-effort iptables when nft absent
 
 ## Documentation
 

--- a/openwrt-feed/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json
+++ b/openwrt-feed/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json
@@ -7,11 +7,7 @@
 			"path": "status/fwlive"
 		},
 		"depends": {
-			"acl": [ "luci-app-fwlive" ],
-			"fs": [
-				{ "/usr/sbin/nft": "executable" },
-				{ "/usr/sbin/iptables": "executable" }
-			]
+			"acl": [ "luci-app-fwlive" ]
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Remove `depends.fs` AND of `/usr/sbin/nft` + `/usr/sbin/iptables` from the menu entry — LuCI hides the item unless every path exists, so stock fw3 and fw4 installs never saw the menu.
- Gate on ACL only; backend selection stays in `detect_firewall_backend` at runtime.
- Clarify package README accordingly.

Closes #53

## Test plan
- [ ] Install on fw4-only image (no iptables) — Status → Firewall Live View appears
- [ ] Install on 21.02 fw3 (no nft) — menu appears
- [ ] Direct URL `/cgi-bin/luci/admin/status/fwlive` still works


Made with [Cursor](https://cursor.com)