### PR TITLE
chore: #90 Step 0 + Phases B/C (rpcd/logging extracts)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -157,6 +157,28 @@ restore_wan_zone_log() {
 	uci commit firewall 2>/dev/null || true
 }
 
+commit_and_reload_wan_log() {
+	zone="$1"
+	previous="$2"
+	fail_msg="$3"
+	success_msg="$4"
+	zone_json="$5"
+
+	if ! uci commit firewall; then
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
+		return 0
+	fi
+	if ! reload_firewall; then
+		restore_wan_zone_log "$zone" "$previous"
+		logger -t fwlive "$fail_msg" 2>/dev/null || true
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
+		return 0
+	fi
+	logger -t fwlive "$success_msg" 2>/dev/null || true
+	printf '{"ok":true,"changed":true,"wan_zone":%s}' "$zone_json"
+	return 0
+}
+
 enable_wan_logging() {
 	zone=$(find_wan_zone_section)
 	if [ -z "$zone" ]; then
@@ -183,20 +205,10 @@ enable_wan_logging() {
 		return 0
 	fi
 
-	if ! uci commit firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
-		return 0
-	fi
-
-	if ! reload_firewall; then
-		restore_wan_zone_log "$zone" "$current"
-		logger -t fwlive 'Firewall reload failed after enable; reverted UCI WAN log' 2>/dev/null || true
-		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
-		return 0
-	fi
-
-	logger -t fwlive 'WAN zone logging enabled' 2>/dev/null || true
-	printf '{"ok":true,"changed":true,"wan_zone":%s}' "$zone_json"
+	commit_and_reload_wan_log "$zone" "$current" \
+		'Firewall reload failed after enable; reverted UCI WAN log' \
+		'WAN zone logging enabled' \
+		"$zone_json"
 }
 
 disable_wan_logging() {
@@ -226,20 +238,10 @@ disable_wan_logging() {
 		fi
 	fi
 
-	if ! uci commit firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
-		return 0
-	fi
-
-	if ! reload_firewall; then
-		restore_wan_zone_log "$zone" "$current"
-		logger -t fwlive 'Firewall reload failed after disable; reverted UCI WAN log' 2>/dev/null || true
-		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
-		return 0
-	fi
-
-	logger -t fwlive 'WAN zone logging disabled' 2>/dev/null || true
-	printf '{"ok":true,"changed":true,"wan_zone":%s}' "$zone_json"
+	commit_and_reload_wan_log "$zone" "$current" \
+		'Firewall reload failed after disable; reverted UCI WAN log' \
+		'WAN zone logging disabled' \
+		"$zone_json"
 }
 
 run_logging_selftest() {

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -87,6 +87,38 @@ normalize_log_prefix() {
 	printf '%s' "$1" | sed 's/[[:space:]]*$//; s/:$//'
 }
 
+read_rpc_input() {
+	if [ -n "$1" ]; then
+		printf '%s' "$1"
+	else
+		cat
+	fi
+}
+
+map_prefix_with_label() {
+	prefix="$1"
+	label="$2"
+	[ -n "$prefix" ] || return 0
+	if [ -n "$label" ]; then
+		map_add "$prefix" "$label"
+		map_add "$(slug_key "$prefix")" "$label"
+	else
+		cosmetic=$(echo "$prefix" | tr '-' ' ')
+		map_add "$prefix" "$cosmetic"
+		map_add "$(slug_key "$prefix")" "$cosmetic"
+	fi
+}
+
+run_with_timeout() {
+	secs="$1"
+	shift
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@" 2>/dev/null
+	else
+		"$@" 2>/dev/null
+	fi
+}
+
 map_log_prefix_entry() {
 	prefix="$1"
 	comment="$2"
@@ -99,14 +131,7 @@ map_log_prefix_entry() {
 	prefix=$(normalize_log_prefix "$prefix")
 	[ -n "$prefix" ] || return 0
 
-	if [ -n "$label" ]; then
-		map_add "$prefix" "$label"
-		map_add "$(slug_key "$prefix")" "$label"
-	else
-		cosmetic=$(echo "$prefix" | tr '-' ' ')
-		map_add "$prefix" "$cosmetic"
-		map_add "$(slug_key "$prefix")" "$cosmetic"
-	fi
+	map_prefix_with_label "$prefix" "$label"
 }
 
 map_uci_rule_names() {
@@ -132,17 +157,9 @@ map_from_nft_stream() {
 		esac
 
 		if [ -n "$prefix" ]; then
-			if [ -n "$label" ]; then
-				map_add "$prefix" "$label"
-				map_add "$(slug_key "$prefix")" "$label"
-			else
-				cosmetic=$(echo "$prefix" | tr '-' ' ')
-				map_add "$prefix" "$cosmetic"
-				map_add "$(slug_key "$prefix")" "$cosmetic"
-			fi
+			map_prefix_with_label "$prefix" "$label"
 		elif [ -n "$label" ]; then
-			map_add "$label" "$label"
-			map_add "$(slug_key "$label")" "$label"
+			map_prefix_with_label "$label" "$label"
 		fi
 	done
 }
@@ -161,11 +178,7 @@ map_from_iptables_save_stream() {
 }
 
 nft_list_ruleset() {
-	if command -v timeout >/dev/null 2>&1; then
-		timeout "$NFT_TIMEOUT" nft list ruleset 2>/dev/null
-	else
-		nft list ruleset 2>/dev/null
-	fi
+	run_with_timeout "$NFT_TIMEOUT" nft list ruleset
 }
 
 detect_firewall_backend() {
@@ -253,11 +266,7 @@ fetch_firewall_logs() {
 }
 
 poll_logs() {
-	if [ -n "$3" ]; then
-		input="$3"
-	else
-		input="$(cat)"
-	fi
+	input=$(read_rpc_input "$3")
 	fetch_firewall_logs "$input"
 }
 
@@ -265,12 +274,7 @@ resolve_hostname() {
 	ip="$1"
 	[ -n "$ip" ] || return 1
 	is_resolvable_address "$ip" || return 1
-	line=""
-	if command -v timeout >/dev/null 2>&1; then
-		line=$(timeout "$RESOLVE_TIMEOUT" getent hosts "$ip" 2>/dev/null | head -1)
-	else
-		line=$(getent hosts "$ip" 2>/dev/null | head -1)
-	fi
+	line=$(run_with_timeout "$RESOLVE_TIMEOUT" getent hosts "$ip" | head -1)
 	[ -n "$line" ] || return 1
 	set -- $line
 	[ "$#" -ge 2 ] || return 1
@@ -290,11 +294,7 @@ is_resolvable_address() {
 }
 
 resolve_addresses() {
-	if [ -n "$3" ]; then
-		input="$3"
-	else
-		input="$(cat)"
-	fi
+	input=$(read_rpc_input "$3")
 	count=0
 	OUT=''
 

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -17,6 +17,9 @@ if [[ -z "$NODE" ]]; then
 	fi
 fi
 
+echo "== fwlive view syntax (node --check) ==" >&2
+"$NODE" --check openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+
 echo "== fwlive parser sync (core vs LuCI) ==" >&2
 "$NODE" tests/fwlive-parser-sync.test.js
 


### PR DESCRIPTION
## Summary
- Add `node --check` on the LuCI view to `fwlive-test.sh` (#90 Step 0; quote already fixed on master)
- Extract `read_rpc_input`, `map_prefix_with_label`, `run_with_timeout` in rpcd `fwlive` (Phase B)
- Extract `commit_and_reload_wan_log` in `fwlive-logging.sh` (Phase C)
- Phase A skipped (superseded by #84); Phase D follows in a sibling PR

Partial progress on #90 (B+C + test gate). Phase D PR will close the issue.

## Test plan
- [x] `./scripts/fwlive-test.sh` green
- [x] `sh -n` on rpcd/fwlive and fwlive-logging.sh

Made with [Cursor](https://cursor.com)