### PR TITLE
docs: record v0.1.29 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [v0.1.29] — 2026-07-28
 
 ### Added
 - Selectable filter chip styles (Labels / Symbols / Tone) with localStorage persistence (#18, #38)
@@ -273,7 +273,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.28...HEAD
+[v0.1.29]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.28...v0.1.29
 [v0.1.28]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.27...v0.1.28
 [v0.1.27]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.26...v0.1.27
 [v0.1.26]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.25...v0.1.26


### PR DESCRIPTION
## Summary
- Promote the prior Unreleased notes to **[v0.1.29] — 2026-07-28**
- Remove the Unreleased section (changelog only against tagged releases)
- Point the compare link at `v0.1.28...v0.1.29`

## Test plan
- [ ] Skim CHANGELOG.md headings: v0.1.29 then v0.1.28, no Unreleased
- [ ] Confirm compare link opens https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.28...v0.1.29

Made with [Cursor](https://cursor.com)