### PR TITLE
ci: shellcheck on rpcd/libexec scripts (#86)

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -16,4 +16,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
       - run: ./scripts/fwlive-test.sh

--- a/docs/developer/build-and-test.md
+++ b/docs/developer/build-and-test.md
@@ -21,7 +21,8 @@ Native SDK (no Docker): [`../minimal-build-sdk.md`](../minimal-build-sdk.md)
 ./scripts/validate-baseline.sh
 ```
 
-Covers parser sync (`core/` vs LuCI `log.js`), schema, filters, CLI pipeline.
+Covers parser sync (`core/` vs LuCI `log.js`), schema, filters, CLI pipeline, and
+shellcheck on shipped `root/usr/libexec` scripts (`./scripts/fwlive-shellcheck.sh`).
 
 ## QEMU smoke (guest running)
 

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh
@@ -10,6 +10,7 @@
 # jsonfilter spawns per index (~3n+1 → ~n+1 process execs per poll).
 
 FILTER_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091 # classifier is a sibling file next to this script
 . "$FILTER_DIR/fwlive-is-firewall-event.sh"
 
 input="$(cat)"

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -52,10 +52,11 @@ json_escape() {
 	}'
 }
 
+# shellcheck disable=SC1090,SC1091 # LOGGING_SH resolves to sibling ../fwlive-logging.sh
 . "$LOGGING_SH"
 
 slug_key() {
-	echo "$1" | tr 'A-Z' 'a-z' | tr ' _' '--'
+	echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' _' '--'
 }
 
 map_add() {
@@ -149,7 +150,7 @@ map_from_nft_stream() {
 
 		case "$comment" in
 			"${FW4_TAG}"*)
-				suffix="${comment#${FW4_TAG}}"
+				suffix="${comment#"${FW4_TAG}"}"
 				if is_uci_style_name "$suffix"; then
 					label="$suffix"
 				fi
@@ -232,6 +233,8 @@ poll_lines_from_input() {
 		return 0
 	fi
 
+	# Device-only helper; not present on host CI runners.
+	# shellcheck disable=SC1091
 	. /usr/share/libubox/jshn.sh
 	json_load "$input" 2>/dev/null || {
 		printf '%s' "$lines"
@@ -239,8 +242,10 @@ poll_lines_from_input() {
 	}
 
 	if json_select addresses 2>/dev/null; then
+		# json_get_var assigns into the named shell variable (jshn).
 		json_get_var first 1
 		json_select ..
+		# shellcheck disable=SC2154 # set by json_get_var above
 		case "$first" in
 			''|*[!0-9]*) ;;
 			*) lines="$first" ;;
@@ -266,7 +271,8 @@ fetch_firewall_logs() {
 }
 
 poll_logs() {
-	input=$(read_rpc_input "$3")
+	# Optional JSON on $1 (rpcd may also pass argv $3 at the call site); else stdin.
+	input=$(read_rpc_input "$1")
 	fetch_firewall_logs "$input"
 }
 
@@ -276,6 +282,8 @@ resolve_hostname() {
 	is_resolvable_address "$ip" || return 1
 	line=$(run_with_timeout "$RESOLVE_TIMEOUT" getent hosts "$ip" | head -1)
 	[ -n "$line" ] || return 1
+	# Intentional field split of getent hosts output (IP then name).
+	# shellcheck disable=SC2086
 	set -- $line
 	[ "$#" -ge 2 ] || return 1
 	printf '%s' "$2"
@@ -294,7 +302,8 @@ is_resolvable_address() {
 }
 
 resolve_addresses() {
-	input=$(read_rpc_input "$3")
+	# Optional JSON on $1 (rpcd may also pass argv $3 at the call site); else stdin.
+	input=$(read_rpc_input "$1")
 	count=0
 	OUT=''
 
@@ -303,6 +312,7 @@ resolve_addresses() {
 		return 0
 	fi
 
+	# shellcheck disable=SC1091
 	. /usr/share/libubox/jshn.sh
 	json_load "$input" 2>/dev/null || {
 		printf '{"names":{}}'
@@ -311,6 +321,8 @@ resolve_addresses() {
 
 	if json_select addresses 2>/dev/null; then
 		idx=1
+		# json_get_type / json_get_var assign into named shell variables (jshn).
+		# shellcheck disable=SC2154
 		while json_get_type atype "$idx" && [ "$atype" = string ]; do
 			[ "$count" -ge "$RESOLVE_MAX" ] && break
 			json_get_var ip "$idx"
@@ -353,6 +365,8 @@ run_selftest() {
 		echo 'is_resolvable_address: expected reject for spaces' >&2
 		return 1
 	fi
+	# Literal metachar token (must not expand) — reject before getent.
+	# shellcheck disable=SC2016
 	if is_resolvable_address '$(reboot)'; then
 		echo 'is_resolvable_address: expected reject for metachar' >&2
 		return 1
@@ -411,10 +425,10 @@ case "$1" in
 				build_rules_map
 				;;
 			poll)
-				poll_logs
+				poll_logs "$3"
 				;;
 			resolve)
-				resolve_addresses
+				resolve_addresses "$3"
 				;;
 			logging_status)
 				build_logging_status_json

--- a/scripts/fwlive-shellcheck.sh
+++ b/scripts/fwlive-shellcheck.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run shellcheck on shipped rpcd/libexec shell scripts (#86).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIBEXEC="$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec"
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+	echo "Install shellcheck (e.g. apt install shellcheck) to run this gate." >&2
+	exit 1
+fi
+
+# Do not use -x: sourced paths are runtime-resolved ($FILTER_DIR / $LOGGING_SH).
+shellcheck -s sh \
+	"$LIBEXEC/fwlive-log-filter.sh" \
+	"$LIBEXEC/fwlive-logging.sh" \
+	"$LIBEXEC/fwlive-is-firewall-event.sh" \
+	"$LIBEXEC/rpcd/fwlive"
+
+echo "fwlive shellcheck OK" >&2

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -20,6 +20,9 @@ fi
 echo "== fwlive view syntax (node --check) ==" >&2
 "$NODE" --check openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
 
+echo "== fwlive shellcheck (libexec/rpcd) ==" >&2
+bash "$ROOT/scripts/fwlive-shellcheck.sh"
+
 echo "== fwlive parser sync (core vs LuCI) ==" >&2
 "$NODE" tests/fwlive-parser-sync.test.js
 


### PR DESCRIPTION
## Summary
- Add `scripts/fwlive-shellcheck.sh` and run it from `fwlive-test.sh` + GHA (install shellcheck)
- Clean remaining actionable shellcheck findings; document source/jshn disables
- Fix `poll_logs` / `resolve_addresses` to take optional JSON as `$1` (call site passes `"$3"`)

Closes #86

## Test plan
- [x] `./scripts/fwlive-shellcheck.sh` green
- [x] `./scripts/fwlive-test.sh` green

Made with [Cursor](https://cursor.com)