### PR TITLE
fix: close #84 MCR classify follow-ups (#99–#103)

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Install shellcheck and busybox
+        run: sudo apt-get update && sudo apt-get install -y shellcheck busybox
       - run: ./scripts/fwlive-test.sh
+      - name: Shell parity under busybox sh
+        run: SH='busybox sh' node tests/fwlive-shell-filter.test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- LuCI wrapper gate deep-equals full `CLASSIFY_SPEC` (not only `actionWords`) (#99)
+- Shell non-firewall prefixes use word-boundary globs matching JS (`dnsmasqfoo` class) (#100)
+
+### Changed
+- `normalizeAction` derives pass/deny-class words from `CLASSIFY_SPEC.actionWords` (#101)
+- Document LuCI gate-not-generator design (banner, `gen-all.sh`, contributing) (#102)
+
+### Added
+- CI shell↔JS parity under BusyBox ash (`SH=busybox sh`) (#103)
+
 ## [v0.1.31] — 2026-07-31
 
 ### Added
-- Single-source classification: `CLASSIFY_SPEC` in `core/fwlive-log.js`, generated shell classifier, LuCI classify parity (#84)
+- Single-source classification: `CLASSIFY_SPEC` in `core/fwlive-log.js`, generated shell classifier; LuCI classify parity via gate + preserve region (#84)
 
 ### Changed
-- Parser sync gate uses classify goldens + codegen freshness (drops `PARSER_SYNC_VERSION` counter)
+- Parser sync gate uses classify goldens + shell codegen freshness / LuCI wrapper gate (drops `PARSER_SYNC_VERSION` counter)
 
 ---
 

--- a/core/fwlive-log.js
+++ b/core/fwlive-log.js
@@ -15,7 +15,10 @@ const CLASSIFY_SPEC = {
 	/* FIREWALL_HINT words */
 	firewallHints: ['fw4', 'nft', 'iptables', 'kernel', 'firewall'],
 
-	/* detectAction words (order matters: ACCEPT first) */
+	/* detectAction words — positional layout (do not reorder without updating consumers):
+	 *   [0..2] pass aliases → normalizeAction 'pass'
+	 *   [3] DROP → 'drop'; [4] REJECT → 'reject'; [5..] DENY|BLOCK → 'block'
+	 *   slice(3) = deny-class for DENY_ACTION / inferActionRaw */
 	actionWords: ['ACCEPT', 'ALLOW', 'PASS', 'DROP', 'REJECT', 'DENY', 'BLOCK'],
 
 	/* Decision tree — order matters, first match wins */
@@ -47,7 +50,9 @@ const NON_FIREWALL_PREFIX = new RegExp(
 );
 const FIREWALL_HINT = wordPattern(CLASSIFY_SPEC.firewallHints);
 const ACTION_RE = wordPattern(CLASSIFY_SPEC.actionWords);
-const DENY_ACTION = wordPattern(CLASSIFY_SPEC.actionWords.slice(3)); /* DROP|REJECT|DENY|BLOCK */
+const PASS_ACTION_WORDS = CLASSIFY_SPEC.actionWords.slice(0, 3); /* ACCEPT|ALLOW|PASS */
+const DENY_CLASS_WORDS = CLASSIFY_SPEC.actionWords.slice(3); /* DROP|REJECT|DENY|BLOCK — pinned */
+const DENY_ACTION = wordPattern(DENY_CLASS_WORDS);
 
 const TCP_FLAG_TAIL = /\b(SYN|ACK|FIN|RST|PSH|URG)(?:\s+(?:SYN|ACK|FIN|RST|PSH|URG))*\s*$/i;
 const NETFILTER_KV_GLUE = /([^\s])(?=(IN|OUT|SRC|DST|PROTO|SPT|DPT|LEN|MAC|TYPE|CODE|TTL|TOS|PREC|DF)=)/g;
@@ -134,13 +139,13 @@ function evaluateClassifySpec(message, actionRaw) {
 
 function normalizeAction(raw) {
 	const a = (raw || '').toUpperCase();
-	if (/^(ACCEPT|ALLOW|PASS)$/.test(a))
+	if (PASS_ACTION_WORDS.indexOf(a) >= 0)
 		return 'pass';
-	if (a === 'DROP')
+	if (a === CLASSIFY_SPEC.actionWords[3]) /* DROP */
 		return 'drop';
-	if (a === 'REJECT')
+	if (a === CLASSIFY_SPEC.actionWords[4]) /* REJECT */
 		return 'reject';
-	if (/^(DENY|BLOCK)$/.test(a))
+	if (DENY_CLASS_WORDS.indexOf(a) >= 0) /* DENY|BLOCK */
 		return 'block';
 	return 'unknown';
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -105,7 +105,7 @@ No. The [Docker SDK](developer/build-and-test.md#sdk-builds) or a [minimal SDK t
 
 ### I changed the parser — why is LuCI not showing my changes?
 
-Edit `core/fwlive-log.js` (classification lives in `CLASSIFY_SPEC`), then run `./scripts/gen-all.sh` and commit the regenerated shell classifier plus any LuCI classify sync. Run `./scripts/fwlive-test.sh` (codegen freshness + parser sync), then `./scripts/qemu-install-fwlive.sh` to copy to the running guest. Package builds do **not** run codegen — artifacts are committed.
+Edit `CLASSIFY_SPEC` in `core/fwlive-log.js` **and** the same object in `htdocs/.../fwlive/log.js`, then run `./scripts/gen-all.sh` (regenerates the shell classifier; gates LuCI full-spec drift — it does not rewrite LuCI shared logic). Run `./scripts/fwlive-test.sh`, then `./scripts/qemu-install-fwlive.sh` to copy to the running guest. Package builds do **not** run Node — committed artifacts are authoritative.
 
 ### How do I run tests without a router or QEMU?
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -35,8 +35,8 @@ flowchart TB
 |--------|----------|----------------|
 | **View shell** | `htdocs/.../view/status/fwlive.js` | Layout, 1s poll, pause/limit, DOM, click-to-filter |
 | **Log brain** | `htdocs/.../fwlive/log.js` | `isFirewallEvent`, `normalizeEntry`, filters, display helpers (classify from `CLASSIFY_SPEC`) |
-| **Test twin / SoT** | `core/fwlive-log.js` | Editable source of truth + CLI; `./scripts/gen-all.sh` regenerates shell classifier |
-| **Shell classifier** | `root/usr/libexec/fwlive-is-firewall-event.sh` | **Generated** from `CLASSIFY_SPEC` (committed; SDK does not run Node) |
+| **Test twin / SoT** | `core/fwlive-log.js` | Editable source of truth + CLI; `CLASSIFY_SPEC` drives classify |
+| **Shell classifier** | `root/usr/libexec/fwlive-is-firewall-event.sh` | **Generated** from `CLASSIFY_SPEC` via `gen-shell-classifier.js` (committed; SDK does not run Node) |
 | **Rule map** | `root/usr/libexec/rpcd/fwlive` | `rules`, `poll` (filtered log), `resolve` (reverse DNS), `logging_status`, `enable_wan_logging`, `disable_wan_logging` |
 | **WAN logging** | `root/usr/libexec/fwlive-logging.sh` | WAN zone `log=1` helpers (sourced by rpcd) |
 | **Log filter** | `root/usr/libexec/fwlive-log-filter.sh` | Shell `isFirewallEvent` parity before JSON leaves router |
@@ -56,6 +56,7 @@ flowchart TB
 | Log filter injection | `fwlive-log-filter.sh` feeds messages as data through jsonfilter/grep stdin — not a shell-injection surface |
 | Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off; server validates IPv4/IPv6 shape before lookup |
 | `core/` + LuCI mirror | Parser tested without browser or router |
+| LuCI gate (not generator) | `gen-luci-wrapper.js` verifies full `CLASSIFY_SPEC` equality + preserve markers; shared classify in `log.js` stays hand-maintained (no text-transform codegen). Core has no `@fwlive-codegen:luci-begin/end` markers — only LuCI has a preserve region for presentation helpers. |
 | nft/fw4 primary | Validated on **21.02.7** (fw3 lab), **22.03.7**, **23.05.5**, **24.10.5**, **25.12.0** lab matrix |
 | iptables LOG | Primary on **21.02.x** (fw3); best-effort on **22.03+** when nft absent — same logd pipe; rule map from `iptables-save` |
 | OPNsense as reference | Interaction and layout patterns, not PHP/Volt port |

--- a/docs/developer/build-and-test.md
+++ b/docs/developer/build-and-test.md
@@ -23,8 +23,8 @@ Native SDK (no Docker): [`../minimal-build-sdk.md`](../minimal-build-sdk.md)
 ```
 
 Covers parser sync (`core/` vs LuCI `log.js`), schema, filters, CLI pipeline,
-codegen freshness (`./scripts/gen-all.sh`), and shellcheck on shipped `root/usr/libexec` scripts
-(`./scripts/fwlive-shellcheck.sh`).
+shell codegen + LuCI wrapper gate (`./scripts/gen-all.sh`), and shellcheck on shipped
+`root/usr/libexec` scripts (`./scripts/fwlive-shellcheck.sh`). Optional: `SH='busybox sh' node tests/fwlive-shell-filter.test.js`.
 
 ## Live View CSS (`fwlive.css` → `css.js`)
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -3,7 +3,7 @@
 ## Principles
 
 - **Small steps** — one behavior per change; verify in CLI + QEMU LuCI when UI-related
-- **Parser sync** — edit `core/fwlive-log.js`, run `./scripts/gen-all.sh`, keep LuCI classify helpers + preserve-region presentation in parity (`fwlive-test.sh` enforces freshness)
+- **Parser sync** — edit `CLASSIFY_SPEC` in `core/fwlive-log.js`, mirror the same object in `htdocs/.../fwlive/log.js`, run `./scripts/gen-all.sh` (regenerates shell; gates LuCI full-spec drift), keep preserve-region presentation in parity
 - **No scope creep** — MVP is done; backlog items are in [`../ROADMAP.md`](../ROADMAP.md)
 
 ## Change workflow
@@ -23,7 +23,14 @@
 
 ## Parser sync / codegen
 
-`fwlive-test.sh` includes classify goldens, shell↔JS parity, and codegen freshness (`gen-shell-classifier.js` / `gen-luci-wrapper.js`). After editing the parser, run `./scripts/gen-all.sh` and commit generated artifacts. SDK package builds do not run Node codegen.
+`fwlive-test.sh` includes classify goldens, shell↔JS parity, and freshness checks:
+
+| Script | Role |
+|--------|------|
+| `gen-shell-classifier.js` | **Codegen** — emits `fwlive-is-firewall-event.sh` from `CLASSIFY_SPEC` |
+| `gen-luci-wrapper.js` | **Gate** — deep-equals full LuCI `CLASSIFY_SPEC` to core, checks preserve markers / 21.02 APIs; re-emits committed `log.js` bytes (does not transform shared logic) |
+
+After editing classification: update **both** `core/fwlive-log.js` and the LuCI `CLASSIFY_SPEC` mirror, run `./scripts/gen-all.sh`, and commit the regenerated shell classifier. A drifted LuCI wrapper fails the gate — it is not auto-fixed by `gen-all.sh`. SDK package builds do not run Node.
 
 ## Feed / package changes
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
@@ -2,8 +2,9 @@
 'require baseclass';
 
 /**
- * GENERATED FILE — do not edit shared logic by hand. Run: ./scripts/gen-all.sh
- * (source: core/fwlive-log.js CLASSIFY_SPEC). LuCI-only helpers live in the preserve region.
+ * Shared classify logic mirrors core/fwlive-log.js CLASSIFY_SPEC — keep in sync
+ * (gen-luci-wrapper.js gates full-spec drift; ./scripts/gen-all.sh verifies).
+ * LuCI-only helpers live in the @fwlive-codegen:luci-preserve region.
  */
 return baseclass.extend({
 	CLASSIFY_SPEC: {
@@ -119,13 +120,16 @@ return baseclass.extend({
 
 	normalizeAction: function(raw) {
 		const a = (raw || '').toUpperCase();
-		if (/^(ACCEPT|ALLOW|PASS)$/.test(a))
+		const words = this.CLASSIFY_SPEC.actionWords;
+		const pass = words.slice(0, 3); /* ACCEPT|ALLOW|PASS */
+		const denyClass = words.slice(3); /* DROP|REJECT|DENY|BLOCK — positional */
+		if (pass.indexOf(a) >= 0)
 			return 'pass';
-		if (a === 'DROP')
+		if (a === words[3]) /* DROP */
 			return 'drop';
-		if (a === 'REJECT')
+		if (a === words[4]) /* REJECT */
 			return 'reject';
-		if (/^(DENY|BLOCK)$/.test(a))
+		if (denyClass.indexOf(a) >= 0) /* DENY|BLOCK */
 			return 'block';
 		return 'unknown';
 	},

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh
@@ -47,7 +47,7 @@ is_firewall_event_msg() {
 
 	msg_lc=$(printf '%s' "$msg" | tr '[:upper:]' '[:lower:]')
 	case "$msg_lc" in
-		dnsmasq*|procd*|ubusd*|netifd*|odhcpd*|logd*|dropbear*|uhttpd*|hostapd*|wpad*) return 1 ;;
+		dnsmasq|dnsmasq[!A-Za-z0-9_]*|procd|procd[!A-Za-z0-9_]*|ubusd|ubusd[!A-Za-z0-9_]*|netifd|netifd[!A-Za-z0-9_]*|odhcpd|odhcpd[!A-Za-z0-9_]*|logd|logd[!A-Za-z0-9_]*|dropbear|dropbear[!A-Za-z0-9_]*|uhttpd|uhttpd[!A-Za-z0-9_]*|hostapd|hostapd[!A-Za-z0-9_]*|wpad|wpad[!A-Za-z0-9_]*) return 1 ;;
 	esac
 
 	action=$(_detect_action "$msg")

--- a/scripts/gen-all.sh
+++ b/scripts/gen-all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Regenerate derived files from core/fwlive-log.js (single source of truth).
+# From core/fwlive-log.js CLASSIFY_SPEC:
+#   - regenerate the shell classifier (true codegen)
+#   - verify the hand-maintained LuCI wrapper (gate; does not transform it)
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp_shell="$(mktemp)"
@@ -9,4 +11,4 @@ node "$ROOT/scripts/gen-shell-classifier.js" > "$tmp_shell"
 node "$ROOT/scripts/gen-luci-wrapper.js" > "$tmp_luci"
 mv "$tmp_shell" "$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh"
 mv "$tmp_luci" "$ROOT/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js"
-echo "Regenerated shell classifier + verified LuCI wrapper. Review git diff and commit."
+echo "Regenerated shell classifier + verified LuCI wrapper (gate). Review git diff and commit."

--- a/scripts/gen-luci-wrapper.js
+++ b/scripts/gen-luci-wrapper.js
@@ -4,6 +4,10 @@
 /**
  * LuCI wrapper gate for gen-all.sh: verifies preserve markers, CLASSIFY_SPEC surface,
  * and 21.02 API constraints; emits committed log.js bytes (idempotent).
+ *
+ * This is a gate, not a generator: shared classify logic in log.js is hand-maintained
+ * and must stay deep-equal to core CLASSIFY_SPEC. Running gen-all.sh re-emits the
+ * committed file only after checks pass.
  */
 
 const fs = require('node:fs');
@@ -25,9 +29,32 @@ assert.ok(src.indexOf('gen-all.sh') >= 0, 'missing gen-all.sh banner');
 assert.ok(src.indexOf('.includes(') < 0 && src.indexOf('Object.values') < 0,
 	'LuCI wrapper must stay 21.02-compatible');
 
-assert.deepEqual(
-	core.CLASSIFY_SPEC.actionWords,
-	['ACCEPT', 'ALLOW', 'PASS', 'DROP', 'REJECT', 'DENY', 'BLOCK']
-);
+function extractClassifySpec(text) {
+	const key = 'CLASSIFY_SPEC:';
+	const keyAt = text.indexOf(key);
+	assert.ok(keyAt >= 0, 'CLASSIFY_SPEC key not found in LuCI wrapper');
+	const start = text.indexOf('{', keyAt);
+	assert.ok(start >= 0, 'CLASSIFY_SPEC object not found in LuCI wrapper');
+	let depth = 0;
+	let end = -1;
+	for (let i = start; i < text.length; i++) {
+		const c = text[i];
+		if (c === '{')
+			depth++;
+		else if (c === '}') {
+			depth--;
+			if (depth === 0) {
+				end = i + 1;
+				break;
+			}
+		}
+	}
+	assert.ok(end > start, 'CLASSIFY_SPEC object not balanced in LuCI wrapper');
+	return Function('"use strict"; return (' + text.slice(start, end) + ');')();
+}
+
+const luciSpec = extractClassifySpec(src);
+assert.deepEqual(core.CLASSIFY_SPEC, luciSpec,
+	'LuCI wrapper CLASSIFY_SPEC drifted from core');
 
 process.stdout.write(src);

--- a/scripts/gen-shell-classifier.js
+++ b/scripts/gen-shell-classifier.js
@@ -54,8 +54,9 @@ function emitHint() {
 }
 
 function emitPrefixCase() {
+	/* Match JS NON_FIREWALL_PREFIX: prefix at start, then non-word or end — not prefix*. */
 	const pats = SPEC.nonFirewallPrefixes.map(function(p) {
-		return p + '*';
+		return p + '|' + p + '[!A-Za-z0-9_]*';
 	}).join('|');
 	return [
 		"\tmsg_lc=$(printf '%s' \"$msg\" | tr '[:upper:]' '[:lower:]')",

--- a/tests/fwlive-shell-filter.test.js
+++ b/tests/fwlive-shell-filter.test.js
@@ -13,12 +13,30 @@ const IS_FW = path.join(ROOT,
 const FILTER_SH = path.join(ROOT,
 	'openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh');
 const FIXTURE = path.join(__dirname, 'fixtures', 'logread-mixed.json');
+/* Override with SH=busybox or SH='busybox sh' for ash parity (#103). */
+const SH = process.env.SH || 'sh';
+
+function shSpawn(scriptOrFile, opts) {
+	const parts = SH.split(/\s+/).filter(Boolean);
+	const cmd = parts[0];
+	const prefix = parts.slice(1);
+	if (opts && opts.argvFile) {
+		return spawnSync(cmd, prefix.concat([opts.argvFile]), {
+			input: opts.input,
+			encoding: opts.encoding || 'utf8'
+		});
+	}
+	return execFileSync(cmd, prefix.concat(['-c', scriptOrFile]), {
+		encoding: 'utf8',
+		env: opts && opts.env ? opts.env : process.env
+	});
+}
 
 function shellIsFirewall(msg) {
-	const out = execFileSync('sh', ['-c', '. "$IS_FW" && is_firewall_event_msg "$FW_MSG" && echo yes || echo no'], {
-		encoding: 'utf8',
-		env: { ...process.env, IS_FW: IS_FW, FW_MSG: msg }
-	}).trim();
+	const out = shSpawn(
+		'. "$IS_FW" && is_firewall_event_msg "$FW_MSG" && echo yes || echo no',
+		{ env: { ...process.env, IS_FW: IS_FW, FW_MSG: msg } }
+	).trim();
 	return out === 'yes';
 }
 
@@ -40,6 +58,8 @@ function runMsgParity() {
 		{ msg: 'not-a-firewall-line at all' },
 		{ msg: 'Dnsmasq[123]: query[A] example.com from 192.168.1.1' },
 		{ msg: 'PROCD[1]: service did something' },
+		/* #100 — prefix boundary: word-suffix must not match non-firewall daemon glob */
+		{ msg: 'dnsmasqfoo: IN=wan OUT= SRC=1.2.3.4 DST=5.6.7.8 PROTO=TCP' },
 		{ msg: 'x DST= DROP' },
 		{ msg: 'IN=wan OUT= SRC= DST=2001:db8::2 PROTO=TCP' }
 	];
@@ -62,10 +82,7 @@ function runJsonParity() {
 		return;
 	}
 
-	const filtered = spawnSync('sh', [FILTER_SH], {
-		input: payload,
-		encoding: 'utf8'
-	});
+	const filtered = shSpawn(null, { argvFile: FILTER_SH, input: payload, encoding: 'utf8' });
 	assert.equal(filtered.status, 0, filtered.stderr || filtered.stdout);
 
 	const shellOut = JSON.parse(filtered.stdout);
@@ -103,10 +120,7 @@ function runMetacharSafety() {
 	const payload = JSON.stringify({
 		log: nasty.map((msg, i) => ({ msg, id: i }))
 	});
-	const filtered = spawnSync('sh', [FILTER_SH], {
-		input: payload,
-		encoding: 'utf8'
-	});
+	const filtered = shSpawn(null, { argvFile: FILTER_SH, input: payload, encoding: 'utf8' });
 	assert.equal(filtered.status, 0, filtered.stderr || filtered.stdout);
 	assert.doesNotThrow(() => JSON.parse(filtered.stdout));
 }
@@ -115,7 +129,7 @@ function run() {
 	runMsgParity();
 	runJsonParity();
 	runMetacharSafety();
-	console.log('fwlive shell filter parity tests passed');
+	console.log('fwlive shell filter parity tests passed (SH=' + SH + ')');
 }
 
 run();


### PR DESCRIPTION
## Summary
- **#99:** LuCI wrapper gate deep-equals full `CLASSIFY_SPEC` (not only `actionWords`)
- **#100:** Shell non-firewall prefixes use word-boundary globs matching JS; pin `dnsmasqfoo` in parity corpus
- **#101:** Derive `normalizeAction` from `CLASSIFY_SPEC.actionWords`; pin `slice(3)`
- **#102:** Document gate-not-generator design (banner, `gen-all.sh`, contributing, CHANGELOG)
- **#103:** Parametrize `SH=` in shell parity tests; CI step under `busybox sh`

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [x] `SH='busybox sh' node tests/fwlive-shell-filter.test.js`
- [x] Confirm rules drift in LuCI `CLASSIFY_SPEC` fails `gen-luci-wrapper.js`


Made with [Cursor](https://cursor.com)