### PR TITLE
ci: add dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+# Warn on new vulnerable dependencies in PRs (dependency graph).
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependency-review.yml` so PRs that change lockfiles get a Dependency Review check (GitHub dependency graph).
- Closes housekeeping Tier-2 finding `dependency_review_missing`.

## Test plan
- [ ] Confirm workflow appears under Actions after merge
- [ ] Open a PR that touches a lockfile and verify the Dependency Review job runs

Made with [Cursor](https://cursor.com)