### PR TITLE
docs: remove internal-process reference from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidated planning/spec docs into ROADMAP.md
 - Restructured over-long user docs (Quick Start first)
 - Added CHANGELOG.md, FAQ.md, and upgrade guide
-- Fixed cross-reference accuracy and MCR review findings throughout
+- Fixed cross-reference accuracy and review findings throughout
 
 ---
 


### PR DESCRIPTION
## Remove internal-process reference from CHANGELOG

"Fixed cross-reference accuracy and MCR review findings throughout"
referenced the internal review workflow. Dropped the process label;
the finding content ("cross-reference accuracy … review findings")
is unchanged.

### Verification
- `rg -n -i "\bmcr\b|\bzen\b|\bbugbot\b"` across repo (excl. .git/node_modules) → 0 hits
