### PR TITLE
fix(rpcd): nft timeout, rulesmap path lock, ubus hardening

### DIFF
--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -78,10 +78,11 @@ check_nf_log_ipv6() {
 logging_blockers_append() {
 	blocker="$1"
 	[ -n "$blocker" ] || return 0
+	esc=$(printf '%s' "$blocker" | json_escape)
 	if [ -n "$LOGGING_BLOCKERS" ]; then
 		LOGGING_BLOCKERS="${LOGGING_BLOCKERS},"
 	fi
-	LOGGING_BLOCKERS="${LOGGING_BLOCKERS}\"${blocker}\""
+	LOGGING_BLOCKERS="${LOGGING_BLOCKERS}\"${esc}\""
 }
 
 collect_logging_blockers() {
@@ -150,35 +151,37 @@ enable_wan_logging() {
 		return 0
 	fi
 
+	zone_json=$(json_null_or_string "$zone")
+
 	if ! check_nf_log_ipv4 || ! check_nf_log_ipv6; then
-		printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"nf_log_missing"}' "$zone"
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"nf_log_missing"}' "$zone_json"
 		return 0
 	fi
 
 	current=$(wan_zone_log_value "$zone")
 	if wan_filter_log_enabled "$current"; then
-		printf '{"ok":true,"changed":false,"wan_zone":"%s"}' "$zone"
+		printf '{"ok":true,"changed":false,"wan_zone":%s}' "$zone_json"
 		return 0
 	fi
 
 	target=$(wan_filter_log_target_value "$current")
 	if ! uci set "firewall.${zone}.log=${target}"; then
-		printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"uci_set_failed"}' "$zone"
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_set_failed"}' "$zone_json"
 		return 0
 	fi
 
 	if ! uci commit firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"uci_commit_failed"}' "$zone"
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
 		return 0
 	fi
 
 	if ! reload_firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"firewall_reload_failed"}' "$zone"
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
 		return 0
 	fi
 
 	logger -t fwlive 'WAN zone logging enabled' 2>/dev/null || true
-	printf '{"ok":true,"changed":true,"wan_zone":"%s"}' "$zone"
+	printf '{"ok":true,"changed":true,"wan_zone":%s}' "$zone_json"
 }
 
 disable_wan_logging() {
@@ -188,37 +191,38 @@ disable_wan_logging() {
 		return 0
 	fi
 
+	zone_json=$(json_null_or_string "$zone")
 	current=$(wan_zone_log_value "$zone")
 	if [ -z "$current" ] || ! wan_filter_log_enabled "$current"; then
-		printf '{"ok":true,"changed":false,"wan_zone":"%s"}' "$zone"
+		printf '{"ok":true,"changed":false,"wan_zone":%s}' "$zone_json"
 		return 0
 	fi
 
 	target=$(wan_filter_log_clear_value "$current")
 	if [ -z "$target" ]; then
 		if ! uci delete "firewall.${zone}.log"; then
-			printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"uci_delete_failed"}' "$zone"
+			printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_delete_failed"}' "$zone_json"
 			return 0
 		fi
 	else
 		if ! uci set "firewall.${zone}.log=${target}"; then
-			printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"uci_set_failed"}' "$zone"
+			printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_set_failed"}' "$zone_json"
 			return 0
 		fi
 	fi
 
 	if ! uci commit firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"uci_commit_failed"}' "$zone"
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
 		return 0
 	fi
 
 	if ! reload_firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":"%s","error":"firewall_reload_failed"}' "$zone"
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
 		return 0
 	fi
 
 	logger -t fwlive 'WAN zone logging disabled' 2>/dev/null || true
-	printf '{"ok":true,"changed":true,"wan_zone":"%s"}' "$zone"
+	printf '{"ok":true,"changed":true,"wan_zone":%s}' "$zone_json"
 }
 
 run_logging_selftest() {

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -19,6 +19,10 @@ RESOLVE_MAX=32
 RESOLVE_TIMEOUT=1
 # Cap raw logd lines per poll (~2000 ≈ typical logd ring / ~200 KB JSON before filter).
 POLL_LINES_MAX=2000
+# Bound nft ruleset dumps (corrupted/hung nft must not block LuCI rules load).
+NFT_TIMEOUT=5
+# CLI-only iptables fixture path for __rulesmap_iptables (no arbitrary paths).
+RULESMAP_IPTABLES_FILE='/tmp/rulesmap'
 
 json_escape() {
 	# Escape for JSON string content per RFC 8259 (including remaining C0 controls).
@@ -156,8 +160,16 @@ map_from_iptables_save_stream() {
 	done
 }
 
+nft_list_ruleset() {
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$NFT_TIMEOUT" nft list ruleset 2>/dev/null
+	else
+		nft list ruleset 2>/dev/null
+	fi
+}
+
 detect_firewall_backend() {
-	if command -v nft >/dev/null 2>&1 && nft list ruleset >/dev/null 2>&1; then
+	if command -v nft >/dev/null 2>&1 && nft_list_ruleset >/dev/null; then
 		printf '%s' nft
 		return 0
 	fi
@@ -176,7 +188,7 @@ build_rules_map() {
 
 	case "$backend" in
 		nft)
-			nft list ruleset 2>/dev/null | map_from_nft_stream
+			nft_list_ruleset | map_from_nft_stream
 			;;
 		iptables)
 			iptables-save 2>/dev/null | map_from_iptables_save_stream
@@ -192,7 +204,8 @@ build_rules_map() {
 rulesmap_from_iptables_file() {
 	file="$1"
 	OUT=''
-	[ -n "$file" ] && [ -f "$file" ] || return 1
+	[ "$file" = "$RULESMAP_IPTABLES_FILE" ] || return 1
+	[ -f "$file" ] || return 1
 	map_from_iptables_save_stream < "$file"
 	printf '{"backend":"iptables","rules":{%s}}' "$OUT"
 }
@@ -231,18 +244,8 @@ poll_lines_from_input() {
 fetch_firewall_logs() {
 	input="$1"
 	lines=$(poll_lines_from_input "$input")
-	stream=false
-	oneshot=true
-	case "$stream" in
-		true|1) stream=true ;;
-		*) stream=false ;;
-	esac
-	case "$oneshot" in
-		false|0) oneshot=false ;;
-		*) oneshot=true ;;
-	esac
-
-	raw=$(sh -c "ubus call log read '{\"lines\":$lines,\"stream\":$stream,\"oneshot\":$oneshot}'" 2>/dev/null) \
+	# lines is numeric-clamped; stream/oneshot are fixed (not caller-controlled).
+	raw=$(ubus call log read "{\"lines\":$lines,\"stream\":false,\"oneshot\":true}" 2>/dev/null) \
 		|| raw='{"log":[]}'
 
 	out=$(printf '%s' "$raw" | "$FILTER_SH" 2>/dev/null) || out='{"log":[]}'
@@ -395,7 +398,8 @@ case "$1" in
 		exit $?
 		;;
 	__rulesmap_iptables)
-		rulesmap_from_iptables_file "$2"
+		# CLI selftest only — never a ubus method. Fixed path only (no argv file read).
+		rulesmap_from_iptables_file "$RULESMAP_IPTABLES_FILE"
 		exit $?
 		;;
 	list)

--- a/tests/fwlive-rules-map.test.js
+++ b/tests/fwlive-rules-map.test.js
@@ -3,20 +3,37 @@
 
 const assert = require('node:assert/strict');
 const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const ROOT = path.join(__dirname, '..');
 const RPCD = path.join(ROOT,
 	'openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive');
 const FIXTURE = path.join(__dirname, 'fixtures', 'iptables-save.sample');
+const RULESMAP = '/tmp/rulesmap';
 
 function run() {
-	const raw = execFileSync(RPCD, ['__rulesmap_iptables', FIXTURE], { encoding: 'utf8' });
+	fs.copyFileSync(FIXTURE, RULESMAP);
+
+	const raw = execFileSync(RPCD, ['__rulesmap_iptables'], { encoding: 'utf8' });
 	const res = JSON.parse(raw);
 
 	assert.equal(res.backend, 'iptables');
 	assert.equal(res.rules['fwlive-ping'], 'fwlive-ping');
 	assert.equal(res.rules['allow-dns'], 'Allow-DNS');
+
+	// Fixed path only: argv fixture path must not be readable when /tmp/rulesmap is gone.
+	fs.unlinkSync(RULESMAP);
+	let failed = false;
+	try {
+		execFileSync(RPCD, ['__rulesmap_iptables', FIXTURE], {
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+	} catch (e) {
+		failed = e.status !== 0;
+	}
+	assert.equal(failed, true, 'arbitrary argv path must not be accepted');
 
 	console.log('fwlive rules map tests passed');
 }


### PR DESCRIPTION
## Summary
- Wrap `nft list ruleset` with `timeout 5` so a hung/corrupted ruleset cannot block LuCI rules load (#61).
- `__rulesmap_iptables` is CLI-only (not a ubus method); restrict it to fixed `/tmp/rulesmap` and update the host test (#54).
- Drop the no-op `sh -c` around `ubus call log read`; call ubus with a fixed JSON blob.
- Escape `wan_zone` / logging blockers via `json_escape` / `json_null_or_string` (#43 leftover).

Replaces #63 (auto-closed when #62’s base branch was deleted during merge).

Closes #61
Closes #54

## Test plan
- [x] `./scripts/fwlive-test.sh`


Made with [Cursor](https://cursor.com)