### PR TITLE
ci: re-enable single-cell QEMU feed smoke (#10)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -10,6 +10,14 @@ on:
         description: 'Release tag to build and publish (e.g. v0.1.13)'
         required: true
         type: string
+      feed_smoke:
+        description: 'Run QEMU feed smoke after publish (single OpenWrt cell)'
+        type: boolean
+        default: true
+      smoke_version:
+        description: 'OpenWrt version for feed smoke (one cell; default 24.10)'
+        type: string
+        default: '24.10'
 
 env:
   FWLIVE_FEED_BASE_URL: https://lucas-albers-lz4.github.io/fwlive-packages
@@ -144,12 +152,15 @@ jobs:
             publish_new
           fi
 
-  # Disabled: QEMU feed smoke burns GHA minutes; KVM/TCG+SSH issues on hosted runners.
-  # Re-enable when https://github.com/lucas-albers-lz4/fwlive/issues/10 is resolved.
+  # Single-cell QEMU feed smoke (#10): TCG on hosted runners; default OpenWrt 24.10.
+  # Tag pushes always smoke; workflow_dispatch can skip via feed_smoke=false.
   smoke-from-feed:
-    if: false
+    if: >-
+      github.event_name == 'push' ||
+      github.event.inputs.feed_smoke == 'true'
     needs: build-publish
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
@@ -158,6 +169,9 @@ jobs:
       OWRT_VALIDATE_SSH_WAIT_X86: "900"
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
 
       - name: Install lab dependencies
         run: |
@@ -167,10 +181,10 @@ jobs:
       - name: Wait for GitHub Pages propagation
         run: ./scripts/wait-feed-pages.sh "$FWLIVE_FEED_BASE_URL"
 
-      - name: Feed smoke (21.02, 22.03, 23.05, 24.10, 25.12)
+      - name: Feed smoke (single reference cell)
         env:
           FWLIVE_FEED_BASE_URL: ${{ env.FWLIVE_FEED_BASE_URL }}
         run: |
-          for ver in 21.02 22.03 23.05 24.10 25.12; do
-            ./scripts/validate-feed-smoke.sh --version "$ver"
-          done
+          ver="${{ github.event.inputs.smoke_version || '24.10' }}"
+          echo "Feed smoke OpenWrt version: $ver"
+          ./scripts/validate-feed-smoke.sh --version "$ver"

--- a/docs/binary-feed.md
+++ b/docs/binary-feed.md
@@ -172,7 +172,7 @@ On **tag push** (`v*`) or manual workflow dispatch, [`.github/workflows/publish-
 4. Stages signed feed via [`publish-packages.sh`](../scripts/publish-packages.sh).
 5. Deploys to **`fwlive-packages`** `gh-pages`.
 6. Uploads `.ipk` / `.apk` to the GitHub Release.
-7. Boots QEMU x86 guests and installs from the **live Pages URL** ([`validate-feed-smoke.sh`](../scripts/validate-feed-smoke.sh)) — *currently disabled in CI* ([#10](https://github.com/lucas-albers-lz4/fwlive/issues/10)).
+7. Boots one QEMU x86 reference guest (**24.10** by default) and installs from the **live Pages URL** ([`validate-feed-smoke.sh`](../scripts/validate-feed-smoke.sh); TCG on hosted runners — [#10](https://github.com/lucas-albers-lz4/fwlive/issues/10)).
 
 ---
 

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -103,4 +103,4 @@ When copying `openwrt-feed/luci-app-fwlive/` into `luci/applications/luci-app-fw
 | Workflow | When |
 |----------|------|
 | `fwlive-test.yml` | Every push/PR — parser tests |
-| `publish-packages.yml` | Tag push `v*` — SDK build, reproducibility, Pages deploy, release assets, feed smoke |
+| `publish-packages.yml` | Tag push `v*` — SDK build, reproducibility, Pages deploy, release assets, single-cell QEMU feed smoke (24.10 / TCG) |


### PR DESCRIPTION
## Summary
- Re-enable `smoke-from-feed` in `publish-packages.yml` (remove `if: false`).
- Smoke **one** reference cell (**24.10**) under `OWRT_QEMU_ACCEL=tcg` with a 900s SSH wait — matches the #10 checklist without burning minutes on five sequential TCG boots.
- `workflow_dispatch`: `feed_smoke` (default true) and `smoke_version` (default `24.10`).
- Docs updated in binary-feed + publish checklist.

Closes #10

## Test plan
- [ ] Merge, then either wait for next `v*` tag publish **or** `workflow_dispatch` publish-packages with an existing tag and `feed_smoke=true`
- [ ] Confirm smoke-from-feed reaches SSH and `validate-feed-smoke.sh --version 24.10` passes
- [ ] Optional: dispatch with `feed_smoke=false` to confirm publish-only path still works


Made with [Cursor](https://cursor.com)