### PR TITLE
docs: new-user install fold — lead with binary feed, fold the rest (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Details: [Requirements](docs/user/requirements.md) · [21.02 compat](docs/openwr
 
 ## Install
 
-**Recommended — [binary feed](docs/binary-feed.md)** (`opkg` on **21.02–24.10**, `apk` on **25.12+** from GitHub Pages).
-
-**opkg (21.02.x – 24.10.x)** — run on the router; picks the feed for your OpenWrt release:
+**Recommended — [binary feed](docs/binary-feed.md).** Run this on the router. It picks the feed for your OpenWrt release:
 
 ```sh
 BASE='https://lucas-albers-lz4.github.io/fwlive-packages'
@@ -64,6 +62,11 @@ echo "src/gz fwlive $BASE/$feed" >> /etc/opkg/customfeeds.conf
 opkg update && opkg install luci-app-fwlive
 ```
 
+**After install:** [enable logging](docs/user/enabling-firewall-logs.md#quick-start-after-install) — the table stays empty until you enable logging.
+
+<details>
+<summary>Other install methods</summary>
+
 **apk (25.12+)** — hardcoded example for OpenWrt **25.12**:
 
 ```sh
@@ -77,7 +80,7 @@ apk update && apk add luci-app-fwlive
 
 More detail: [binary feed](docs/binary-feed.md) · per-release notes in [21.02](docs/openwrt-21.02-compat.md) / [22.03](docs/openwrt-22.03-compat.md) compat docs.
 
-**Alternative — [GitHub Releases](https://github.com/lucas-albers-lz4/fwlive/releases):** download the package for your OpenWrt version and install manually.
+**GitHub Releases** — download the package for your OpenWrt version and install manually:
 
 | OpenWrt | Package | Install |
 |---------|---------|---------|
@@ -92,6 +95,8 @@ echo "src-link fwlive $(pwd)/fwlive/openwrt-feed" >> feeds.conf
 ./scripts/feeds update fwlive
 ./scripts/feeds install luci-app-fwlive
 ```
+
+</details>
 
 Full paths: [Installation guide](docs/user/installation.md) · [Binary feed](docs/binary-feed.md) · [Release workflow](docs/release.md) (maintainers)
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -6,7 +6,7 @@ Documentation for **installing and using** `luci-app-fwlive` on an OpenWrt route
 |-------|-------------------|
 | [Overview](overview.md) | What the package does and when to use it |
 | [Requirements](requirements.md) | Supported OpenWrt versions and dependencies |
-| [Installation](installation.md) | Binary feed (recommended), GitHub Release, or `src-link` feed |
+| [Installation](installation.md) | Binary feed (recommended), or other methods |
 | [Using the UI](using-the-ui.md) | First visit, Simple & Detailed views, Show Detail, Help |
 | [Enabling firewall logs](enabling-firewall-logs.md) | Quick start after install, zone/rule logging, log more traffic |
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Four paths: **opkg/apk feed** (recommended for router owners), **GitHub Release** download, **feed via `src-link`** (builders), or **Docker SDK** (developers / lab).
+Most users install from the **[binary feed](#1-binary-feed-recommended)**. It needs no manual download. When the feed does not work for you, use the other methods.
 
 ## 1. Binary feed (recommended)
 
@@ -23,6 +23,11 @@ opkg update && opkg install luci-app-fwlive
 ```
 
 Use `…/23.05` for OpenWrt 23.05, `…/22.03` for **22.03.x**, `…/21.02` for legacy **21.02.x (fw3)**. For 25.12+, see the apk section in [binary-feed.md](../binary-feed.md).
+
+<details>
+<summary>Other install methods</summary>
+
+Use these methods when the binary feed does not work for you. Most users do not need them.
 
 ## 2. GitHub Release (manual download)
 
@@ -98,6 +103,8 @@ On **Linux x86_64**:
 Packages land under `out/<arch>/<version>/fwlive/`. Deploy with `scp` + `opkg`/`apk` as in section 1.
 
 For a full QEMU lab loop (build → boot → install), see [Developer: QEMU lab](../developer/qemu-lab.md).
+
+</details>
 
 ## After install
 

--- a/packages-repo/README.md
+++ b/packages-repo/README.md
@@ -8,7 +8,7 @@ Signed **opkg** / **apk** binary feed for [`luci-app-fwlive`](https://github.com
 
 **Recommended — binary feed** (`opkg` on **21.02–24.10**, `apk` on **25.12+** from GitHub Pages). Full guide: [installation](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/user/installation.md#1-binary-feed-recommended).
 
-**opkg (21.02.x – 24.10.x)** — run on the router; picks the feed for your OpenWrt release:
+**opkg (21.02.x – 24.10.x)** — run on the router. It picks the feed for your OpenWrt release:
 
 ```sh
 BASE='https://lucas-albers-lz4.github.io/fwlive-packages'
@@ -27,6 +27,9 @@ echo "src/gz fwlive $BASE/$feed" >> /etc/opkg/customfeeds.conf
 opkg update && opkg install luci-app-fwlive
 ```
 
+<details>
+<summary>apk (25.12+) and more detail</summary>
+
 **apk (25.12+)** — hardcoded example for OpenWrt **25.12**:
 
 ```sh
@@ -39,6 +42,8 @@ apk update && apk add luci-app-fwlive
 ```
 
 More detail: [binary feed](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/binary-feed.md) · per-release notes in [21.02](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/openwrt-21.02-compat.md) / [22.03](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/openwrt-22.03-compat.md) compat docs.
+
+</details>
 
 Menu after install: **Status → Firewall Live View**.
 


### PR DESCRIPTION
Fixes #113 — Stack 2/2: new-user install experience (full fold, per your direction).

**What changed**
- **docs/user/installation.md** — intro rewritten to lead with the binary feed; GitHub Release / feed via src-link / Docker SDK wrapped in an `<details>` \"Other install methods\" fold. Section headings and numbers are untouched, so every existing anchor (`#1-binary-feed-recommended`, `#2-github-release-manual-download`, `#3-feed-via-src-link-builders`, `#4-docker-sdk-developers--lab`) still resolves — verified by the anchor-validating checker from #114.
- **README.md** — Install section compresses to the recommended opkg one-liner, then folds apk / GitHub Releases / src-link under `<details>`. Added an \"After install: enable logging\" pointer right above the fold so the empty-table gotcha stays visible.
- **packages-repo/README.md** — feed landing page mirrors the fold (opkg leads, apk + detail links folded).
- **docs/user/README.md** — install row no longer lists four methods with equal weight.
- STE prose pass applied to all touched copy (semicolons removed, condition-before-command, no phrasal verbs).

**Verification**
- `./scripts/fwlive-linkcheck.sh`: 332 internal links, 0 broken (file + anchor); 19 external, 0 failed (one transient 000 on a github.com blob URL, confirmed 200 on direct probe and on re-run).
- `<details>`/\`</details>` balanced in all three folded files.

Stacked on #114 (docs/113-anchor-check) — merge #114 first, then this.