### PR TITLE
fix(logging): revert UCI when firewall reload fails

### DIFF
--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -144,6 +144,19 @@ reload_firewall() {
 	return 1
 }
 
+# Best-effort UCI rollback when firewall reload fails after commit.
+restore_wan_zone_log() {
+	zone="$1"
+	previous="$2"
+	[ -n "$zone" ] || return 1
+	if [ -z "$previous" ]; then
+		uci -q delete "firewall.${zone}.log" 2>/dev/null || true
+	else
+		uci -q set "firewall.${zone}.log=${previous}" 2>/dev/null || true
+	fi
+	uci commit firewall 2>/dev/null || true
+}
+
 enable_wan_logging() {
 	zone=$(find_wan_zone_section)
 	if [ -z "$zone" ]; then
@@ -176,6 +189,8 @@ enable_wan_logging() {
 	fi
 
 	if ! reload_firewall; then
+		restore_wan_zone_log "$zone" "$current"
+		logger -t fwlive 'Firewall reload failed after enable; reverted UCI WAN log' 2>/dev/null || true
 		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
 		return 0
 	fi
@@ -217,6 +232,8 @@ disable_wan_logging() {
 	fi
 
 	if ! reload_firewall; then
+		restore_wan_zone_log "$zone" "$current"
+		logger -t fwlive 'Firewall reload failed after disable; reverted UCI WAN log' 2>/dev/null || true
 		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
 		return 0
 	fi

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -40,6 +40,29 @@ case "$out" in
 esac
 ok "build_logging_status_json shape"
 
+# restore_wan_zone_log: empty previous => delete; non-empty => set + commit
+UCI_LOG=()
+uci() {
+	UCI_LOG+=("$*")
+	return 0
+}
+UCI_LOG=()
+restore_wan_zone_log '@zone[0]' ''
+joined="${UCI_LOG[*]}"
+case "$joined" in
+	*'-q delete firewall.@zone[0].log'*'commit firewall'*) ;;
+	*) die "restore empty previous expected delete+commit, got: $joined" ;;
+esac
+UCI_LOG=()
+restore_wan_zone_log '@zone[1]' '3'
+joined="${UCI_LOG[*]}"
+case "$joined" in
+	*'-q set firewall.@zone[1].log=3'*'commit firewall'*) ;;
+	*) die "restore value expected set+commit, got: $joined" ;;
+esac
+unset -f uci
+ok "restore_wan_zone_log stubs"
+
 sh "$RPCD" __selftest >/dev/null || die "rpcd __selftest"
 ok "rpcd __selftest"
 


### PR DESCRIPTION
## Summary
- On `enable_wan_logging` / `disable_wan_logging`, if `reload_firewall` fails after `uci commit`, restore the prior `firewall.<zone>.log` value (or delete) and recommit.
- Prevents a partial failure state where UCI and the running firewall diverge (#57).
- Host unit coverage via stubbed `uci` for `restore_wan_zone_log`.

Stacked on #63.

Closes #57

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [ ] On device (optional): mock/force reload failure and confirm UCI log option rolls back


Made with [Cursor](https://cursor.com)