### PR TITLE
fix(parser): space timestamps + filter parity fixtures

### DIFF
--- a/core/fwlive-log.js
+++ b/core/fwlive-log.js
@@ -3,7 +3,7 @@
 /**
  * Shared firewall log parsing and filtering (Node CLI + unit tests).
  * Keep in sync with openwrt-feed/.../fwlive/log.js (LuCI baseclass wrapper).
- * PARSER_SYNC_VERSION: 3
+ * PARSER_SYNC_VERSION: 4
  */
 
 const NON_FIREWALL_PREFIX = /^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)\b/i;
@@ -87,7 +87,9 @@ function inferActionRaw(message, kv, actionRaw) {
 		return actionRaw;
 
 	const msg = normalizeNetfilterMessage(message || '');
-	if (DENY_ACTION.test(msg))
+	/* Ignore KEY=value payloads so MAC=…DROP… / PASS=… do not suppress pass inference. */
+	const withoutKv = msg.replace(/\b[A-Z]+=[^\s]*/g, ' ');
+	if (DENY_ACTION.test(withoutKv))
 		return 'UNKNOWN';
 
 	if (/^kernel:/i.test(msg.trim()))
@@ -126,8 +128,11 @@ function timestampUnix(entry) {
 	if (!entry || entry.time == null || entry.time === '')
 		return null;
 
-	if (typeof entry.time === 'string' && entry.time.indexOf('T') !== -1)
-		return Math.floor(new Date(entry.time).getTime() / 1000);
+	if (typeof entry.time === 'string' && /^\d{4}-\d{2}-\d{2}[T ]/.test(entry.time)) {
+		const ms = new Date(entry.time).getTime();
+		if (Number.isFinite(ms))
+			return Math.floor(ms / 1000);
+	}
 
 	const n = Number(entry.time);
 	if (!Number.isFinite(n))

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
@@ -3,7 +3,7 @@
 
 /**
  * LuCI wrapper — keep logic aligned with core/fwlive-log.js (see scripts/fwlive-test.sh).
- * PARSER_SYNC_VERSION: 3
+ * PARSER_SYNC_VERSION: 4
  */
 return baseclass.extend({
 	NON_FIREWALL_PREFIX: /^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)\b/i,
@@ -83,7 +83,9 @@ return baseclass.extend({
 			return actionRaw;
 
 		const msg = this.normalizeNetfilterMessage(message || '');
-		if (this.DENY_ACTION.test(msg))
+		/* Ignore KEY=value payloads so MAC=…DROP… / PASS=… do not suppress pass inference. */
+		const withoutKv = msg.replace(/\b[A-Z]+=[^\s]*/g, ' ');
+		if (this.DENY_ACTION.test(withoutKv))
 			return 'UNKNOWN';
 
 		if (/^kernel:/i.test(msg.trim()))
@@ -122,8 +124,11 @@ return baseclass.extend({
 		if (!entry || entry.time == null || entry.time === '')
 			return null;
 
-		if (typeof entry.time === 'string' && entry.time.indexOf('T') !== -1)
-			return Math.floor(new Date(entry.time).getTime() / 1000);
+		if (typeof entry.time === 'string' && /^\d{4}-\d{2}-\d{2}[T ]/.test(entry.time)) {
+			const ms = new Date(entry.time).getTime();
+			if (isFinite(ms))
+				return Math.floor(ms / 1000);
+		}
 
 		const n = Number(entry.time);
 		if (!isFinite(n))

--- a/tests/fwlive-parser-filter.test.js
+++ b/tests/fwlive-parser-filter.test.js
@@ -14,6 +14,13 @@ function run() {
 	const row = core.normalizeEntry(sample);
 	assert.equal(row.timestamp, Math.floor(new Date(sample.time).getTime() / 1000));
 	assert.equal(row.timestamp_display, '2026-03-20T02:00:00.000Z');
+
+	const spaceTime = {
+		time: '2026-03-20 02:00:00',
+		msg: sample.msg
+	};
+	const spaceRow = core.normalizeEntry(spaceTime);
+	assert.equal(spaceRow.timestamp, Math.floor(new Date('2026-03-20T02:00:00').getTime() / 1000));
 	assert.equal(row.action, 'drop');
 	assert.equal(row.action_raw, 'DROP');
 	assert.equal(row.proto, 'TCP');

--- a/tests/fwlive-parser-sync.test.js
+++ b/tests/fwlive-parser-sync.test.js
@@ -54,6 +54,26 @@ assert.strictEqual(core.actionRowClass('pass'), 'fwlive-action fwlive-pass');
 assert.strictEqual(core.actionRowClass('drop'), 'fwlive-action fwlive-deny');
 assert.strictEqual(core.actionRowClass('weird'), 'fwlive-action fwlive-unknown');
 
+/* Space-separated RFC3339-ish timestamps (#60) — core and LuCI must agree. */
+const spaceTs = { time: '2024-01-01 12:00:00' };
+assert.strictEqual(core.timestampUnix(spaceTs), luci.timestampUnix(spaceTs));
+assert.ok(core.timestampUnix(spaceTs) > 0);
+assert.strictEqual(
+	core.timestampUnix({ time: '2024-01-01T12:00:00Z' }),
+	luci.timestampUnix({ time: '2024-01-01T12:00:00Z' })
+);
+
+/* inferActionRaw: KV values containing DROP/PASS must not block pass inference. */
+const kvPass = core.parseKeyValueLog('IN=wan OUT= SRC=1.2.3.4 DST=5.6.7.8 PROTO=TCP MAC=aa:bb PASS=noise');
+assert.strictEqual(
+	core.inferActionRaw('IN=wan OUT= SRC=1.2.3.4 DST=5.6.7.8 PROTO=TCP MAC=aa:bb PASS=noise', kvPass, 'UNKNOWN'),
+	'PASS'
+);
+assert.strictEqual(
+	luci.inferActionRaw('IN=wan OUT= SRC=1.2.3.4 DST=5.6.7.8 PROTO=TCP MAC=aa:bb PASS=noise', kvPass, 'UNKNOWN'),
+	'PASS'
+);
+
 /* 21.02-era APIs: no String.includes / Object.values in either mirror. */
 const coreSrc = fs.readFileSync(CORE, 'utf8');
 const luciSrc = fs.readFileSync(LUCI, 'utf8');

--- a/tests/fwlive-shell-filter.test.js
+++ b/tests/fwlive-shell-filter.test.js
@@ -30,7 +30,14 @@ function runMsgParity() {
 		{ msg: '[  123.456789] fwlive-ping: IN=br-lan OUT= SRC=192.168.1.10 DST=192.168.1.1 PROTO=ICMP' },
 		{ msg: 'iptables: DROP IN=wan OUT= SRC=203.0.113.5 DST=192.168.1.1 PROTO=TCP DPT=22' },
 		{ msg: '' },
-		{ msg: '   ' }
+		{ msg: '   ' },
+		/* #58 edge cases — keep shell/JS parity honest across engines */
+		{ msg: 'IN=wan OUT= SRC=2001:db8::1 DST=2001:db8::2 PROTO=TCP SPT=1234 DPT=443' },
+		{ msg: '\tIN=wan OUT= SRC=203.0.113.9 DST=192.0.2.9 PROTO=UDP SPT=53 DPT=53\n' },
+		{ msg: 'kernel: IN=wan OUT= SRC=203.0.113.10 DST=192.0.2.10 PROTO=ICMP' },
+		{ msg: 'fw4rejectIN=wan OUT= SRC=203.0.113.11 DST=192.0.2.11 PROTO=TCP DPT=22' },
+		{ msg: 'IN=wan OUT= SRC=203.0.113.12 DST=192.0.2.12 PROTO=TCP MAC=aa:bb:cc:dd:ee:ff PASS=noise' },
+		{ msg: 'not-a-firewall-line at all' }
 	];
 
 	for (const entry of fixture.log.concat(extra)) {


### PR DESCRIPTION
## Summary
- Accept space-separated datetimes (`2024-01-01 12:00:00`) in `timestampUnix` (core + LuCI); bump `PARSER_SYNC_VERSION` to **4** (#60).
- Strip `KEY=value` regions before deny-keyword checks in `inferActionRaw` so values like `PASS=noise` do not block pass inference (#43 leftover).
- Expand shell/JS `isFirewallEvent` parity fixtures (IPv6, whitespace, glued prefixes, keyword-in-value) without rewriting the dual implementation (#58).

Stacked on #65.

Closes #60

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [ ] Spot-check relative time sorting with space-separated logread times if available


Made with [Cursor](https://cursor.com)