### PR TITLE
chore: add SECURITY.md disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest release on `master` for currently
+supported OpenWrt targets.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security reports.
+
+Use GitHub's private vulnerability reporting for this repository
+(**Security → Report a vulnerability**), or email the maintainer via the
+address on the GitHub profile.
+
+We aim to acknowledge reports within a few business days and will coordinate
+a fix and disclosure timeline with you.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with private vulnerability reporting guidance (housekeeping `security_repos` / `missing_security_policy`).

## Test plan
- [ ] Security policy visible under the repo Security tab

Made with [Cursor](https://cursor.com)