### PR TITLE
docs: fix binary-feed anchor + validate heading anchors in link checker (#113)

### DIFF
--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -10,7 +10,7 @@ Install directly from the signed GitHub Pages feed — no manual download.
 |---------|-----------------|----------|
 | **21.02.x** (legacy fw3) | `opkg` | [Binary feed — 21.02](../binary-feed.md#openwrt-2102x-opkg-legacy-fw3) |
 | **22.03.x** (EOL) | `opkg` | [Binary feed — 22.03](../binary-feed.md#openwrt-2203x-opkg-eol) |
-| **23.05** / **24.10** | `opkg` | [Binary feed — opkg](../binary-feed.md#openwrt-2410-opkg) |
+| **23.05** / **24.10** | `opkg` | [Binary feed — opkg](../binary-feed.md#openwrt-2305--2410-opkg) |
 | **25.12+** | `apk` | [Binary feed — apk](../binary-feed.md#openwrt-2512-apk) |
 
 **OpenWrt 24.10** example:

--- a/scripts/fwlive-linkcheck.sh
+++ b/scripts/fwlive-linkcheck.sh
@@ -7,9 +7,27 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-echo "== internal markdown links =="
+echo "== internal markdown links (file + anchor) =="
 python3 - <<'PYEOF'
 import os, re, subprocess, sys
+
+
+def heading_slugs(path):
+    """GitHub-style anchor slugs for every heading in a markdown file."""
+    slugs = set()
+    try:
+        txt = open(path, encoding='utf-8', errors='replace').read()
+    except OSError:
+        return slugs
+    for line in txt.splitlines():
+        if not re.match(r'^#{1,6}\s', line):
+            continue
+        text = re.sub(r'^#{1,6}\s+', '', line).strip()
+        # GitHub slugger: lowercase, strip punctuation, spaces -> '-'
+        slug = re.sub(r'[^\w\s-]', '', text.lower()).replace(' ', '-')
+        slugs.add(slug)
+    return slugs
+
 
 files = subprocess.check_output(
     ['git', 'ls-files', '*.md'], text=True
@@ -24,17 +42,29 @@ for path in files:
     except OSError:
         continue
     for m in re.finditer(r'\[[^\]]*\]\(([^)]+)\)', txt):
-        target = m.group(1).split('#')[0].split('?')[0].strip()
+        target = m.group(1).split('?')[0].strip()
         if not target or target.startswith(('http://', 'https://', 'mailto:')):
             continue
+        if '#' in target:
+            filepart, anchor = target.split('#', 1)
+        else:
+            filepart, anchor = target, None
         checked += 1
-        full = os.path.normpath(os.path.join(dirpath, target))
+        full = os.path.normpath(os.path.join(dirpath, filepart))
         if not os.path.exists(full):
-            broken.append((path, target))
+            broken.append((path, target, f"file missing: {full}"))
+            continue
+        if anchor is not None:
+            # Heading-only links (bare '#foo') resolve against the same file.
+            # If a target file has NO headings, treat '#' links as unchecked
+            # rather than broken (e.g. generated content).
+            slugs = heading_slugs(full)
+            if slugs and anchor not in slugs:
+                broken.append((path, target, f"anchor missing in {full}: #{anchor}"))
 
 if broken:
-    for path, target in broken:
-        print(f"  BROKEN: {path}: -> {target}")
+    for path, target, why in broken:
+        print(f"  BROKEN: {path}: -> {target} ({why})")
     print(f"internal links checked: {checked}, broken: {len(broken)}")
     sys.exit(1)
 print(f"internal links checked: {checked}, broken: 0")


### PR DESCRIPTION
Fixes #113 — Stack 1/2: accuracy + checker hardening.

- **docs/user/installation.md** — fix dead anchor `binary-feed.md#openwrt-2410-opkg` → `#openwrt-2305--2410-opkg` (real heading: `OpenWrt 23.05 / 24.10 (opkg)`). The link checker passed this because it only resolved file paths, never heading anchors.
- **scripts/fwlive-linkcheck.sh** — internal link check now validates `#anchor` fragments against GitHub-style heading slugs (lowercase, strip punctuation, spaces → `-`), aligned with the script's `git ls-files` / git-tracked convention. Negative-tested: reintroducing the old dead anchor is caught with a clear message.

Stack 2 (new-user install fold) to follow.