### PR TITLE
test: menu visibility on fw4-only and 21.02 (#70)

### DIFF
--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -35,6 +35,9 @@ echo "== fwlive rpcd security ==" >&2
 echo "== fwlive schema (stage 2) ==" >&2
 "$NODE" tests/fwlive-schema.test.js
 
+echo "== fwlive menu depends (ACL-only / #70) ==" >&2
+"$NODE" tests/fwlive-menu-depends.test.js
+
 echo "== fwlive theme CSS (LuCI dark mode / tint resilience) ==" >&2
 "$NODE" tests/fwlive-theme-css.test.js
 

--- a/scripts/qemu-smoke-fwlive.sh
+++ b/scripts/qemu-smoke-fwlive.sh
@@ -64,8 +64,15 @@ if printf '%s' "$MENU_BODY" | grep -qE '"fs"|/usr/sbin/nft|/usr/sbin/iptables'; 
 fi
 ok "LuCI menu.d ACL-only depends"
 
-# Warm dispatcher so index cache includes the node, then assert Status → fwlive is satisfied.
-HTTP_HEADERS="$(curl -sS -D - -o /dev/null \
+# Warm dispatcher (authenticated when possible) so index cache includes the node.
+COOKIE_JAR="$(mktemp)"
+cleanup_cookies() { rm -f "$COOKIE_JAR"; }
+trap cleanup_cookies EXIT
+# Empty-password lab: establish a session so /tmp/luci-indexcache*.json is written.
+curl -sS -c "$COOKIE_JAR" -b "$COOKIE_JAR" \
+	-d 'luci_username=root&luci_password=' \
+	"http://${HOST}:${HTTP_PORT}/cgi-bin/luci" >/dev/null 2>&1 || true
+HTTP_HEADERS="$(curl -sS -c "$COOKIE_JAR" -b "$COOKIE_JAR" -D - -o /dev/null \
 	"http://${HOST}:${HTTP_PORT}/cgi-bin/luci/admin/status/fwlive" 2>/dev/null || true)"
 HTTP_CODE="$(printf '%s' "$HTTP_HEADERS" | awk 'toupper($1) ~ /^HTTP/ { print $2; exit }')"
 if [[ -z "$HTTP_CODE" ]]; then
@@ -83,29 +90,18 @@ case "$HTTP_CODE" in
 	*) die "LuCI page HTTP ${HTTP_CODE} (expected 200/302/403-login)" ;;
 esac
 
-# After a page hit, LuCI writes /tmp/luci-indexcache*.json (empty-password lab) or session cache.
-CACHE_JSON="$(ssh_guest 'ls /tmp/luci-indexcache*.json 2>/dev/null | head -1')"
-if [[ -n "$CACHE_JSON" ]]; then
-	CACHE_BODY="$(ssh_guest "cat '$CACHE_JSON'")"
-	if printf '%s' "$CACHE_BODY" | grep -q 'Firewall Live View'; then
-		ok "LuCI index cache lists Firewall Live View (Status menu)"
-	else
-		die "LuCI index cache present but Firewall Live View missing"
-	fi
-else
-	echo "smoke WARN: no luci-indexcache yet (login may be required); menu.d + HTTP checks still OK" >&2
+# Prefer newest index cache (stale/other-language copies may exist).
+CACHE_JSON="$(ssh_guest 'ls -1t /tmp/luci-indexcache*.json 2>/dev/null | head -1')"
+if [[ -z "$CACHE_JSON" ]]; then
+	die "no luci-indexcache after page hit — Status menu entry not verified"
 fi
+CACHE_BODY="$(ssh_guest "cat '$CACHE_JSON'")"
+printf '%s' "$CACHE_BODY" | grep -q 'Firewall Live View' \
+	|| die "LuCI index cache present but Firewall Live View missing"
+ok "LuCI index cache lists Firewall Live View (Status menu)"
 
 if ssh_guest 'command -v nft >/dev/null 2>&1'; then
-	BACKEND=nft
-elif ssh_guest 'command -v iptables >/dev/null 2>&1'; then
-	BACKEND=iptables
-else
-	BACKEND=unknown
-fi
-ok "firewall backend probe: ${BACKEND}"
-
-if ssh_guest 'command -v nft >/dev/null 2>&1'; then
+	ok "firewall backend probe: nft"
 	"${ROOT}/scripts/fwlive-nft-ping-log.sh" add --ssh >/dev/null 2>&1 || true
 	ssh_guest 'ping -c 3 -W 1 127.0.0.1 >/dev/null 2>&1' || true
 	sleep 1
@@ -116,6 +112,7 @@ if ssh_guest 'command -v nft >/dev/null 2>&1'; then
 		echo "smoke WARN: no parsed firewall rows yet (nft log rule may need traffic)" >&2
 	fi
 elif ssh_guest 'command -v iptables >/dev/null 2>&1'; then
+	ok "firewall backend probe: iptables"
 	"${ROOT}/scripts/fwlive-iptables-ping-log.sh" add --ssh >/dev/null 2>&1 || true
 	ssh_guest 'ping -c 3 -W 1 127.0.0.1 >/dev/null 2>&1' || true
 	sleep 1
@@ -125,6 +122,8 @@ elif ssh_guest 'command -v iptables >/dev/null 2>&1'; then
 	else
 		echo "smoke WARN: no parsed firewall rows yet (iptables LOG rule may need traffic)" >&2
 	fi
+else
+	die "firewall backend probe: neither nft nor iptables found"
 fi
 
 echo "== smoke passed ==" >&2

--- a/scripts/qemu-smoke-fwlive.sh
+++ b/scripts/qemu-smoke-fwlive.sh
@@ -51,6 +51,20 @@ ssh_guest 'test -f /www/luci-static/resources/fwlive/log.js' \
 	|| die "missing fwlive/log.js"
 ok "LuCI static assets"
 
+MENU_JSON=/usr/share/luci/menu.d/luci-app-fwlive.json
+ssh_guest "test -f '$MENU_JSON'" || die "missing LuCI menu.d entry"
+# #53/#62/#70: menu must depend on ACL only — fs AND of nft+iptables hid the entry on stock fw3/fw4.
+MENU_BODY="$(ssh_guest "cat '$MENU_JSON'")"
+printf '%s' "$MENU_BODY" | grep -q 'Firewall Live View' \
+	|| die "menu.d missing Firewall Live View title"
+printf '%s' "$MENU_BODY" | grep -q 'luci-app-fwlive' \
+	|| die "menu.d missing ACL depend luci-app-fwlive"
+if printf '%s' "$MENU_BODY" | grep -qE '"fs"|/usr/sbin/nft|/usr/sbin/iptables'; then
+	die "menu.d still has fs/nft/iptables depends (breaks fw3-only or fw4-only menus)"
+fi
+ok "LuCI menu.d ACL-only depends"
+
+# Warm dispatcher so index cache includes the node, then assert Status → fwlive is satisfied.
 HTTP_HEADERS="$(curl -sS -D - -o /dev/null \
 	"http://${HOST}:${HTTP_PORT}/cgi-bin/luci/admin/status/fwlive" 2>/dev/null || true)"
 HTTP_CODE="$(printf '%s' "$HTTP_HEADERS" | awk 'toupper($1) ~ /^HTTP/ { print $2; exit }')"
@@ -68,6 +82,28 @@ case "$HTTP_CODE" in
 		;;
 	*) die "LuCI page HTTP ${HTTP_CODE} (expected 200/302/403-login)" ;;
 esac
+
+# After a page hit, LuCI writes /tmp/luci-indexcache*.json (empty-password lab) or session cache.
+CACHE_JSON="$(ssh_guest 'ls /tmp/luci-indexcache*.json 2>/dev/null | head -1')"
+if [[ -n "$CACHE_JSON" ]]; then
+	CACHE_BODY="$(ssh_guest "cat '$CACHE_JSON'")"
+	if printf '%s' "$CACHE_BODY" | grep -q 'Firewall Live View'; then
+		ok "LuCI index cache lists Firewall Live View (Status menu)"
+	else
+		die "LuCI index cache present but Firewall Live View missing"
+	fi
+else
+	echo "smoke WARN: no luci-indexcache yet (login may be required); menu.d + HTTP checks still OK" >&2
+fi
+
+if ssh_guest 'command -v nft >/dev/null 2>&1'; then
+	BACKEND=nft
+elif ssh_guest 'command -v iptables >/dev/null 2>&1'; then
+	BACKEND=iptables
+else
+	BACKEND=unknown
+fi
+ok "firewall backend probe: ${BACKEND}"
 
 if ssh_guest 'command -v nft >/dev/null 2>&1'; then
 	"${ROOT}/scripts/fwlive-nft-ping-log.sh" add --ssh >/dev/null 2>&1 || true

--- a/tests/fwlive-menu-depends.test.js
+++ b/tests/fwlive-menu-depends.test.js
@@ -15,7 +15,16 @@ const MENU_PATH = path.join(
 	'openwrt-feed/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json'
 );
 
-const menu = JSON.parse(fs.readFileSync(MENU_PATH, 'utf8'));
+let menu;
+let raw;
+try {
+	raw = fs.readFileSync(MENU_PATH, 'utf8');
+	menu = JSON.parse(raw);
+} catch (e) {
+	console.error('failed to read/parse menu.d JSON at %s: %s', MENU_PATH, e.message || e);
+	process.exit(1);
+}
+
 const node = menu['admin/status/fwlive'];
 if (!node) {
 	console.error('missing admin/status/fwlive menu node');
@@ -35,7 +44,6 @@ if (depends.fs) {
 	console.error('menu must not use depends.fs (breaks fw3-only / fw4-only):', depends.fs);
 	process.exit(1);
 }
-const raw = fs.readFileSync(MENU_PATH, 'utf8');
 if (/\/usr\/sbin\/nft|\/usr\/sbin\/iptables/.test(raw)) {
 	console.error('menu.d must not reference nft/iptables paths');
 	process.exit(1);

--- a/tests/fwlive-menu-depends.test.js
+++ b/tests/fwlive-menu-depends.test.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Guard: LuCI menu.d depends on ACL only (#53 / #62 / #70).
+ * fs AND of nft+iptables hid Firewall Live View on stock fw3-only and fw4-only images.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MENU_PATH = path.join(
+	__dirname,
+	'..',
+	'openwrt-feed/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json'
+);
+
+const menu = JSON.parse(fs.readFileSync(MENU_PATH, 'utf8'));
+const node = menu['admin/status/fwlive'];
+if (!node) {
+	console.error('missing admin/status/fwlive menu node');
+	process.exit(1);
+}
+if (node.title !== 'Firewall Live View') {
+	console.error('unexpected menu title:', node.title);
+	process.exit(1);
+}
+const depends = node.depends || {};
+const acl = depends.acl || [];
+if (acl.indexOf('luci-app-fwlive') < 0) {
+	console.error('menu must depend on acl luci-app-fwlive');
+	process.exit(1);
+}
+if (depends.fs) {
+	console.error('menu must not use depends.fs (breaks fw3-only / fw4-only):', depends.fs);
+	process.exit(1);
+}
+const raw = fs.readFileSync(MENU_PATH, 'utf8');
+if (/\/usr\/sbin\/nft|\/usr\/sbin\/iptables/.test(raw)) {
+	console.error('menu.d must not reference nft/iptables paths');
+	process.exit(1);
+}
+
+console.log('fwlive menu depends tests passed');


### PR DESCRIPTION
## Summary
- Closes [#70](https://github.com/lucas-albers-lz4/fwlive/issues/70): verify **Status → Firewall Live View** with ACL-only `menu.d` on fw4-only and fw3 guests.
- Extend `scripts/qemu-smoke-fwlive.sh` to assert menu.d (no fs/nft/iptables depends), LuCI index cache entry, backend probe, and existing direct URL check.
- Host test `tests/fwlive-menu-depends.test.js` wired into `fwlive-test.sh`.

## Lab results (this session)

| Guest | Backend | Menu in Status cache | Direct `/admin/status/fwlive` | Smoke |
|-------|---------|----------------------|-------------------------------|-------|
| 24.10.5 x86 | **nft**, iptables **ABSENT** | satisfied `Firewall Live View` | 403 login / dispatcher OK | passed |
| 21.02.7 x86 | **iptables**, nft **ABSENT** | satisfied `Firewall Live View` | 403 login / dispatcher OK | passed |

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [x] QEMU 24.10.5: `./scripts/qemu-smoke-fwlive.sh`
- [x] QEMU 21.02.7: install + `./scripts/qemu-smoke-fwlive.sh`


Made with [Cursor](https://cursor.com)