### PR TITLE
docs: fix broken links (blob/main→master, archive refs, iptables relative path)

### DIFF
--- a/docs/fwlive-iptables-logging.md
+++ b/docs/fwlive-iptables-logging.md
@@ -11,7 +11,7 @@ Firewall Live View reads **logd** — the same pipeline as fw4. On iptables back
 
 **This is not iptables TRACE.** Silent rule hits without LOG never appear in the table.
 
-See also: [nft/fw4 logging](fwlive-nft-logging.md) · [enabling logs (user)](../user/enabling-firewall-logs.md)
+See also: [nft/fw4 logging](fwlive-nft-logging.md) · [enabling logs (user)](user/enabling-firewall-logs.md)
 
 ## Quick lab test
 

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -9,7 +9,7 @@ Use before making this repo public upstream.
 - [ ] Run `./scripts/fwlive-test.sh`
 - [ ] `./scripts/validate-baseline.sh`
 - [ ] Optional QEMU: `./scripts/validate-openwrt.sh --version 24.10` — see [`validation-matrix.md`](validation-matrix.md)
-- [ ] Review [`archive/README.md`](../archive/README.md) — nothing there should be required for new users
+- [ ] Confirm nothing in the removed `archive/` tree (deleted in #98) is required for new users — `rg -n "archive" .` should return no dead references
 
 ### Security (pre-release)
 
@@ -89,7 +89,7 @@ When copying `openwrt-feed/luci-app-fwlive/` into `luci/applications/luci-app-fw
 
 - Edit JS/docs and run `./scripts/fwlive-test.sh` locally
 - **SDK builds and QEMU labs:** Linux x86_64 (VM, CI, or remote host)
-- Unmaintained macOS QEMU: `archive/scripts/legacy/`
+- Unmaintained macOS QEMU: `archive/scripts/legacy/` *(removed in #98 — see git history)*
 
 ## After publish
 

--- a/packages-repo/README.md
+++ b/packages-repo/README.md
@@ -6,7 +6,7 @@ Signed **opkg** / **apk** binary feed for [`luci-app-fwlive`](https://github.com
 
 ## Install
 
-**Recommended — binary feed** (`opkg` on **21.02–24.10**, `apk` on **25.12+** from GitHub Pages). Full guide: [installation](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/user/installation.md#1-binary-feed-recommended).
+**Recommended — binary feed** (`opkg` on **21.02–24.10**, `apk` on **25.12+** from GitHub Pages). Full guide: [installation](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/user/installation.md#1-binary-feed-recommended).
 
 **opkg (21.02.x – 24.10.x)** — run on the router; picks the feed for your OpenWrt release:
 
@@ -38,7 +38,7 @@ echo 'https://lucas-albers-lz4.github.io/fwlive-packages/25.12/all/packages.adb'
 apk update && apk add luci-app-fwlive
 ```
 
-More detail: [binary feed](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/binary-feed.md) · per-release notes in [21.02](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/openwrt-21.02-compat.md) / [22.03](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/openwrt-22.03-compat.md) compat docs.
+More detail: [binary feed](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/binary-feed.md) · per-release notes in [21.02](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/openwrt-21.02-compat.md) / [22.03](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/openwrt-22.03-compat.md) compat docs.
 
 Menu after install: **Status → Firewall Live View**.
 


### PR DESCRIPTION
**Stack 1/3** of doc-review plan #107.

Fixes:
- `packages-repo/README.md`: 4× `blob/main` → `blob/master` (default branch is master; all 404'd)
- `docs/github-publish-checklist.md`: dropped dead `archive/README.md` link (dir removed in #98), annotated `archive/scripts/legacy/` ref
- `docs/fwlive-iptables-logging.md`: `../user/enabling-firewall-logs.md` → `user/enabling-firewall-logs.md`

Addresses MCR findings **F2, F5** (issue #107 comment).

⚠️ Merge in order: Stack 1 → 2 → 3. This PR ships only after review.