### PR TITLE
ci: add markdown link checker (internal + external) to host test gate

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -21,3 +21,5 @@ jobs:
       - run: ./scripts/fwlive-test.sh
       - name: Shell parity under busybox sh
         run: SH='busybox sh' node tests/fwlive-shell-filter.test.js
+      - name: Link check (internal markdown links + external URLs)
+        run: ./scripts/fwlive-linkcheck.sh

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Dev dependencies for fwlive / luci-app-fwlive tooling (not shipped on router)",
   "scripts": {
     "test": "./scripts/fwlive-test.sh",
+    "test:links": "./scripts/fwlive-linkcheck.sh",
     "test:ui": "node scripts/capture-fwlive-screenshots.mjs"
   },
   "devDependencies": {

--- a/scripts/fwlive-linkcheck.sh
+++ b/scripts/fwlive-linkcheck.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # fwlive link check: internal markdown links (strict) + external URLs (404 = fail).
+# Scans git-tracked *.md only (skips local SDK/openwrt trees).
 # Run via: npm run test:links   (or CI: ./scripts/fwlive-linkcheck.sh)
 set -euo pipefail
 
@@ -8,28 +9,28 @@ cd "$ROOT"
 
 echo "== internal markdown links =="
 python3 - <<'PYEOF'
-import os, re, sys
+import os, re, subprocess, sys
+
+files = subprocess.check_output(
+    ['git', 'ls-files', '*.md'], text=True
+).splitlines()
 
 broken = []
 checked = 0
-for dirpath, dirnames, filenames in os.walk('.'):
-    dirnames[:] = [d for d in dirnames if d not in ('.git', 'node_modules')]
-    for fn in filenames:
-        if not fn.endswith('.md'):
+for path in files:
+    dirpath = os.path.dirname(path) or '.'
+    try:
+        txt = open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        continue
+    for m in re.finditer(r'\[[^\]]*\]\(([^)]+)\)', txt):
+        target = m.group(1).split('#')[0].split('?')[0].strip()
+        if not target or target.startswith(('http://', 'https://', 'mailto:')):
             continue
-        path = os.path.join(dirpath, fn)
-        try:
-            txt = open(path, encoding='utf-8', errors='replace').read()
-        except OSError:
-            continue
-        for m in re.finditer(r'\[[^\]]*\]\(([^)]+)\)', txt):
-            target = m.group(1).split('#')[0].split('?')[0].strip()
-            if not target or target.startswith(('http://', 'https://', 'mailto:')):
-                continue
-            checked += 1
-            full = os.path.normpath(os.path.join(dirpath, target))
-            if not os.path.exists(full):
-                broken.append((path, target))
+        checked += 1
+        full = os.path.normpath(os.path.join(dirpath, target))
+        if not os.path.exists(full):
+            broken.append((path, target))
 
 if broken:
     for path, target in broken:
@@ -43,22 +44,30 @@ echo "== external URLs (404 = fail; 403/429/5xx = warn) =="
 python3 - <<'PYEOF'
 import os, re, subprocess, sys
 
+files = subprocess.check_output(
+    ['git', 'ls-files', '*.md'], text=True
+).splitlines()
+
 urls = set()
-for dirpath, dirnames, filenames in os.walk('.'):
-    dirnames[:] = [d for d in dirnames if d not in ('.git', 'node_modules')]
-    for fn in filenames:
-        if not fn.endswith('.md'):
-            continue
-        path = os.path.join(dirpath, fn)
-        try:
-            txt = open(path, encoding='utf-8', errors='replace').read()
-        except OSError:
-            continue
-        for m in re.finditer(r'\[[^\]]*\]\((https?://[^)\s]+)\)', txt):
-            urls.add(m.group(1).rstrip('.,;:'))
+for path in files:
+    try:
+        txt = open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        continue
+    for m in re.finditer(r'\[[^\]]*\]\((https?://[^)\s]+)\)', txt):
+        urls.add(m.group(1).rstrip('.,;:'))
+
+# Lab / local examples (QEMU LuCI) — not reachable from CI
+SKIP_HOST_RE = re.compile(
+    r'^https?://(127\.0\.0\.1|localhost|\[::1\])(:|/|$)', re.I
+)
 
 fails, warns = [], []
+skipped = 0
 for u in sorted(urls):
+    if SKIP_HOST_RE.match(u):
+        skipped += 1
+        continue
     try:
         r = subprocess.run(
             ['curl', '-sL', '-o', '/dev/null', '-w', '%{http_code}',
@@ -79,6 +88,9 @@ for u, code in warns:
 for u, code in fails:
     print(f"  FAIL: {u} -> {code}")
 
-print(f"external URLs checked: {len(urls)}, failed: {len(fails)}, warned: {len(warns)}")
+print(
+    f"external URLs checked: {len(urls)}, failed: {len(fails)}, "
+    f"warned: {len(warns)}, skipped-local: {skipped}"
+)
 sys.exit(1 if fails else 0)
 PYEOF

--- a/scripts/fwlive-linkcheck.sh
+++ b/scripts/fwlive-linkcheck.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# fwlive link check: internal markdown links (strict) + external URLs (404 = fail).
+# Run via: npm run test:links   (or CI: ./scripts/fwlive-linkcheck.sh)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== internal markdown links =="
+python3 - <<'PYEOF'
+import os, re, sys
+
+broken = []
+checked = 0
+for dirpath, dirnames, filenames in os.walk('.'):
+    dirnames[:] = [d for d in dirnames if d not in ('.git', 'node_modules')]
+    for fn in filenames:
+        if not fn.endswith('.md'):
+            continue
+        path = os.path.join(dirpath, fn)
+        try:
+            txt = open(path, encoding='utf-8', errors='replace').read()
+        except OSError:
+            continue
+        for m in re.finditer(r'\[[^\]]*\]\(([^)]+)\)', txt):
+            target = m.group(1).split('#')[0].split('?')[0].strip()
+            if not target or target.startswith(('http://', 'https://', 'mailto:')):
+                continue
+            checked += 1
+            full = os.path.normpath(os.path.join(dirpath, target))
+            if not os.path.exists(full):
+                broken.append((path, target))
+
+if broken:
+    for path, target in broken:
+        print(f"  BROKEN: {path}: -> {target}")
+    print(f"internal links checked: {checked}, broken: {len(broken)}")
+    sys.exit(1)
+print(f"internal links checked: {checked}, broken: 0")
+PYEOF
+
+echo "== external URLs (404 = fail; 403/429/5xx = warn) =="
+python3 - <<'PYEOF'
+import os, re, subprocess, sys
+
+urls = set()
+for dirpath, dirnames, filenames in os.walk('.'):
+    dirnames[:] = [d for d in dirnames if d not in ('.git', 'node_modules')]
+    for fn in filenames:
+        if not fn.endswith('.md'):
+            continue
+        path = os.path.join(dirpath, fn)
+        try:
+            txt = open(path, encoding='utf-8', errors='replace').read()
+        except OSError:
+            continue
+        for m in re.finditer(r'\[[^\]]*\]\((https?://[^)\s]+)\)', txt):
+            urls.add(m.group(1).rstrip('.,;:'))
+
+fails, warns = [], []
+for u in sorted(urls):
+    try:
+        r = subprocess.run(
+            ['curl', '-sL', '-o', '/dev/null', '-w', '%{http_code}',
+             '-A', 'Mozilla/5.0 (X11; Linux x86_64)', '--max-time', '15', u],
+            capture_output=True, text=True, timeout=20)
+        code = r.stdout.strip()
+        if code.startswith('2') or code.startswith('3'):
+            continue
+        if code in ('403', '429', '500', '502', '503', '504'):
+            warns.append((u, code))
+        else:
+            fails.append((u, code))
+    except Exception as e:
+        warns.append((u, f'error: {e}'))
+
+for u, code in warns:
+    print(f"  WARN: {u} -> {code} (bot protection / rate limit / timeout)")
+for u, code in fails:
+    print(f"  FAIL: {u} -> {code}")
+
+print(f"external URLs checked: {len(urls)}, failed: {len(fails)}, warned: {len(warns)}")
+sys.exit(1 if fails else 0)
+PYEOF


### PR DESCRIPTION
**Stack 3/3** of doc-review plan #107.

Changes:
- `scripts/fwlive-linkcheck.sh`: strict internal-relative-link scan + external URL check (404 = fail; 403/429/5xx = warn for bot protection)
- `package.json`: `npm run test:links` alias
- `.github/workflows/fwlive-test.yml`: link-check step on push + PR

Verified: the checker flags master's two pre-existing broken links (github-publish-checklist archive ref, iptables-logging relative path) that Stacks 1-2 fix — CI goes green after they merge.

Addresses MCR finding **F8** (issue #107 comment).

⚠️ Merge in order: Stack 1 → 2 → 3.