### PR TITLE
feat: CLASSIFY_SPEC + shell classifier codegen (#84 A+B)

### DIFF
--- a/core/fwlive-log.js
+++ b/core/fwlive-log.js
@@ -6,8 +6,50 @@
  * PARSER_SYNC_VERSION: 4
  */
 
-const NON_FIREWALL_PREFIX = /^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)\b/i;
-const FIREWALL_HINT = /\b(fw4|nft|iptables|kernel|firewall)\b/i;
+const CLASSIFY_SPEC = {
+	/* Normalization: KV keys whose glued prefix needs a space (fwlive-pingIN=lo → fwlive-ping IN=lo) */
+	glueKeys: ['IN', 'OUT', 'SRC', 'DST', 'PROTO', 'SPT', 'DPT', 'LEN', 'MAC', 'TYPE', 'CODE', 'TTL', 'TOS', 'PREC', 'DF'],
+
+	/* NON_FIREWALL_PREFIX daemon names (matched at message start) */
+	nonFirewallPrefixes: ['dnsmasq', 'procd', 'ubusd', 'netifd', 'odhcpd', 'logd', 'dropbear', 'uhttpd', 'hostapd', 'wpad'],
+
+	/* FIREWALL_HINT words */
+	firewallHints: ['fw4', 'nft', 'iptables', 'kernel', 'firewall'],
+
+	/* detectAction words (order matters: ACCEPT first) */
+	actionWords: ['ACCEPT', 'ALLOW', 'PASS', 'DROP', 'REJECT', 'DENY', 'BLOCK'],
+
+	/* Decision tree — order matters, first match wins */
+	rules: [
+		{ or: [
+			{ and: [ { kv: ['SRC'] }, { kv: ['DST'] } ] },
+			{ and: [ { kvAny: ['IN', 'OUT'] }, { kvAny: ['SRC', 'DST', 'PROTO', 'SPT', 'DPT'] } ] },
+			{ and: [ { action: 'known' }, { kvAny: ['IN', 'OUT', 'PROTO', 'SRC', 'DST'] } ] }
+		]},
+		{ and: [ { hint: true }, { action: 'known' } ] },
+		{ and: [ { hint: true }, { kvAny: ['IN', 'OUT', 'SRC', 'DST', 'PROTO'] } ] }
+	]
+};
+
+function wordPattern(words) {
+	const alt = words.join('|');
+	return new RegExp('(^|[^A-Za-z0-9_])(' + alt + ')([^A-Za-z0-9_]|$)', 'i');
+}
+
+/** Presence of `K=` in the normalized message — matches shell `_has_kv`, empty values included. */
+function kvHas(msg, key) {
+	return new RegExp('(^|[^A-Za-z0-9_])' + key + '=').test(msg);
+}
+
+/* ---- spec-derived classification regexes (explicit boundaries, no \\b) ---- */
+const NON_FIREWALL_PREFIX = new RegExp(
+	'^(' + CLASSIFY_SPEC.nonFirewallPrefixes.join('|') + ')([^A-Za-z0-9_]|$)',
+	'i'
+);
+const FIREWALL_HINT = wordPattern(CLASSIFY_SPEC.firewallHints);
+const ACTION_RE = wordPattern(CLASSIFY_SPEC.actionWords);
+const DENY_ACTION = wordPattern(CLASSIFY_SPEC.actionWords.slice(3)); /* DROP|REJECT|DENY|BLOCK */
+
 const TCP_FLAG_TAIL = /\b(SYN|ACK|FIN|RST|PSH|URG)(?:\s+(?:SYN|ACK|FIN|RST|PSH|URG))*\s*$/i;
 const NETFILTER_KV_GLUE = /([^\s])(?=(IN|OUT|SRC|DST|PROTO|SPT|DPT|LEN|MAC|TYPE|CODE|TTL|TOS|PREC|DF)=)/g;
 
@@ -18,6 +60,7 @@ function normalizeNetfilterMessage(message) {
 
 function parseKeyValueLog(message) {
 	const out = {};
+	/* Non-empty values only — dual KV semantics vs presence-based classify (kvHas). */
 	const re = /\b([A-Z]+)=([^\s]+)/g;
 	const normalized = normalizeNetfilterMessage(message);
 	let match;
@@ -28,9 +71,66 @@ function parseKeyValueLog(message) {
 	return out;
 }
 
+/** Spec-derived action detection; m[2] is the word (group 1/3 are the boundaries). */
 function detectAction(message) {
-	const m = message.match(/\b(ACCEPT|ALLOW|PASS|DROP|REJECT|DENY|BLOCK)\b/i);
-	return m ? m[1].toUpperCase() : 'UNKNOWN';
+	const m = message.match(ACTION_RE);
+	return m ? m[2].toUpperCase() : 'UNKNOWN';
+}
+
+function evaluateClassifySpec(message, actionRaw) {
+	const msg = normalizeNetfilterMessage(message || '');
+	const action = actionRaw === undefined ? detectAction(msg) : actionRaw;
+	const has = function(key) { return kvHas(msg, key); };
+	const hasAny = function(keys) {
+		for (let i = 0; i < keys.length; i++) {
+			if (has(keys[i]))
+				return true;
+		}
+		return false;
+	};
+
+	const pred = {
+		kv: function(c) {
+			for (let i = 0; i < c.kv.length; i++) {
+				if (!has(c.kv[i]))
+					return false;
+			}
+			return true;
+		},
+		kvAny: function(c) { return hasAny(c.kvAny); },
+		action: function(c) { return (c.action === 'known') ? action !== 'UNKNOWN' : true; },
+		hint: function() { return FIREWALL_HINT.test(msg); }
+	};
+
+	const evalNode = function(node) {
+		if (node.and) {
+			for (let i = 0; i < node.and.length; i++) {
+				if (!evalNode(node.and[i]))
+					return false;
+			}
+			return true;
+		}
+		if (node.or) {
+			for (let i = 0; i < node.or.length; i++) {
+				if (evalNode(node.or[i]))
+					return true;
+			}
+			return false;
+		}
+		const keys = Object.keys(node);
+		for (let i = 0; i < keys.length; i++) {
+			const k = keys[i];
+			if (pred[k])
+				return pred[k](node);
+		}
+		return false;
+	};
+
+	for (let i = 0; i < CLASSIFY_SPEC.rules.length; i++) {
+		if (evalNode(CLASSIFY_SPEC.rules[i]))
+			return true;
+	}
+	return false;
 }
 
 function normalizeAction(raw) {
@@ -45,8 +145,6 @@ function normalizeAction(raw) {
 		return 'block';
 	return 'unknown';
 }
-
-const DENY_ACTION = /\b(DROP|REJECT|DENY|BLOCK)\b/i;
 
 /** Extract nft/fw4 log prefix or tag (e.g. fwlive-ping, fwlive-test, fw4). */
 function parseRuleHint(message) {
@@ -154,22 +252,11 @@ function isFirewallEvent(entry) {
 	if (!msg.trim())
 		return false;
 
+	/* Spec-derived prefix guard: explicit boundary + /i (matches shell case-insensitive). */
 	if (NON_FIREWALL_PREFIX.test(msg))
 		return false;
 
-	const kv = parseKeyValueLog(msg);
-	const hasSrcDst = !!(kv.SRC && kv.DST);
-	const hasNetfilterTuple = !!(kv.IN || kv.OUT) && !!(kv.SRC || kv.DST || kv.PROTO || kv.SPT || kv.DPT);
-	const action = detectAction(msg);
-	const hasActionAndContext = action !== 'UNKNOWN' && !!(kv.IN || kv.OUT || kv.PROTO || kv.SRC || kv.DST);
-
-	if (hasSrcDst || hasNetfilterTuple || hasActionAndContext)
-		return true;
-
-	if (FIREWALL_HINT.test(msg) && action !== 'UNKNOWN')
-		return true;
-
-	return FIREWALL_HINT.test(msg) && !!(kv.IN || kv.OUT || kv.SRC || kv.DST || kv.PROTO);
+	return evaluateClassifySpec(msg);
 }
 
 function makeEntryId(entry, tsUnix, action, src, dst, sport, dport, proto, ifaceIn, ifaceOut) {
@@ -433,6 +520,9 @@ module.exports = {
 	timestampUnix,
 	formatTimestampDisplay,
 	isFirewallEvent,
+	evaluateClassifySpec,
+	wordPattern,
+	kvHas,
 	normalizeEntry,
 	parseFilterValue,
 	toggleFilterNegation,
@@ -442,8 +532,10 @@ module.exports = {
 	filterLogEntries,
 	statsLogEntries,
 	readInputPayload,
+	CLASSIFY_SPEC,
 	NON_FIREWALL_PREFIX,
-	FIREWALL_HINT
+	FIREWALL_HINT,
+	DENY_ACTION
 };
 
 if (require.main === module)

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com>
 #
+# GENERATED FILE — do not edit. Run: ./scripts/gen-all.sh
+# source: core/fwlive-log.js CLASSIFY_SPEC
 # Shared isFirewallEvent parity logic (shell). Sourced by fwlive-log-filter.sh and tests.
-# Keep aligned with core/fwlive-log.js — see tests/fwlive-shell-filter.test.js
 
 normalize_nf_msg() {
 	printf '%s' "$1" | sed \
@@ -44,57 +45,29 @@ is_firewall_event_msg() {
 	msg=$(printf '%s' "$msg" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 	[ -n "$msg" ] || return 1
 
-	case "$msg" in
-		dnsmasq*|Dnsmasq*) return 1 ;;
-		procd*|Procd*) return 1 ;;
-		ubusd*|Ubusd*) return 1 ;;
-		netifd*|Netifd*) return 1 ;;
-		odhcpd*|Odhcpd*) return 1 ;;
-		logd*|Logd*) return 1 ;;
-		dropbear*|Dropbear*) return 1 ;;
-		uhttpd*|Uhttpd*) return 1 ;;
-		hostapd*|Hostapd*) return 1 ;;
-		wpad*|Wpad*) return 1 ;;
+	msg_lc=$(printf '%s' "$msg" | tr '[:upper:]' '[:lower:]')
+	case "$msg_lc" in
+		dnsmasq*|procd*|ubusd*|netifd*|odhcpd*|logd*|dropbear*|uhttpd*|hostapd*|wpad*) return 1 ;;
 	esac
+
+	action=$(_detect_action "$msg")
 
 	if _has_kv "$msg" SRC && _has_kv "$msg" DST; then
 		return 0
 	fi
-
-	has_io=0
-	_has_kv "$msg" IN && has_io=1
-	_has_kv "$msg" OUT && has_io=1
-
-	has_tuple=0
-	_has_kv "$msg" SRC && has_tuple=1
-	_has_kv "$msg" DST && has_tuple=1
-	_has_kv "$msg" PROTO && has_tuple=1
-	_has_kv "$msg" SPT && has_tuple=1
-	_has_kv "$msg" DPT && has_tuple=1
-
-	if [ "$has_io" -eq 1 ] && [ "$has_tuple" -eq 1 ]; then
+	if { _has_kv "$msg" IN || _has_kv "$msg" OUT; } && { _has_kv "$msg" SRC || _has_kv "$msg" DST || _has_kv "$msg" PROTO || _has_kv "$msg" SPT || _has_kv "$msg" DPT; }; then
 		return 0
 	fi
-
-	action=$(_detect_action "$msg")
-	if [ "$action" != "UNKNOWN" ]; then
-		_has_kv "$msg" IN && return 0
-		_has_kv "$msg" OUT && return 0
-		_has_kv "$msg" PROTO && return 0
-		_has_kv "$msg" SRC && return 0
-		_has_kv "$msg" DST && return 0
+	if [ "$action" != "UNKNOWN" ] && { _has_kv "$msg" IN || _has_kv "$msg" OUT || _has_kv "$msg" PROTO || _has_kv "$msg" SRC || _has_kv "$msg" DST; }; then
+		return 0
 	fi
 
 	if _has_firewall_hint "$msg" && [ "$action" != "UNKNOWN" ]; then
 		return 0
 	fi
 
-	if _has_firewall_hint "$msg"; then
-		_has_kv "$msg" IN && return 0
-		_has_kv "$msg" OUT && return 0
-		_has_kv "$msg" SRC && return 0
-		_has_kv "$msg" DST && return 0
-		_has_kv "$msg" PROTO && return 0
+	if _has_firewall_hint "$msg" && { _has_kv "$msg" IN || _has_kv "$msg" OUT || _has_kv "$msg" SRC || _has_kv "$msg" DST || _has_kv "$msg" PROTO; }; then
+		return 0
 	fi
 
 	return 1

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -35,6 +35,12 @@ echo "== fwlive firewall filter (fixtures) ==" >&2
 echo "== fwlive shell filter parity ==" >&2
 "$NODE" tests/fwlive-shell-filter.test.js
 
+echo "== fwlive classify spec ==" >&2
+"$NODE" tests/fwlive-classify-spec.test.js
+
+echo "== fwlive codegen freshness ==" >&2
+"$NODE" tests/fwlive-codegen.test.js
+
 echo "== fwlive rpcd security ==" >&2
 "$NODE" tests/fwlive-rpcd-security.test.js
 

--- a/scripts/gen-shell-classifier.js
+++ b/scripts/gen-shell-classifier.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Emit POSIX fwlive-is-firewall-event.sh from core CLASSIFY_SPEC.
+ * Usage: node scripts/gen-shell-classifier.js > path/to/fwlive-is-firewall-event.sh
+ */
+
+const path = require('node:path');
+const core = require(path.join(__dirname, '..', 'core', 'fwlive-log.js'));
+const SPEC = core.CLASSIFY_SPEC;
+
+function emitNormalize() {
+	const lines = SPEC.glueKeys.map(function(k) {
+		return "\t\t-e 's/\\([^[:space:]]\\)\\(" + k + "=\\)/\\1 \\2/g' \\";
+	});
+	lines[lines.length - 1] = lines[lines.length - 1].replace(/ \\$/, '');
+	return [
+		'normalize_nf_msg() {',
+		"\tprintf '%s' \"$1\" | sed \\",
+		...lines,
+		'}'
+	].join('\n');
+}
+
+function emitDetectAction() {
+	const alt = SPEC.actionWords.join('|');
+	return [
+		'_detect_action() {',
+		'\tmsg="$1"',
+		"\taction=$(printf '%s' \"$msg\" | grep -ioE '(^|[^A-Za-z0-9_])(" + alt + ")([^A-Za-z0-9_]|$)' \\",
+		"\t\t| head -1 | sed 's/^[^A-Za-z]*//;s/[^A-Za-z]*$//')",
+		'\t[ -n "$action" ] || action=UNKNOWN',
+		"\tprintf '%s' \"$action\"",
+		'}'
+	].join('\n');
+}
+
+function emitHasKv() {
+	return [
+		'_has_kv() {',
+		"\tprintf '%s' \"$1\" | grep -qE \"(^|[^A-Za-z0-9_])$2=\"",
+		'}'
+	].join('\n');
+}
+
+function emitHint() {
+	const alt = SPEC.firewallHints.join('|');
+	return [
+		'_has_firewall_hint() {',
+		"\tprintf '%s' \"$1\" | grep -qiE '(^|[^A-Za-z0-9_])(" + alt + ")([^A-Za-z0-9_]|$)'",
+		'}'
+	].join('\n');
+}
+
+function emitPrefixCase() {
+	const pats = SPEC.nonFirewallPrefixes.map(function(p) {
+		return p + '*';
+	}).join('|');
+	return [
+		"\tmsg_lc=$(printf '%s' \"$msg\" | tr '[:upper:]' '[:lower:]')",
+		'\tcase "$msg_lc" in',
+		'\t\t' + pats + ') return 1 ;;',
+		'\tesac'
+	].join('\n');
+}
+
+function emitAndRule(node, indent) {
+	const pad = indent || '\t';
+	const parts = node.and.map(function(n) {
+		if (n.kv)
+			return n.kv.map(function(k) { return '_has_kv "$msg" ' + k; }).join(' && ');
+		if (n.kvAny)
+			return '{ ' + n.kvAny.map(function(k) { return '_has_kv "$msg" ' + k; }).join(' || ') + '; }';
+		if (n.action === 'known')
+			return '[ "$action" != "UNKNOWN" ]';
+		if (n.hint)
+			return '_has_firewall_hint "$msg"';
+		return 'false';
+	});
+	return pad + 'if ' + parts.join(' && ') + '; then\n' + pad + '\treturn 0\n' + pad + 'fi';
+}
+
+function emitDecisionTree() {
+	const chunks = [];
+	chunks.push('\taction=$(_detect_action "$msg")');
+	chunks.push('');
+	for (let i = 0; i < SPEC.rules.length; i++) {
+		const rule = SPEC.rules[i];
+		if (rule.or) {
+			for (let j = 0; j < rule.or.length; j++)
+				chunks.push(emitAndRule(rule.or[j], '\t'));
+		} else if (rule.and) {
+			chunks.push(emitAndRule(rule, '\t'));
+		}
+		chunks.push('');
+	}
+	chunks.push('\treturn 1');
+	return chunks.join('\n');
+}
+
+function emitIsFirewall() {
+	return [
+		'is_firewall_event_msg() {',
+		'\tmsg=$(normalize_nf_msg "$1")',
+		"\tmsg=$(printf '%s' \"$msg\" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')",
+		'\t[ -n "$msg" ] || return 1',
+		'',
+		emitPrefixCase(),
+		'',
+		emitDecisionTree(),
+		'}'
+	].join('\n');
+}
+
+const out = [
+	'# SPDX-License-Identifier: Apache-2.0',
+	'# Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com>',
+	'#',
+	'# GENERATED FILE — do not edit. Run: ./scripts/gen-all.sh',
+	'# source: core/fwlive-log.js CLASSIFY_SPEC',
+	'# Shared isFirewallEvent parity logic (shell). Sourced by fwlive-log-filter.sh and tests.',
+	'',
+	emitNormalize(),
+	'',
+	emitDetectAction(),
+	'',
+	emitHasKv(),
+	'',
+	emitHint(),
+	'',
+	emitIsFirewall(),
+	''
+].join('\n');
+
+process.stdout.write(out);

--- a/tests/fwlive-classify-spec.test.js
+++ b/tests/fwlive-classify-spec.test.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const core = require('../core/fwlive-log.js');
+
+const FIXTURES = [
+	path.join(__dirname, 'fixtures', 'logread-mixed.json'),
+	path.join(__dirname, 'fixtures', 'logread-iptables.json'),
+];
+/* Golden expectations: {msg, expect} — extend from the shell-parity `extra` list.
+   Mixed-case daemon lines pin the /i prefix semantics (MCR A/C); empty-value KV lines
+   pin the presence-based `kv` semantics, documenting the intentional flip: today
+   JS=false, shell=true for "x DST= DROP" — after A3 both agree (MCR C3). */
+const GOLDEN = [
+	{ msg: '', expect: false },
+	{ msg: '   ', expect: false },
+	{ msg: 'dnsmasq[123]: query[A] google.com from 192.168.1.1', expect: false },
+	{ msg: 'Dnsmasq[123]: query[A] example.com from 192.168.1.1', expect: false },
+	{ msg: 'PROCD[1]: service did something', expect: false },
+	{ msg: 'dropbear[1]: Bad packet length 12345', expect: false },
+	{ msg: '[  239.247521] fwlive-pingIN=lo OUT= SRC=127.0.0.1 DST=127.0.0.1 PROTO=ICMP', expect: true },
+	{ msg: 'IN=wan OUT= SRC=2001:db8::1 DST=2001:db8::2 PROTO=TCP SPT=1234 DPT=443', expect: true },
+	{ msg: 'not-a-firewall-line at all', expect: false },
+	/* Presence semantics (empty values): unified outcome = shell's current TRUE. */
+	{ msg: 'x DST= DROP', expect: true },
+	{ msg: 'IN=wan OUT= SRC= DST=2001:db8::2 PROTO=TCP', expect: true },
+];
+
+function run() {
+	/* Dual KV semantics: classify uses presence (empty OK); parseKeyValueLog needs non-empty. */
+	const emptyKv = 'x DST= DROP';
+	assert.equal(Object.prototype.hasOwnProperty.call(core.parseKeyValueLog(emptyKv), 'DST'), false,
+		'parseKeyValueLog must omit empty DST=');
+	assert.equal(core.kvHas(emptyKv, 'DST'), true,
+		'kvHas must treat empty DST= as present');
+
+	const partialEmpty = 'IN=wan OUT= SRC= DST=2001:db8::2 PROTO=TCP';
+	const parsed = core.parseKeyValueLog(partialEmpty);
+	assert.equal(parsed.IN, 'wan');
+	assert.equal(Object.prototype.hasOwnProperty.call(parsed, 'SRC'), false,
+		'parseKeyValueLog must omit empty SRC=');
+	assert.equal(core.kvHas(partialEmpty, 'SRC'), true);
+
+	/* Equivalence loop vs the CURRENT isFirewallEvent. Holds only because no fixture
+	   line is daemon-prefixed AND carries firewall KV (the prefix guard lives in
+	   isFirewallEvent, not in evaluateClassifySpec) — keep it that way. */
+	for (const f of FIXTURES) {
+		for (const e of JSON.parse(fs.readFileSync(f, 'utf8')).log) {
+			const expect = core.isFirewallEvent(e);
+			const got = core.evaluateClassifySpec(e.msg || '');
+			assert.strictEqual(got, expect, 'corpus: ' + e.msg);
+		}
+	}
+	/* The evaluator under test (golden expectations). actionRaw is intentionally
+	   undefined so the evaluator computes it on the NORMALIZED message, matching the
+	   production call site (raw detectAction misses glued prefixes like "fw4 DROPIN=…"). */
+	for (const g of GOLDEN) {
+		const got = core.evaluateClassifySpec(g.msg);
+		assert.strictEqual(got, g.expect, JSON.stringify(g.msg));
+	}
+	console.log('fwlive classify spec golden corpus passed');
+}
+
+run();

--- a/tests/fwlive-classify-spec.test.js
+++ b/tests/fwlive-classify-spec.test.js
@@ -8,12 +8,10 @@ const core = require('../core/fwlive-log.js');
 
 const FIXTURES = [
 	path.join(__dirname, 'fixtures', 'logread-mixed.json'),
-	path.join(__dirname, 'fixtures', 'logread-iptables.json'),
+	path.join(__dirname, 'fixtures', 'logread-iptables.json')
 ];
-/* Golden expectations: {msg, expect} — extend from the shell-parity `extra` list.
-   Mixed-case daemon lines pin the /i prefix semantics (MCR A/C); empty-value KV lines
-   pin the presence-based `kv` semantics, documenting the intentional flip: today
-   JS=false, shell=true for "x DST= DROP" — after A3 both agree (MCR C3). */
+
+/* Golden expectations: presence-based kv (empty values count); mixed-case daemons. */
 const GOLDEN = [
 	{ msg: '', expect: false },
 	{ msg: '   ', expect: false },
@@ -24,29 +22,13 @@ const GOLDEN = [
 	{ msg: '[  239.247521] fwlive-pingIN=lo OUT= SRC=127.0.0.1 DST=127.0.0.1 PROTO=ICMP', expect: true },
 	{ msg: 'IN=wan OUT= SRC=2001:db8::1 DST=2001:db8::2 PROTO=TCP SPT=1234 DPT=443', expect: true },
 	{ msg: 'not-a-firewall-line at all', expect: false },
-	/* Presence semantics (empty values): unified outcome = shell's current TRUE. */
+	/* Presence semantics (empty values): unified outcome = shell's TRUE. */
 	{ msg: 'x DST= DROP', expect: true },
 	{ msg: 'IN=wan OUT= SRC= DST=2001:db8::2 PROTO=TCP', expect: true },
+	{ msg: 'IN= OUT= SRC= DST= PROTO=', expect: true }
 ];
 
 function run() {
-	/* Dual KV semantics: classify uses presence (empty OK); parseKeyValueLog needs non-empty. */
-	const emptyKv = 'x DST= DROP';
-	assert.equal(Object.prototype.hasOwnProperty.call(core.parseKeyValueLog(emptyKv), 'DST'), false,
-		'parseKeyValueLog must omit empty DST=');
-	assert.equal(core.kvHas(emptyKv, 'DST'), true,
-		'kvHas must treat empty DST= as present');
-
-	const partialEmpty = 'IN=wan OUT= SRC= DST=2001:db8::2 PROTO=TCP';
-	const parsed = core.parseKeyValueLog(partialEmpty);
-	assert.equal(parsed.IN, 'wan');
-	assert.equal(Object.prototype.hasOwnProperty.call(parsed, 'SRC'), false,
-		'parseKeyValueLog must omit empty SRC=');
-	assert.equal(core.kvHas(partialEmpty, 'SRC'), true);
-
-	/* Equivalence loop vs the CURRENT isFirewallEvent. Holds only because no fixture
-	   line is daemon-prefixed AND carries firewall KV (the prefix guard lives in
-	   isFirewallEvent, not in evaluateClassifySpec) — keep it that way. */
 	for (const f of FIXTURES) {
 		for (const e of JSON.parse(fs.readFileSync(f, 'utf8')).log) {
 			const expect = core.isFirewallEvent(e);
@@ -54,13 +36,14 @@ function run() {
 			assert.strictEqual(got, expect, 'corpus: ' + e.msg);
 		}
 	}
-	/* The evaluator under test (golden expectations). actionRaw is intentionally
-	   undefined so the evaluator computes it on the NORMALIZED message, matching the
-	   production call site (raw detectAction misses glued prefixes like "fw4 DROPIN=…"). */
+
 	for (const g of GOLDEN) {
 		const got = core.evaluateClassifySpec(g.msg);
 		assert.strictEqual(got, g.expect, JSON.stringify(g.msg));
+		assert.strictEqual(core.isFirewallEvent({ msg: g.msg }), g.expect,
+			'isFirewallEvent: ' + JSON.stringify(g.msg));
 	}
+
 	console.log('fwlive classify spec golden corpus passed');
 }
 

--- a/tests/fwlive-codegen.test.js
+++ b/tests/fwlive-codegen.test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const SHELL_DST = path.join(ROOT,
+	'openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh');
+const GEN = path.join(ROOT, 'scripts/gen-shell-classifier.js');
+
+const out = spawnSync(process.execPath, [GEN], { encoding: 'utf8' });
+assert.equal(out.status, 0, out.stderr || out.stdout);
+assert.strictEqual(out.stdout, fs.readFileSync(SHELL_DST, 'utf8'),
+	'fwlive-is-firewall-event.sh is stale — run node scripts/gen-shell-classifier.js and commit');
+
+const syn = spawnSync('sh', ['-n', SHELL_DST], { encoding: 'utf8' });
+assert.equal(syn.status, 0, 'generated shell fails sh -n: ' + syn.stderr);
+
+console.log('fwlive codegen freshness + syntax OK');

--- a/tests/fwlive-shell-filter.test.js
+++ b/tests/fwlive-shell-filter.test.js
@@ -37,7 +37,11 @@ function runMsgParity() {
 		{ msg: 'kernel: IN=wan OUT= SRC=203.0.113.10 DST=192.0.2.10 PROTO=ICMP' },
 		{ msg: 'fw4rejectIN=wan OUT= SRC=203.0.113.11 DST=192.0.2.11 PROTO=TCP DPT=22' },
 		{ msg: 'IN=wan OUT= SRC=203.0.113.12 DST=192.0.2.12 PROTO=TCP MAC=aa:bb:cc:dd:ee:ff PASS=noise' },
-		{ msg: 'not-a-firewall-line at all' }
+		{ msg: 'not-a-firewall-line at all' },
+		{ msg: 'Dnsmasq[123]: query[A] example.com from 192.168.1.1' },
+		{ msg: 'PROCD[1]: service did something' },
+		{ msg: 'x DST= DROP' },
+		{ msg: 'IN=wan OUT= SRC= DST=2001:db8::2 PROTO=TCP' }
 	];
 
 	for (const entry of fixture.log.concat(extra)) {


### PR DESCRIPTION
## Summary
- Add `CLASSIFY_SPEC` + `evaluateClassifySpec` in `core/fwlive-log.js` (presence KV, explicit boundaries)
- Generate committed `fwlive-is-firewall-event.sh` via `scripts/gen-shell-classifier.js`
- Golden corpus + codegen freshness wired into `fwlive-test.sh`
- Extend shell parity extras (empty-KV, mixed-case daemons)

Part 1 of 2 for #84 — does not close the issue (LuCI gen + 0.1.31 in follow-up).

## Test plan
- [x] `./scripts/fwlive-test.sh` green

Made with [Cursor](https://cursor.com)