### PR TITLE
docs: align Stage 6/7 status (done) across ROADMAP + acceptance, keep iptables test

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ Product: **LuCI Firewall Live View** — OPNsense Live View–style operator UX 
 
 ---
 
-## Status summary (2026-06)
+## Status summary (2026-07)
 
 | Milestone | State | Notes |
 | --------- | ----- | ----- |
@@ -32,8 +32,8 @@ Product: **LuCI Firewall Live View** — OPNsense Live View–style operator UX 
 | **Stage 4b** | **Done** | Auto-refresh checkbox + row limit dropdown |
 | **Stage 5** | **Done (core)** | Click-to-filter, chips, pass inference |
 | **Stage 3** Rule attribution | **Done (core)** | rule_hint, Rule column, deep link |
-| **Stage 6** | **Partial** | **Show hostnames** checkbox (default off) — `ubus fwlive resolve` |
-| **Stage 7** | **Partial** | **`ubus fwlive poll`** — server-side firewall-only filter |
+| **Stage 6** | **Done** | **Show hostnames** checkbox (default off) — `ubus fwlive resolve` |
+| **Stage 7** | **Done** | **`ubus fwlive poll`** — server-side firewall-only filter |
 | **Stage 6–7 rest** | Backlog | Rule overlay, digest/SSE |
 | **Classify codegen** | **Done (#84)** | `CLASSIFY_SPEC` + generated shell classifier; LuCI classify parity + preserve region |
 

--- a/docs/fwlive-acceptance.md
+++ b/docs/fwlive-acceptance.md
@@ -4,7 +4,7 @@
 
 ## MVP status
 
-**MVP and pre-backport feature work are complete** (stages 1–5 core, 4b, 3.4b, 5.6). Stage 6+ remains backlog — see [Stage 6 (next)](#stage-6--inspect--enrichment-backlog) below.
+**MVP and pre-backport feature work are complete** (stages 1–5 core, 4b, 3.4b, 5.6). Stage 6 (hostnames) and Stage 7 (server-side filter) are **done** — see [Stage 6](#stage-6--inspect--enrichment-done) and [Stage 7](#stage-7--transport-done) below. Remaining backlog: rule overlay, digest/SSE.
 
 Re-validate after changes — see [Build & test](developer/build-and-test.md) for the full command reference.
 
@@ -120,7 +120,7 @@ Validated on **QEMU x86_64 21.02.7**, **22.03.7**, **24.10** (KVM) and **armsr 2
 
 ---
 
-## Stage 6 — Inspect & enrichment (partial)
+## Stage 6 — Inspect & enrichment (done)
 
 | Item | Status |
 |------|--------|
@@ -128,7 +128,7 @@ Validated on **QEMU x86_64 21.02.7**, **22.03.7**, **24.10** (KVM) and **armsr 2
 | Rule overlay | backlog |
 | Row detail drawer | backlog |
 
-## Stage 7 — Transport (partial)
+## Stage 7 — Transport (done)
 
 | Item | Status |
 |------|--------|

--- a/docs/fwlive-iptables-logging.md
+++ b/docs/fwlive-iptables-logging.md
@@ -15,6 +15,8 @@ See also: [nft/fw4 logging](fwlive-nft-logging.md) · [enabling logs (user)](use
 
 ## Quick lab test
 
+This test is **iptables-specific** — it uses `fwlive-iptables-ping-log.sh` and validates the fw3/21.02 path. For the nft/fw4 quick test, use the [User guide → Quick start](user/enabling-firewall-logs.md#quick-start-after-install) instead.
+
 ```sh
 ./scripts/fwlive-iptables-ping-log.sh add --ssh
 ping -c 3 $(./scripts/fwlive-iptables-ping-log.sh guest-ip)

--- a/docs/fwlive-iptables-logging.md
+++ b/docs/fwlive-iptables-logging.md
@@ -11,7 +11,7 @@ Firewall Live View reads **logd** — the same pipeline as fw4. On iptables back
 
 **This is not iptables TRACE.** Silent rule hits without LOG never appear in the table.
 
-See also: [nft/fw4 logging](fwlive-nft-logging.md) · [enabling logs (user)](../user/enabling-firewall-logs.md)
+See also: [nft/fw4 logging](fwlive-nft-logging.md) · [enabling logs (user)](user/enabling-firewall-logs.md)
 
 ## Quick lab test
 

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -9,7 +9,7 @@ Use before making this repo public upstream.
 - [ ] Run `./scripts/fwlive-test.sh`
 - [ ] `./scripts/validate-baseline.sh`
 - [ ] Optional QEMU: `./scripts/validate-openwrt.sh --version 24.10` — see [`validation-matrix.md`](validation-matrix.md)
-- [ ] Review [`archive/README.md`](../archive/README.md) — nothing there should be required for new users
+- [ ] Confirm nothing in the removed `archive/` tree (deleted in #98) is required for new users — `rg -n "archive" .` should return no dead references
 
 ### Security (pre-release)
 
@@ -89,7 +89,7 @@ When copying `openwrt-feed/luci-app-fwlive/` into `luci/applications/luci-app-fw
 
 - Edit JS/docs and run `./scripts/fwlive-test.sh` locally
 - **SDK builds and QEMU labs:** Linux x86_64 (VM, CI, or remote host)
-- Unmaintained macOS QEMU: `archive/scripts/legacy/`
+- Unmaintained macOS QEMU: `archive/scripts/legacy/` *(removed in #98 — see git history)*
 
 ## After publish
 

--- a/packages-repo/README.md
+++ b/packages-repo/README.md
@@ -6,7 +6,7 @@ Signed **opkg** / **apk** binary feed for [`luci-app-fwlive`](https://github.com
 
 ## Install
 
-**Recommended — binary feed** (`opkg` on **21.02–24.10**, `apk` on **25.12+** from GitHub Pages). Full guide: [installation](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/user/installation.md#1-binary-feed-recommended).
+**Recommended — binary feed** (`opkg` on **21.02–24.10**, `apk` on **25.12+** from GitHub Pages). Full guide: [installation](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/user/installation.md#1-binary-feed-recommended).
 
 **opkg (21.02.x – 24.10.x)** — run on the router; picks the feed for your OpenWrt release:
 
@@ -38,7 +38,7 @@ echo 'https://lucas-albers-lz4.github.io/fwlive-packages/25.12/all/packages.adb'
 apk update && apk add luci-app-fwlive
 ```
 
-More detail: [binary feed](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/binary-feed.md) · per-release notes in [21.02](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/openwrt-21.02-compat.md) / [22.03](https://github.com/lucas-albers-lz4/fwlive/blob/main/docs/openwrt-22.03-compat.md) compat docs.
+More detail: [binary feed](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/binary-feed.md) · per-release notes in [21.02](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/openwrt-21.02-compat.md) / [22.03](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/openwrt-22.03-compat.md) compat docs.
 
 Menu after install: **Status → Firewall Live View**.
 


### PR DESCRIPTION
**Stack 2/3** of doc-review plan #107.

Changes:
- `docs/ROADMAP.md`: Status summary 2026-06 → 2026-07; Stage 6/7 **Partial → Done** (matches the Feature-backlog table and README status)
- `docs/fwlive-acceptance.md`: line 7 backlog claim → done with corrected anchors; section headings `(partial)` → `(done)`
- `docs/fwlive-iptables-logging.md`: kept the backend-specific quick lab test, added cross-link to the nft user-guide quick start (prose pass applied per simple-english)

Addresses MCR findings **F1, F3, F4** (issue #107 comment).

⚠️ Merge in order: Stack 1 → 2 → 3.