### PR TITLE
fix: capture log prefix/comment with escaped quotes (fixes #124)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -144,8 +144,10 @@ map_uci_rule_names() {
 
 map_from_nft_stream() {
 	while IFS= read -r line; do
-		prefix=$(echo "$line" | sed -n 's/.*log prefix "\([^"]*\)".*/\1/p')
-		comment=$(echo "$line" | sed -n 's/.*comment "\([^"]*\)".*/\1/p')
+		# Capture [^"]* plus escaped-quote units (\"...) so a log prefix or
+		# comment containing an escaped quote is not truncated at the quote.
+		prefix=$(echo "$line" | sed -n 's/.*log prefix "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
+		comment=$(echo "$line" | sed -n 's/.*comment "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
 		label=''
 
 		case "$comment" in
@@ -171,8 +173,8 @@ map_from_iptables_save_stream() {
 			-*) ;;
 			*) continue ;;
 		esac
-		prefix=$(echo "$line" | sed -n 's/.*--log-prefix "\([^"]*\)".*/\1/p')
-		comment=$(echo "$line" | sed -n 's/.*--comment "\([^"]*\)".*/\1/p')
+		prefix=$(echo "$line" | sed -n 's/.*--log-prefix "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
+		comment=$(echo "$line" | sed -n 's/.*--comment "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
 		[ -n "$prefix" ] || continue
 		map_log_prefix_entry "$prefix" "$comment"
 	done
@@ -381,6 +383,26 @@ run_selftest() {
 	fi
 	if ! is_resolvable_address '2001:db8::1'; then
 		echo 'is_resolvable_address: expected accept IPv6' >&2
+		return 1
+	fi
+
+	# Escaped-quote capture: a log prefix containing \" must not be truncated
+	# at the escaped quote (nft dumps strings with backslash escapes).
+	got=$(printf '%s\n' 'log prefix "My \" Rule"' | sed -n 's/.*log prefix "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
+	if [ "$got" != 'My \" Rule' ]; then
+		echo "escaped-quote prefix capture: expected 'My \\\" Rule' got '$got'" >&2
+		return 1
+	fi
+	# Plain prefix still captures unchanged.
+	got=$(printf '%s\n' 'log prefix "Plain Rule"' | sed -n 's/.*log prefix "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
+	if [ "$got" != 'Plain Rule' ]; then
+		echo "plain prefix capture: expected 'Plain Rule' got '$got'" >&2
+		return 1
+	fi
+	# Empty prefix edge.
+	got=$(printf '%s\n' 'log prefix ""' | sed -n 's/.*log prefix "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p')
+	if [ "$got" != '' ]; then
+		echo "empty prefix capture: expected '' got '$got'" >&2
 		return 1
 	fi
 


### PR DESCRIPTION
## fix: capture log prefix/comment with escaped quotes (fixes #124)

### The bug

The rpcd rules-map used `sed` captures of `[^"]*`:

```sh
sed -n 's/.*log prefix "\([^"]*\)".*/\1/p'
```

`[^"]*` stops at the **first** quote — escaped or not. An nft/iptables
rule whose name or comment contains an escaped quote (`\"`) was truncated
at that quote. Ground truth:

```
log prefix "My \" Rule"   -> [My \]      (was: truncated)
log prefix "a\"b\"c"      -> [a\]       (was: truncated)
```

Severity: LOW — input is admin-set `/etc/config/firewall` (nft ruleset
dump), no attacker-controlled path (per the repo-wide regexproof sweep).
This is a display/correctness bug in the LuCI rules map.

### The fix

Capture `[^"\\]*` plus escaped-char units `(\\.)`:

```sh
sed -n 's/.*log prefix "\([^"\\]*\(\\.[^"\\]*\)*\)".*/\1/p'
```

The base class excludes backslash so `\"` is consumed atomically; only the
closing **bare** quote terminates the capture. Applied to all four
extraction sites (nft `log prefix`/`comment`, iptables `--log-prefix`/
`--comment`).

### Verification

- **GNU sed and BusyBox 1.37 (OpenWrt target) produce identical output**:
  `My \" Rule` → `My \" Rule` (full), `Plain Rule` unchanged, `""` → empty.
- **Selftest** (`rpcd/fwlive __selftest`) extended with escaped-quote,
  plain, and empty-prefix cases — all pass (exit 0; jshn skip is expected
  off-device).
- **shellcheck** clean.

### Acceptance criteria

- [x] Rule name containing `\"` renders in full in the LuCI rules map
- [x] Plain and empty prefixes unchanged
