### PR TITLE
fix(ci): resilient feed fetch for publish-packages (#122)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -74,6 +74,18 @@ jobs:
           APK_FEED_PUBLIC_KEY: ${{ github.workspace }}/fwlive-feed.rsa.pub
         run: ./scripts/validate-feed-keys.sh
 
+      # #122: reuse feed clones + dl/ across publishes (lock hash = cache key).
+      - name: Cache SDK feeds and dl
+        uses: actions/cache@v4
+        with:
+          path: .cache/sdk-feeds
+          key: sdk-feeds-${{ runner.os }}-${{ hashFiles('scripts/feeds.lock/**') }}
+          restore-keys: |
+            sdk-feeds-${{ runner.os }}-
+
+      - name: Restore SDK feeds into docker volumes
+        run: ./scripts/ci-cache-sdk-feeds.sh restore .cache/sdk-feeds
+
       - name: Build packages (21.02, 22.03, 23.05, 24.10, 25.12)
         run: |
           mkdir -p out
@@ -81,6 +93,10 @@ jobs:
             echo "=== docker-sdk build: OpenWrt ${ver} ==="
             ./scripts/docker-sdk.sh build --target x86-64 --version "$ver"
           done
+
+      - name: Save SDK feeds from docker volumes
+        if: always()
+        run: ./scripts/ci-cache-sdk-feeds.sh save .cache/sdk-feeds
 
       - name: Verify reproducible builds
         run: ./scripts/verify-reproducible-build.sh

--- a/docs/binary-feed.md
+++ b/docs/binary-feed.md
@@ -204,10 +204,14 @@ Pinned inputs (regenerate when bumping OpenWrt point releases):
 
 | Input | Location |
 |-------|----------|
-| Feed commits | [`scripts/feeds.lock/`](../scripts/feeds.lock/) per SDK version |
+| Feed commits | [`scripts/feeds.lock/`](../scripts/feeds.lock/) per SDK version (GitHub mirrors of git.openwrt.org; pinned SHAs unchanged) |
 | SDK image tag | [`scripts/lib/sdk-matrix.sh`](../scripts/lib/sdk-matrix.sh) |
 | Package version | `PKG_VERSION` / `PKG_RELEASE` in package Makefile |
 | Timestamps | `SOURCE_DATE_EPOCH` (git commit epoch; set in CI on release tag) |
+
+Publish CI (`publish-packages`) retries `feeds update` (3× + HTTP/1.1) and caches
+`/builder/feeds` + `/builder/dl` across runs (`scripts/ci-cache-sdk-feeds.sh`,
+keyed on the feeds.lock tree) so a transient TLS drop does not fail a release.
 
 Verify locally:
 

--- a/scripts/ci-cache-sdk-feeds.sh
+++ b/scripts/ci-cache-sdk-feeds.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Persist OpenWrt SDK feed clones + dl/ across GitHub Actions runs (#122).
+#
+# Named docker volumes are empty on every fresh runner; this caches only the
+# heavy network-fetched trees (feeds + dl), not the full toolchain, keyed from
+# the workflow via hashFiles('scripts/feeds.lock/**').
+#
+# Usage:
+#   ./scripts/ci-cache-sdk-feeds.sh restore <cache-dir>
+#   ./scripts/ci-cache-sdk-feeds.sh save <cache-dir>
+#
+# Volumes covered: x86-64 publish matrix (21.02 … 25.12).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/sdk-matrix.sh
+source "$ROOT/scripts/lib/sdk-matrix.sh"
+
+ci_cache_publish_volumes() {
+	local ver vol
+	for ver in 21.02 22.03 23.05 24.10 25.12; do
+		sdk_matrix_resolve x86-64 "$ver"
+		printf '%s\n' "$SDK_MATRIX_VOLUME"
+	done
+}
+
+ci_cache_ensure_volume() {
+	docker volume inspect "$1" >/dev/null 2>&1 || docker volume create "$1" >/dev/null
+}
+
+ci_cache_restore() {
+	local cache_dir="$1" vol src
+	[[ -d "$cache_dir" ]] || {
+		echo "ci-cache-sdk-feeds: no cache dir at $cache_dir (cold start)" >&2
+		return 0
+	}
+	while IFS= read -r vol; do
+		src="${cache_dir}/${vol}"
+		[[ -d "$src" ]] || continue
+		ci_cache_ensure_volume "$vol"
+		echo "ci-cache-sdk-feeds: restore $vol" >&2
+		docker run --rm \
+			-v "${vol}:/builder" \
+			-v "${src}:/cache:ro" \
+			alpine:3.20 \
+			sh -ec '
+				mkdir -p /builder/dl /builder/feeds
+				if [ -d /cache/dl ]; then cp -a /cache/dl/. /builder/dl/; fi
+				if [ -d /cache/feeds ]; then cp -a /cache/feeds/. /builder/feeds/; fi
+			'
+	done < <(ci_cache_publish_volumes)
+}
+
+ci_cache_save() {
+	local cache_dir="$1" vol dest
+	mkdir -p "$cache_dir"
+	while IFS= read -r vol; do
+		docker volume inspect "$vol" >/dev/null 2>&1 || continue
+		dest="${cache_dir}/${vol}"
+		rm -rf "$dest"
+		mkdir -p "$dest"
+		echo "ci-cache-sdk-feeds: save $vol" >&2
+		docker run --rm \
+			-v "${vol}:/builder:ro" \
+			-v "${dest}:/cache" \
+			alpine:3.20 \
+			sh -ec '
+				if [ -d /builder/dl ]; then cp -a /builder/dl /cache/; fi
+				if [ -d /builder/feeds ]; then cp -a /builder/feeds /cache/; fi
+			'
+	done < <(ci_cache_publish_volumes)
+}
+
+main() {
+	local cmd="${1:-}" cache_dir="${2:-}"
+	[[ -n "$cmd" && -n "$cache_dir" ]] || {
+		echo "usage: $0 restore|save <cache-dir>" >&2
+		return 2
+	}
+	case "$cmd" in
+		restore) ci_cache_restore "$cache_dir" ;;
+		save) ci_cache_save "$cache_dir" ;;
+		*)
+			echo "unknown command: $cmd (expected restore|save)" >&2
+			return 2
+			;;
+	esac
+}
+
+main "$@"

--- a/scripts/feeds.lock/21.02.7/feeds.conf
+++ b/scripts/feeds.lock/21.02.7/feeds.conf
@@ -1,8 +1,9 @@
 # Pinned feeds for OpenWrt 21.02.7 SDK (from ghcr.io/openwrt/sdk:x86-64-21.02.7 feeds.conf.default).
 # Regenerate when bumping the 21.02 point release — see docs/binary-feed.md.
-src-git base https://git.openwrt.org/openwrt/openwrt.git;v21.02.7
-src-git-full packages https://git.openwrt.org/feed/packages.git^48242ee7a190db7740f7b9b3ef1debfa4d5857f6
-src-git-full luci https://git.openwrt.org/project/luci.git^e98243ef9eb838cca80cdd6d1bd0cf69a509d103
-src-git-full routing https://git.openwrt.org/feed/routing.git^8071852b4556a02533cacb7a0f6a432df3507302
-src-git-full telephony https://git.openwrt.org/feed/telephony.git^920fbc5c0a2e4badf51bceff42e9a1e3eb693462
+# Feed URLs use GitHub mirrors of git.openwrt.org (CI TLS resilience; same SHAs).
+src-git base https://github.com/openwrt/openwrt.git;v21.02.7
+src-git packages https://github.com/openwrt/packages.git^48242ee7a190db7740f7b9b3ef1debfa4d5857f6
+src-git luci https://github.com/openwrt/luci.git^e98243ef9eb838cca80cdd6d1bd0cf69a509d103
+src-git routing https://github.com/openwrt/routing.git^8071852b4556a02533cacb7a0f6a432df3507302
+src-git telephony https://github.com/openwrt/telephony.git^920fbc5c0a2e4badf51bceff42e9a1e3eb693462
 src-link fwlive /work/fwlive/openwrt-feed

--- a/scripts/feeds.lock/22.03.7/feeds.conf
+++ b/scripts/feeds.lock/22.03.7/feeds.conf
@@ -1,8 +1,9 @@
 # Pinned feeds for OpenWrt 22.03.7 SDK (from ghcr.io/openwrt/sdk:x86-64-22.03.7 feeds.conf.default).
 # Regenerate when bumping the 22.03 point release — see docs/binary-feed.md.
-src-git base https://git.openwrt.org/openwrt/openwrt.git;openwrt-22.03
-src-git-full packages https://git.openwrt.org/feed/packages.git^3b79b05673a15e7f41f157d1320597244a344a95
-src-git-full luci https://git.openwrt.org/project/luci.git^374888b1476df064281022c4d605b7ecf9e684e4
-src-git-full routing https://git.openwrt.org/feed/routing.git^1ff9ee61cde0829f206f275b1b2f5fa990fd2ba9
-src-git-full telephony https://git.openwrt.org/feed/telephony.git^2a69b3a6f0a42c7fa965a72f9a1361cb94a1ce86
+# Feed URLs use GitHub mirrors of git.openwrt.org (CI TLS resilience; same SHAs).
+src-git base https://github.com/openwrt/openwrt.git;openwrt-22.03
+src-git packages https://github.com/openwrt/packages.git^3b79b05673a15e7f41f157d1320597244a344a95
+src-git luci https://github.com/openwrt/luci.git^374888b1476df064281022c4d605b7ecf9e684e4
+src-git routing https://github.com/openwrt/routing.git^1ff9ee61cde0829f206f275b1b2f5fa990fd2ba9
+src-git telephony https://github.com/openwrt/telephony.git^2a69b3a6f0a42c7fa965a72f9a1361cb94a1ce86
 src-link fwlive /work/fwlive/openwrt-feed

--- a/scripts/feeds.lock/23.05.5/feeds.conf
+++ b/scripts/feeds.lock/23.05.5/feeds.conf
@@ -1,8 +1,9 @@
 # Pinned feeds for OpenWrt 23.05.5 SDK (from ghcr.io/openwrt/sdk:x86-64-23.05.5 feeds.conf.default).
 # Regenerate when bumping the 23.05 point release — see docs/binary-feed.md.
-src-git-full base https://git.openwrt.org/openwrt/openwrt.git;openwrt-23.05
-src-git packages https://git.openwrt.org/feed/packages.git^b5ed85f6e94aa08de1433272dc007550f4a28201
-src-git luci https://git.openwrt.org/project/luci.git^63ba3cba5b7bfb803a875d4d8f01248634687fd5
-src-git routing https://git.openwrt.org/feed/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
-src-git telephony https://git.openwrt.org/feed/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
+# Feed URLs use GitHub mirrors of git.openwrt.org (CI TLS resilience; same SHAs).
+src-git-full base https://github.com/openwrt/openwrt.git;openwrt-23.05
+src-git packages https://github.com/openwrt/packages.git^b5ed85f6e94aa08de1433272dc007550f4a28201
+src-git luci https://github.com/openwrt/luci.git^63ba3cba5b7bfb803a875d4d8f01248634687fd5
+src-git routing https://github.com/openwrt/routing.git^e351d1e623e9ef2ab78f28cb1ce8d271d28c902d
+src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
 src-link fwlive /work/fwlive/openwrt-feed

--- a/scripts/feeds.lock/24.10.5/feeds.conf
+++ b/scripts/feeds.lock/24.10.5/feeds.conf
@@ -1,8 +1,9 @@
 # Pinned feeds for OpenWrt 24.10.5 SDK (from ghcr.io/openwrt/sdk:x86-64-24.10.5 feeds.conf.default).
 # Regenerate when bumping the 24.10 point release — see docs/binary-feed.md.
-src-git-full base https://git.openwrt.org/openwrt/openwrt.git;v24.10.5
-src-git packages https://git.openwrt.org/feed/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206
-src-git luci https://git.openwrt.org/project/luci.git^d88390be4ec9722cb427fee03368fc8c8582627d
-src-git routing https://git.openwrt.org/feed/routing.git^178a40d321d6c11f18528f34777f4e24ce62b19a
-src-git telephony https://git.openwrt.org/feed/telephony.git^92892fa285360b8981f62bf4e0a097e6449e7e33
+# Feed URLs use GitHub mirrors of git.openwrt.org (CI TLS resilience; same SHAs).
+src-git-full base https://github.com/openwrt/openwrt.git;v24.10.5
+src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206
+src-git luci https://github.com/openwrt/luci.git^d88390be4ec9722cb427fee03368fc8c8582627d
+src-git routing https://github.com/openwrt/routing.git^178a40d321d6c11f18528f34777f4e24ce62b19a
+src-git telephony https://github.com/openwrt/telephony.git^92892fa285360b8981f62bf4e0a097e6449e7e33
 src-link fwlive /work/fwlive/openwrt-feed

--- a/scripts/feeds.lock/25.12.0/feeds.conf
+++ b/scripts/feeds.lock/25.12.0/feeds.conf
@@ -1,9 +1,10 @@
 # Pinned feeds for OpenWrt 25.12.0 SDK (from ghcr.io/openwrt/sdk:x86-64-25.12.0 feeds.conf.default).
 # Regenerate when bumping the 25.12 point release — see docs/binary-feed.md.
-src-git --root=package base https://git.openwrt.org/openwrt/openwrt.git^4da53efc2fe744601e6189492dbd06b8930d72b8
-src-git packages https://git.openwrt.org/feed/packages.git^506c37591d7cd9b3cfd812e69e708349268f9865
-src-git luci https://git.openwrt.org/project/luci.git^27a9c0c94264063894d40420956696d19b175744
-src-git routing https://git.openwrt.org/feed/routing.git^662b57dff7d20634f2b8676400cf4299611cfe4b
-src-git telephony https://git.openwrt.org/feed/telephony.git^2618106d5846a4a542fdf5809f0d3ed228ce439b
+# Feed URLs use GitHub mirrors of git.openwrt.org (CI TLS resilience; same SHAs).
+src-git --root=package base https://github.com/openwrt/openwrt.git^4da53efc2fe744601e6189492dbd06b8930d72b8
+src-git packages https://github.com/openwrt/packages.git^506c37591d7cd9b3cfd812e69e708349268f9865
+src-git luci https://github.com/openwrt/luci.git^27a9c0c94264063894d40420956696d19b175744
+src-git routing https://github.com/openwrt/routing.git^662b57dff7d20634f2b8676400cf4299611cfe4b
+src-git telephony https://github.com/openwrt/telephony.git^2618106d5846a4a542fdf5809f0d3ed228ce439b
 src-git video https://github.com/openwrt/video.git^094bf58da6682f895255a35a84349a79dab4bf95
 src-link fwlive /work/fwlive/openwrt-feed

--- a/scripts/feeds.lock/snapshot/feeds.conf
+++ b/scripts/feeds.lock/snapshot/feeds.conf
@@ -1,9 +1,10 @@
 # Snapshot SDK uses rolling feeds — same pins as 25.12.0 until refreshed manually.
 # Regenerate from: docker run --rm ghcr.io/openwrt/sdk:armsr-armv8 cat feeds.conf.default
-src-git --root=package base https://git.openwrt.org/openwrt/openwrt.git^4da53efc2fe744601e6189492dbd06b8930d72b8
-src-git packages https://git.openwrt.org/feed/packages.git^506c37591d7cd9b3cfd812e69e708349268f9865
-src-git luci https://git.openwrt.org/project/luci.git^27a9c0c94264063894d40420956696d19b175744
-src-git routing https://git.openwrt.org/feed/routing.git^662b57dff7d20634f2b8676400cf4299611cfe4b
-src-git telephony https://git.openwrt.org/feed/telephony.git^2618106d5846a4a542fdf5809f0d3ed228ce439b
+# Feed URLs use GitHub mirrors of git.openwrt.org (CI TLS resilience; same SHAs).
+src-git --root=package base https://github.com/openwrt/openwrt.git^4da53efc2fe744601e6189492dbd06b8930d72b8
+src-git packages https://github.com/openwrt/packages.git^506c37591d7cd9b3cfd812e69e708349268f9865
+src-git luci https://github.com/openwrt/luci.git^27a9c0c94264063894d40420956696d19b175744
+src-git routing https://github.com/openwrt/routing.git^662b57dff7d20634f2b8676400cf4299611cfe4b
+src-git telephony https://github.com/openwrt/telephony.git^2618106d5846a4a542fdf5809f0d3ed228ce439b
 src-git video https://github.com/openwrt/video.git^094bf58da6682f895255a35a84349a79dab4bf95
 src-link fwlive /work/fwlive/openwrt-feed

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -108,7 +108,7 @@ feed_publish_ensure_usign() {
 	echo "→ building usign (one-time)..." >&2
 	mkdir -p "$build_dir"
 	if [[ ! -d "${build_dir}/src/.git" ]]; then
-		git clone --depth 1 https://git.openwrt.org/project/usign.git "${build_dir}/src"
+		git clone --depth 1 https://github.com/openwrt/usign.git "${build_dir}/src"
 	fi
 	make -C "${build_dir}/src" -j"$(nproc 2>/dev/null || echo 2)" >/dev/null
 	ln -sf "${build_dir}/src/usign" "${build_dir}/usign"

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -145,6 +145,8 @@ sdk_matrix_feeds_setup() {
 		echo "missing pinned feeds lock: $lock_path" >&2
 		return 1
 	}
+	# Retry feeds update: git.openwrt.org (and mirrors) drop TLS under CI load.
+	# HTTP/1.1 reduces curl-35 / gnutls_handshake failures (openwrt/openwrt#21854).
 	sdk_matrix_compose_run sh -ec "
 		cd /builder
 		export TERM=dumb
@@ -154,7 +156,19 @@ sdk_matrix_feeds_setup() {
 		cp /work/fwlive/scripts/feeds.lock/${SDK_MATRIX_VERSION_LABEL}/feeds.conf feeds.conf
 		grep -q '^src-link fwlive' feeds.conf || echo 'src-link fwlive /work/fwlive/openwrt-feed' >> feeds.conf
 
-		./scripts/feeds update base luci packages
+		git config --global http.version HTTP/1.1 || true
+
+		ok=0
+		for i in 1 2 3; do
+			if ./scripts/feeds update base luci packages; then
+				ok=1
+				break
+			fi
+			echo \"feeds update attempt \$i failed; retrying in \$((i * 5))s...\" >&2
+			sleep \$((i * 5))
+		done
+		test \"\$ok\" -eq 1
+
 		./scripts/feeds install -p base ${base_pkgs}
 		./scripts/feeds install luci-base
 		./scripts/feeds update fwlive


### PR DESCRIPTION
## Summary
Fixes #122 — same latent TLS/feed-fetch risk usrmanage hit on `git.openwrt.org`.

- **Mirrors:** all `scripts/feeds.lock/*/feeds.conf` URLs → GitHub (`openwrt/{openwrt,packages,luci,routing,telephony}`); pinned SHAs unchanged; 21.02/22.03 `src-git-full` → `src-git`.
- **Retry:** `sdk_matrix_feeds_setup` sets `git config http.version HTTP/1.1` and retries `./scripts/feeds update base luci packages` 3× with backoff.
- **Cache:** `scripts/ci-cache-sdk-feeds.sh` + `actions/cache` on `.cache/sdk-feeds` keyed by `hashFiles('scripts/feeds.lock/**')` persists `/builder/feeds` + `/builder/dl` for the x86-64 publish matrix.
- **usign:** build clone also uses `github.com/openwrt/usign`.

## Test plan
- [x] `./scripts/fwlive-test.sh` green
- [x] Pin SHAs identical before/after mirror swap
- [ ] `publish-packages` workflow_dispatch on next release / dry tag when convenient
- [ ] Second publish with same lock hits cache restore (no full re-clone)


Made with [Cursor](https://cursor.com)