### PR TITLE
docs: security model, agent orientation, and repeatable audit playbook

### DIFF
--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -24,38 +24,23 @@ backend has held up under audit.
 
 ## Verified facts — do not re-derive
 
-These were confirmed against upstream source. Trust them; re-verify only if
-upstream changed.
+The facts themselves live in the security model; this section only records **how
+to re-confirm them** if upstream changed. Read
+[`security-model.md`](../../../docs/developer/security-model.md) first — do not
+re-reason about trust boundaries from source.
 
-**LuCI `E()` renders bare string children as HTML.** `dom.append` appends array
-children via `createTextNode` but assigns bare strings to `innerHTML`. So
-`E('td', attrs, str)` is an HTML sink and `E('td', attrs, [ str ])` is not. This
-is the single most important fact for auditing this repo.
+| Fact | Re-verification |
+|------|-----------------|
+| LuCI `E()` assigns bare string children to `innerHTML`; only array children become text nodes | `curl -sS https://raw.githubusercontent.com/openwrt/luci/openwrt-24.10/modules/luci-base/htdocs/luci-static/resources/luci.js \| rg -n "innerHTML" -B 20` |
+| `logd` chmods its socket `0666`, so any local UID can inject syslog lines | `curl -sS https://raw.githubusercontent.com/openwrt/ubox/master/log/syslog.c \| rg -n "chmod"` |
+| Netfilter values parse as `[^\s]+`, so whitespace-free content survives intact | `rg -n "A-Z\]\+\)=" openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js` |
 
-Re-verify with:
+Time-savers learned the hard way:
 
-```sh
-curl -sS https://raw.githubusercontent.com/openwrt/luci/openwrt-24.10/modules/luci-base/htdocs/luci-static/resources/luci.js \
-  | rg -n "innerHTML" -B 20
-```
-
-Note `dom.js` does not exist on that branch — `dom` lives inside `luci.js`.
-
-**Any local process can inject syslog lines.** `logd` chmods its socket `0666`:
-
-```sh
-curl -sS https://raw.githubusercontent.com/openwrt/ubox/master/log/syslog.c | rg -n "chmod"
-```
-
-So firewall log content is untrusted input from *any* UID, not just root.
-
-**Netfilter values are parsed as `[^\s]+`.** `parseKeyValueLog` in
-`fwlive/log.js` — any whitespace-free payload survives into `interface_in`,
-`sport`, `dport`, `proto`, `flags`.
-
-**Host tests cannot see rendering bugs.** `tests/lib/load-fwlive-module.js`
-stubs `E()` as a non-rendering object (`fakeE`). Structural assertions pass
-regardless of encoding. Use the harness below instead.
+- `dom.js` does **not** exist on the `openwrt-24.10` branch — `dom` lives inside
+  `luci.js`. Fetching `dom.js` returns 404 and wastes a round trip.
+- Renderer tests do not render, so a green suite proves nothing about encoding —
+  [build-and-test.md § Renderer tests do not render](../../../docs/developer/build-and-test.md#renderer-tests-do-not-render).
 
 ## Step 1 — frontend rendering sinks
 
@@ -110,11 +95,9 @@ turns into a permanent regression test — check whether it already exists in
 
 ## Step 3 — rpcd plugin and ACL
 
-Read `root/usr/libexec/rpcd/fwlive` end to end; it is short. Check that the
-invariants in the security model still hold: shape-validated addresses, clamped
-line counts, `json_escape` on all string content, no `log.read` in the ACL, read
-and write methods in separate scopes, and CLI-only `__` methods absent from
-`list`.
+Read `root/usr/libexec/rpcd/fwlive` end to end; it is short. Walk the invariants
+in [`security-model.md`](../../../docs/developer/security-model.md) and confirm
+each still holds, plus that CLI-only `__` methods stay absent from `list`.
 
 ```sh
 node tests/fwlive-rpcd-security.test.js
@@ -184,11 +167,14 @@ gh api /repos/{owner}/{repo}/security-advisories --jq '.[] | "\(.ghsa_id) \(.sta
 
 ## Known-good — do not re-litigate without new evidence
 
-Audited and sound: `is_resolvable_address` metacharacter rejection,
-`poll_lines_from_input` clamping, `json_escape` C0 handling, log messages passed
-as stdin data, ACL read/write split, `__rulesmap_iptables` fixed-path guard, WAN
-log bit-0-only manipulation with UCI rollback, and secret-key file permissions
-plus gitignore coverage.
+Invariants 2–7 in [`security-model.md`](../../../docs/developer/security-model.md)
+were each audited and found correctly implemented, as were the
+`__rulesmap_iptables` fixed-path guard, the WAN-log bit-0-only manipulation with
+UCI rollback, and secret-key file permissions plus gitignore coverage.
+
+Re-examine them only with new evidence — a code change in the area, or a concrete
+bypass. Spending the pass re-reading known-good shell is the main way an audit
+runs out of time before reaching the frontend.
 
 Open items are tracked as issues — check them before re-reporting:
 

--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -53,7 +53,11 @@ rg -n "E\('[a-z]+',\s*(\{[^}]*\}|null),\s*[A-Za-z_$][A-Za-z0-9_.$]*(\(|\)|,|\s*\
 ```
 
 Then confirm which of those carry untrusted data by tracing the argument back to
-`normalizeEntry`, the hostname cache, or the filter state. Also check direct
+`normalizeEntry`, the hostname cache, or the filter state. The regex matches
+bare identifiers. This includes **array-typed variables**, which are safe.
+For example, `E(..., parts)` where `parts = []` creates text nodes. Trace the
+identifier declaration first. Only string-typed or function-call third
+arguments are candidates. Also check direct
 sinks:
 
 ```sh

--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: security-audit
+description: Audit the fwlive repository for security issues — LuCI frontend injection sinks, the root rpcd plugin, shell helpers, and the signing/release pipeline. Use when the user asks for a security audit, security review, threat model, or hardening pass on this repo, or asks whether log data is safely rendered.
+---
+
+# fwlive security audit
+
+Repeatable audit procedure. Read
+[`docs/developer/security-model.md`](../../../docs/developer/security-model.md)
+for the trust boundaries and invariants; this file is the *how*.
+
+## Order of work
+
+Highest yield first. The frontend is where the exploitable bugs live; the
+backend has held up under audit.
+
+```
+- [ ] 1. Frontend rendering sinks (E() string children)
+- [ ] 2. Untrusted-input trace (log fields, PTR, URL hash, UCI)
+- [ ] 3. rpcd plugin + ACL scope
+- [ ] 4. Shell helpers (injection, quoting)
+- [ ] 5. Release pipeline (secrets, pinning, temp paths)
+```
+
+## Verified facts — do not re-derive
+
+These were confirmed against upstream source. Trust them; re-verify only if
+upstream changed.
+
+**LuCI `E()` renders bare string children as HTML.** `dom.append` appends array
+children via `createTextNode` but assigns bare strings to `innerHTML`. So
+`E('td', attrs, str)` is an HTML sink and `E('td', attrs, [ str ])` is not. This
+is the single most important fact for auditing this repo.
+
+Re-verify with:
+
+```sh
+curl -sS https://raw.githubusercontent.com/openwrt/luci/openwrt-24.10/modules/luci-base/htdocs/luci-static/resources/luci.js \
+  | rg -n "innerHTML" -B 20
+```
+
+Note `dom.js` does not exist on that branch — `dom` lives inside `luci.js`.
+
+**Any local process can inject syslog lines.** `logd` chmods its socket `0666`:
+
+```sh
+curl -sS https://raw.githubusercontent.com/openwrt/ubox/master/log/syslog.c | rg -n "chmod"
+```
+
+So firewall log content is untrusted input from *any* UID, not just root.
+
+**Netfilter values are parsed as `[^\s]+`.** `parseKeyValueLog` in
+`fwlive/log.js` — any whitespace-free payload survives into `interface_in`,
+`sport`, `dport`, `proto`, `flags`.
+
+**Host tests cannot see rendering bugs.** `tests/lib/load-fwlive-module.js`
+stubs `E()` as a non-rendering object (`fakeE`). Structural assertions pass
+regardless of encoding. Use the harness below instead.
+
+## Step 1 — frontend rendering sinks
+
+Find `E()` calls whose third argument is a bare identifier or expression rather
+than an array:
+
+```sh
+rg -n "E\('[a-z]+',\s*(\{[^}]*\}|null),\s*[A-Za-z_$][A-Za-z0-9_.$]*(\(|\)|,|\s*\|\||$)" \
+  openwrt-feed/luci-app-fwlive/htdocs
+```
+
+Then confirm which of those carry untrusted data by tracing the argument back to
+`normalizeEntry`, the hostname cache, or the filter state. Also check direct
+sinks:
+
+```sh
+rg -n "innerHTML|insertAdjacentHTML|outerHTML|document\.write|eval\(|new Function" \
+  openwrt-feed/luci-app-fwlive/htdocs
+```
+
+`host.innerHTML = ''` to clear a container is fine. Anything with a non-empty
+right-hand side is not.
+
+Confirm there is still no escaping helper:
+
+```sh
+rg -n "escapeHtml|sanitiz|textContent" openwrt-feed/luci-app-fwlive/htdocs
+```
+
+## Step 2 — prove it with a rendering harness
+
+Do not assert an XSS finding from reading code. Build a harness that loads the
+real modules against an `E()` that is a **verbatim port** of LuCI
+`dom.create`/`dom.append`, with a `Node` class whose `innerHTML` **setter
+records every write**. Then render a crafted row and assert no recorded write
+contains `<`.
+
+Essentials:
+
+- Reuse `loadFwliveModule` from `tests/lib/load-fwlive-module.js`, passing the
+  real `E` via `deps` so `log`, `links`, `table`, and `chips` all share it.
+- Use a **whitespace-free** payload such as `<svg/onload=PWNED>`; anything with
+  spaces gets split by the `[^\s]+` field parser and truncated mid-payload.
+- Cover the default Simple view columns (`constants.js` `COLUMN_SETS.simple`),
+  not just Detailed — a finding that needs a view toggle is weaker.
+- Exercise all three input paths: a crafted log message, a `!`-prefixed filter
+  value (URL hash), and a populated hostname cache.
+
+This is the same harness [#138](https://github.com/lucas-albers-lz4/fwlive/issues/138)
+turns into a permanent regression test — check whether it already exists in
+`tests/` before writing a throwaway.
+
+## Step 3 — rpcd plugin and ACL
+
+Read `root/usr/libexec/rpcd/fwlive` end to end; it is short. Check that the
+invariants in the security model still hold: shape-validated addresses, clamped
+line counts, `json_escape` on all string content, no `log.read` in the ACL, read
+and write methods in separate scopes, and CLI-only `__` methods absent from
+`list`.
+
+```sh
+node tests/fwlive-rpcd-security.test.js
+sh openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive __selftest
+```
+
+## Step 4 — shell helpers
+
+```sh
+./scripts/fwlive-shellcheck.sh
+rg -n "eval|\\\$\(.*\\\$[A-Za-z_]|>\s*/tmp/|mktemp" openwrt-feed/luci-app-fwlive/root scripts
+```
+
+Look for log content reaching a command string, and for fixed `/tmp` paths that
+are read or executed rather than created with `mktemp`.
+
+## Step 5 — release pipeline
+
+```sh
+rg -n "uses:|\\\$\{\{" .github/workflows
+rg -n "curl|chmod \+x|PATH=" scripts/lib/feed-publish.sh
+```
+
+Check for: workflow inputs interpolated into `run:` blocks, actions pinned by
+mutable tag (especially any step receiving a secret), fetched-and-executed
+helpers without a checksum, predictable temp paths in the signing path, and
+whether any secret can reach `feed-staging/`.
+
+Confirm key files stay ignored:
+
+```sh
+git check-ignore -v opkg-secret.key apk-secret.rsa public.key fwlive-feed.rsa.pub
+```
+
+## Severity calibration
+
+Judge by who can reach it, not by sink class alone.
+
+| Severity | Bar |
+|----------|-----|
+| High | Unauthenticated or unprivileged-local attacker reaches an admin session or root |
+| Medium | Requires a shared host, a maintainer mistake, or a narrow race |
+| Low | Requires an authenticated session already holding the relevant ACL, or write access to the repo |
+
+Anything reachable in the **default** Simple view with no interaction ranks
+above something needing a view toggle or a settings change.
+
+## Reporting
+
+`SECURITY.md` prohibits public issues for vulnerabilities. Split the output:
+
+- **Exploitable vulnerability** → private draft advisory:
+  `gh api --method POST /repos/{owner}/{repo}/security-advisories --input advisory.json`
+  (needs `summary`, `description`, and `severity` or `cvss_vector_string`).
+  Optionally add a public tracking issue describing the *invariant* and files to
+  sweep, with no payloads or injection path.
+- **Hardening** → public issue, one atomic issue per fix, labels `security`
+  and/or `supply-chain`.
+
+Verify the advisory landed as `state=draft` before reporting success, and check
+for duplicates — the create call returns compact JSON, so a filter expecting
+spaces after colons will match nothing and look like a failure:
+
+```sh
+gh api /repos/{owner}/{repo}/security-advisories --jq '.[] | "\(.ghsa_id) \(.state)"'
+```
+
+## Known-good — do not re-litigate without new evidence
+
+Audited and sound: `is_resolvable_address` metacharacter rejection,
+`poll_lines_from_input` clamping, `json_escape` C0 handling, log messages passed
+as stdin data, ACL read/write split, `__rulesmap_iptables` fixed-path guard, WAN
+log bit-0-only manipulation with UCI rollback, and secret-key file permissions
+plus gitignore coverage.
+
+Open items are tracked as issues — check them before re-reporting:
+
+```sh
+gh issue list --label security --label supply-chain --state open
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+Orientation for coding agents working in this repository. Humans should start at
+[`README.md`](README.md) and the [developer guide](docs/developer/README.md).
+
+## What this is
+
+`luci-app-fwlive` — a LuCI JavaScript app that renders a live table of firewall
+LOG events on OpenWrt. Pure client-side JS plus a small root rpcd plugin and
+shell helpers. No Lua, no custom daemon, no build step for the shipped JS.
+
+The shipped surface is small: everything under
+`openwrt-feed/luci-app-fwlive/`. The rest of the repo is docs, tests, and lab
+tooling.
+
+## Hard invariants
+
+Violating any of these breaks CI or ships a security regression.
+
+**Parser sync.** `core/fwlive-log.js` is the source of truth for
+`CLASSIFY_SPEC`. The LuCI copy in
+`openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js` must
+mirror it exactly. After changing classification, edit **both**, then run
+`./scripts/gen-all.sh` and commit the regenerated shell classifier.
+`gen-luci-wrapper.js` is a gate, not a generator — it will not fix drift for you.
+
+**Generated files.** `root/usr/libexec/fwlive-is-firewall-event.sh` is generated.
+Never hand-edit it. SDK package builds do not run Node, which is why it is
+committed.
+
+**Output encoding.** LuCI's `E(tag, attrs, str)` assigns bare string children to
+`innerHTML`; only array children become text nodes. Always write
+`E(tag, attrs, [ value ])`. Log data, reverse-DNS hostnames, URL-hash filter
+values, and UCI values are all untrusted — see
+[security model](docs/developer/security-model.md).
+
+**ACL scope.** Never grant `ubus log.read` to sessions. The rpcd plugin performs
+privileged log reads as root and returns filtered output. Read methods and
+state-changing methods stay in separate ACL scopes.
+
+**Version sync.** `PKG_VERSION` in the package `Makefile` and `APP_VERSION` in
+`fwlive/constants.js` must match.
+
+## Commands
+
+```sh
+npm test                          # ./scripts/fwlive-test.sh — parser, shell parity, codegen freshness, rpcd security
+./scripts/fwlive-linkcheck.sh     # markdown links + heading anchors + external URLs
+./scripts/validate-baseline.sh    # pre-release gate
+./scripts/gen-all.sh              # regenerate shell classifier, verify LuCI wrapper
+```
+
+Tests are host-only and need no router. UI changes still need a QEMU check —
+see [qemu-lab.md](docs/developer/qemu-lab.md).
+
+Docs changes must pass the link checker: it validates relative paths **and**
+heading anchors against a GitHub-style slugger.
+
+## Testing gotcha
+
+`tests/lib/load-fwlive-module.js` stubs `E()` as a plain object that never
+renders. Renderer tests assert on descriptive objects, so **no existing test can
+observe a DOM injection bug**. When touching renderers, verify through a
+LuCI-accurate `E()` harness — recipe in
+`.cursor/skills/security-audit/SKILL.md`.
+
+## Security work
+
+Read [`docs/developer/security-model.md`](docs/developer/security-model.md) for
+trust boundaries and invariants. For an audit, use the `security-audit` skill in
+`.cursor/skills/` — it carries verified upstream facts, the grep patterns, and
+severity/disclosure rules, so it avoids re-deriving known-good ground.
+
+Vulnerabilities go to a **private advisory**, never a public issue
+([`SECURITY.md`](SECURITY.md)). Hardening items are normal public issues.
+
+## Conventions
+
+- Small changes, one behavior each; see
+  [contributing.md](docs/developer/contributing.md)
+- Tabs for indentation in shell and the shipped JS (match surrounding code)
+- Comments explain constraints the code cannot show — not what the next line does
+- Keep user docs free of QEMU/SDK detail; keep developer docs free of marketing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,64 @@
 # AGENTS.md
 
-Orientation for coding agents working in this repository. Humans should start at
-[`README.md`](README.md) and the [developer guide](docs/developer/README.md).
+Router for coding agents. Every rule below is stated once, in the document
+linked beside it — **read the link before acting on the rule**, and change the
+canonical document rather than this file when a rule evolves.
+
+Humans should start at [`README.md`](README.md) and the
+[developer guide](docs/developer/README.md).
 
 ## What this is
 
-`luci-app-fwlive` — a LuCI JavaScript app that renders a live table of firewall
-LOG events on OpenWrt. Pure client-side JS plus a small root rpcd plugin and
-shell helpers. No Lua, no custom daemon, no build step for the shipped JS.
+`luci-app-fwlive` — a LuCI JavaScript app rendering a live table of firewall LOG
+events on OpenWrt. Client-side JS plus a small root rpcd plugin and shell
+helpers. No Lua, no daemon, no build step for the shipped JS.
 
-The shipped surface is small: everything under
-`openwrt-feed/luci-app-fwlive/`. The rest of the repo is docs, tests, and lab
-tooling.
+The shipped surface is everything under `openwrt-feed/luci-app-fwlive/`; the rest
+is docs, tests, and lab tooling. Layout:
+[developer guide § Repository map](docs/developer/README.md#repository-map).
 
 ## Hard invariants
 
-Violating any of these breaks CI or ships a security regression.
+Breaking any of these fails CI or ships a security regression.
 
-**Parser sync.** `core/fwlive-log.js` is the source of truth for
-`CLASSIFY_SPEC`. The LuCI copy in
-`openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js` must
-mirror it exactly. After changing classification, edit **both**, then run
-`./scripts/gen-all.sh` and commit the regenerated shell classifier.
-`gen-luci-wrapper.js` is a gate, not a generator — it will not fix drift for you.
+| Rule | Canonical source |
+|------|------------------|
+| Untrusted values reach the DOM as text nodes, never an HTML sink | [security-model.md § Invariants](docs/developer/security-model.md#invariants) |
+| Log content, hostnames, URL-hash values, and UCI values are all untrusted | [security-model.md § Untrusted input inventory](docs/developer/security-model.md#untrusted-input-inventory) |
+| `CLASSIFY_SPEC` edits go in `core/` **and** the LuCI mirror, then `gen-all.sh` | [contributing.md § Parser sync / codegen](docs/developer/contributing.md#parser-sync--codegen) |
+| Never hand-edit generated files (shell classifier, `css.js`) | [contributing.md § Parser sync / codegen](docs/developer/contributing.md#parser-sync--codegen), [build-and-test.md](docs/developer/build-and-test.md) |
+| Sessions never get `ubus log.read`; read and write ACL scopes stay separate | [security-model.md § Invariants](docs/developer/security-model.md#invariants) |
+| `PKG_VERSION` and `APP_VERSION` must match | [contributing.md § Feed / package changes](docs/developer/contributing.md#feed--package-changes) |
 
-**Generated files.** `root/usr/libexec/fwlive-is-firewall-event.sh` is generated.
-Never hand-edit it. SDK package builds do not run Node, which is why it is
-committed.
+## Before you start
 
-**Output encoding.** LuCI's `E(tag, attrs, str)` assigns bare string children to
-`innerHTML`; only array children become text nodes. Always write
-`E(tag, attrs, [ value ])`. Log data, reverse-DNS hostnames, URL-hash filter
-values, and UCI values are all untrusted — see
-[security model](docs/developer/security-model.md).
+| Task | Read first |
+|------|------------|
+| Any change | [contributing.md](docs/developer/contributing.md) |
+| Renderers, rpcd plugin, shell helpers, release pipeline | [security-model.md](docs/developer/security-model.md) |
+| Classification or parsing | [architecture.md](docs/developer/architecture.md) |
+| A security audit | `security-audit` skill in `.cursor/skills/` |
 
-**ACL scope.** Never grant `ubus log.read` to sessions. The rpcd plugin performs
-privileged log reads as root and returns filtered output. Read methods and
-state-changing methods stay in separate ACL scopes.
+## Commands and testing
 
-**Version sync.** `PKG_VERSION` in the package `Makefile` and `APP_VERSION` in
-`fwlive/constants.js` must match.
+Commands, what each gate covers, and the QEMU flow:
+[build-and-test.md](docs/developer/build-and-test.md).
 
-## Commands
+Two traps worth knowing before you trust a green run:
 
-```sh
-npm test                          # ./scripts/fwlive-test.sh — parser, shell parity, codegen freshness, rpcd security
-./scripts/fwlive-linkcheck.sh     # markdown links + heading anchors + external URLs
-./scripts/validate-baseline.sh    # pre-release gate
-./scripts/gen-all.sh              # regenerate shell classifier, verify LuCI wrapper
-```
+- Renderer tests **do not render** — see
+  [build-and-test.md § Renderer tests do not render](docs/developer/build-and-test.md#renderer-tests-do-not-render).
+- `gen-luci-wrapper.js` is a gate, not a generator. It reports drift; it will not
+  fix it for you.
 
-Tests are host-only and need no router. UI changes still need a QEMU check —
-see [qemu-lab.md](docs/developer/qemu-lab.md).
+## Reporting security issues
 
-Docs changes must pass the link checker: it validates relative paths **and**
-heading anchors against a GitHub-style slugger.
-
-## Testing gotcha
-
-`tests/lib/load-fwlive-module.js` stubs `E()` as a plain object that never
-renders. Renderer tests assert on descriptive objects, so **no existing test can
-observe a DOM injection bug**. When touching renderers, verify through a
-LuCI-accurate `E()` harness — recipe in
-`.cursor/skills/security-audit/SKILL.md`.
-
-## Security work
-
-Read [`docs/developer/security-model.md`](docs/developer/security-model.md) for
-trust boundaries and invariants. For an audit, use the `security-audit` skill in
-`.cursor/skills/` — it carries verified upstream facts, the grep patterns, and
-severity/disclosure rules, so it avoids re-deriving known-good ground.
-
-Vulnerabilities go to a **private advisory**, never a public issue
+Vulnerabilities go to a private advisory, never a public issue
 ([`SECURITY.md`](SECURITY.md)). Hardening items are normal public issues.
 
 ## Conventions
 
-- Small changes, one behavior each; see
-  [contributing.md](docs/developer/contributing.md)
-- Tabs for indentation in shell and the shipped JS (match surrounding code)
+- Small changes, one behavior each
+- Tabs for indentation in shell and the shipped JS; match surrounding code
 - Comments explain constraints the code cannot show — not what the next line does
 - Keep user docs free of QEMU/SDK detail; keep developer docs free of marketing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,11 @@
 # AGENTS.md
 
 Router for coding agents. Every rule below is stated once, in the document
-linked beside it — **read the link before acting on the rule**, and change the
-canonical document rather than this file when a rule evolves.
+linked beside it — **read the link before acting on the rule**, and edit that
+document rather than this file when a rule evolves.
+
+Which document owns which rule, and the narrow cases where restating one is
+allowed: [contributing.md § Single source of truth](docs/developer/contributing.md#single-source-of-truth).
 
 Humans should start at [`README.md`](README.md) and the
 [developer guide](docs/developer/README.md).
@@ -61,4 +64,5 @@ Vulnerabilities go to a private advisory, never a public issue
 - Small changes, one behavior each
 - Tabs for indentation in shell and the shipped JS; match surrounding code
 - Comments explain constraints the code cannot show — not what the next line does
-- Keep user docs free of QEMU/SDK detail; keep developer docs free of marketing
+- Documentation conventions, including rule ownership:
+  [contributing.md § Documentation](docs/developer/contributing.md#documentation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Security model doc: trust boundaries, untrusted-input inventory, and testable security invariants ([`docs/developer/security-model.md`](docs/developer/security-model.md))
-- `AGENTS.md` — repository orientation and hard invariants for coding agents
-- Repeatable `security-audit` skill under `.cursor/skills/` (verified upstream facts, audit order, severity and disclosure rules)
+- `AGENTS.md` — router for coding agents; each rule links to its canonical document rather than restating it
+- Repeatable `security-audit` skill under `.cursor/skills/` (audit order, re-verification commands, severity and disclosure rules)
+- Renderer-test caveat and link-checker step in the build/test guide
 
 ### Fixed
-- Architecture doc claimed rule labels render as text nodes via `E(..., text)`; bare string children are assigned to `innerHTML` and only array children become text nodes (#137)
+- Architecture doc stated the output-encoding rule backwards; corrected and pointed at the security model as its single source (#137)
 
 ## [v0.1.31] — 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Security model doc: trust boundaries, untrusted-input inventory, and testable security invariants ([`docs/developer/security-model.md`](docs/developer/security-model.md))
+- `AGENTS.md` — repository orientation and hard invariants for coding agents
+- Repeatable `security-audit` skill under `.cursor/skills/` (verified upstream facts, audit order, severity and disclosure rules)
+
+### Fixed
+- Architecture doc claimed rule labels render as text nodes via `E(..., text)`; bare string children are assigned to `innerHTML` and only array children become text nodes (#137)
+
 ## [v0.1.31] — 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AGENTS.md` — router for coding agents; each rule links to its canonical document rather than restating it
 - Repeatable `security-audit` skill under `.cursor/skills/` (audit order, re-verification commands, severity and disclosure rules)
 - Renderer-test caveat and link-checker step in the build/test guide
+- Documentation rule-ownership policy: one owner per rule, plus the narrow forms in which restating one is allowed
 
 ### Fixed
 - Architecture doc stated the output-encoding rule backwards; corrected and pointed at the security model as its single source (#137)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Build, test, and extend the package from this repository.
 - [Build & test](developer/build-and-test.md)
 - [QEMU lab](developer/qemu-lab.md)
 - [Contributing](developer/contributing.md)
+- [Security model](developer/security-model.md)
 
 ---
 
@@ -27,6 +28,7 @@ Build, test, and extend the package from this repository.
 
 | Document | Topic |
 |----------|-------|
+| [developer/security-model.md](developer/security-model.md) | Trust boundaries, security invariants, audit procedure |
 | [binary-feed.md](binary-feed.md) | Signed opkg/apk feed install |
 | [openwrt-21.02-compat.md](openwrt-21.02-compat.md) | Legacy fw3 / 21.02.x |
 | [openwrt-22.03-compat.md](openwrt-22.03-compat.md) | EOL fw4 / 22.03.x |

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -10,6 +10,7 @@ Documentation for **building, testing, and extending** `luci-app-fwlive` and the
 | 2 | [Architecture](architecture.md) — modules, data path, design choices |
 | 3 | [Build & test](build-and-test.md) — SDK matrix, validation, smoke scripts |
 | 4 | [Contributing](contributing.md) — parser sync, acceptance criteria, workflow |
+| 5 | [Security model](security-model.md) — trust boundaries, invariants, audit procedure |
 
 ## Repository map
 
@@ -36,6 +37,8 @@ Documentation for **building, testing, and extending** `luci-app-fwlive` and the
 | Roadmap | [`../ROADMAP.md`](../ROADMAP.md) |
 | Publish checklist | [`../github-publish-checklist.md`](../github-publish-checklist.md) |
 | Feed layout (no submodule split) | [architecture.md § Feed layout decision](architecture.md#feed-layout-decision) |
+| Trust boundaries & security invariants | [security-model.md](security-model.md) |
+| Agent orientation (invariants, commands) | [`../../AGENTS.md`](../../AGENTS.md) |
 
 ## User documentation
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -52,9 +52,9 @@ flowchart TB
 | Enable/disable concurrency | No confirm dialog / no flock — low multi-admin risk; UI uses `loggingBusy`; concurrent toggles are last-writer-wins |
 | Parser disagreement | After poll, the client re-applies `isFirewallEvent`; **client wins** (drops lines the shell kept if heuristics disagree) |
 | MAC redaction | Client display only (`formatMessageDisplay` strips `MAC=…`, including message `title`); poll JSON may still contain MACs on the wire |
-| Output encoding | LuCI `E(tag, attrs, str)` assigns bare string children to `innerHTML`; **only array children become text nodes**. Renderers must use `E(tag, attrs, [ value ])`. Server map keys are additionally gated by `is_uci_style_name`. See [Security model](security-model.md) |
+| Output encoding | Renderers must emit untrusted values as text nodes; server map keys are additionally gated by `is_uci_style_name` — [Security model § Invariants](security-model.md#invariants) |
 | Log filter injection | `fwlive-log-filter.sh` feeds messages as data through jsonfilter/grep stdin — not a shell-injection surface |
-| Log content is untrusted | `logd` accepts syslog writes from any local UID, so every parsed field is attacker-influenced regardless of who wrote the firewall rule |
+| Log content is untrusted | Every parsed field is attacker-influenced regardless of who wrote the firewall rule — [Security model § Untrusted input inventory](security-model.md#untrusted-input-inventory) |
 | Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off; server validates IPv4/IPv6 shape before lookup |
 | `core/` + LuCI mirror | Parser tested without browser or router |
 | LuCI gate (not generator) | `gen-luci-wrapper.js` verifies full `CLASSIFY_SPEC` equality + preserve markers; shared classify in `log.js` stays hand-maintained (no text-transform codegen). Core has no `@fwlive-codegen:luci-begin/end` markers — only LuCI has a preserve region for presentation helpers. |

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -52,8 +52,9 @@ flowchart TB
 | Enable/disable concurrency | No confirm dialog / no flock — low multi-admin risk; UI uses `loggingBusy`; concurrent toggles are last-writer-wins |
 | Parser disagreement | After poll, the client re-applies `isFirewallEvent`; **client wins** (drops lines the shell kept if heuristics disagree) |
 | MAC redaction | Client display only (`formatMessageDisplay` strips `MAC=…`, including message `title`); poll JSON may still contain MACs on the wire |
-| Rule / prefix XSS | Rule labels render via LuCI `E(..., text)` (text nodes); server map keys gated by `is_uci_style_name` |
+| Output encoding | LuCI `E(tag, attrs, str)` assigns bare string children to `innerHTML`; **only array children become text nodes**. Renderers must use `E(tag, attrs, [ value ])`. Server map keys are additionally gated by `is_uci_style_name`. See [Security model](security-model.md) |
 | Log filter injection | `fwlive-log-filter.sh` feeds messages as data through jsonfilter/grep stdin — not a shell-injection surface |
+| Log content is untrusted | `logd` accepts syslog writes from any local UID, so every parsed field is attacker-influenced regardless of who wrote the firewall rule |
 | Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off; server validates IPv4/IPv6 shape before lookup |
 | `core/` + LuCI mirror | Parser tested without browser or router |
 | LuCI gate (not generator) | `gen-luci-wrapper.js` verifies full `CLASSIFY_SPEC` equality + preserve markers; shared classify in `log.js` stays hand-maintained (no text-transform codegen). Core has no `@fwlive-codegen:luci-begin/end` markers — only LuCI has a preserve region for presentation helpers. |

--- a/docs/developer/build-and-test.md
+++ b/docs/developer/build-and-test.md
@@ -20,11 +20,25 @@ Native SDK (no Docker): [`../minimal-build-sdk.md`](../minimal-build-sdk.md)
 ./scripts/fwlive-test.sh
 # or: npm test
 ./scripts/validate-baseline.sh
+./scripts/fwlive-linkcheck.sh    # markdown links + heading anchors + external URLs
 ```
 
 Covers parser sync (`core/` vs LuCI `log.js`), schema, filters, CLI pipeline,
 shell codegen + LuCI wrapper gate (`./scripts/gen-all.sh`), and shellcheck on shipped
 `root/usr/libexec` scripts (`./scripts/fwlive-shellcheck.sh`). Optional: `SH='busybox sh' node tests/fwlive-shell-filter.test.js`.
+
+Docs changes must pass the link checker — it validates relative paths **and**
+heading anchors against a GitHub-style slugger.
+
+### Renderer tests do not render
+
+`tests/lib/load-fwlive-module.js` stubs LuCI's `E()` as a plain object
+constructor (`fakeE`) that never builds DOM. Renderer tests therefore assert on
+descriptive objects, which is fine for structure but means **a value reaching an
+HTML sink instead of a text node is invisible to them**.
+
+When changing a renderer, verify through an `E()` that reproduces upstream
+`dom.append` semantics. Recipe: `.cursor/skills/security-audit/SKILL.md`.
 
 ## Live View CSS (`fwlive.css` → `css.js`)
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -4,7 +4,7 @@
 
 - **Small steps** — one behavior per change; verify in CLI + QEMU LuCI when UI-related
 - **Parser sync** — edit `CLASSIFY_SPEC` in `core/fwlive-log.js`, mirror the same object in `htdocs/.../fwlive/log.js`, run `./scripts/gen-all.sh` (regenerates shell; gates LuCI full-spec drift), keep preserve-region presentation in parity
-- **Output encoding** — pass string children to `E()` as arrays (`E(tag, attrs, [ value ])`); the bare form assigns `innerHTML`. Applies to every renderer, including values that look constrained — see [Security model](security-model.md)
+- **Output encoding** — untrusted values must reach the DOM as text nodes, never through an HTML sink; applies to every renderer, including values that look constrained — see [Security model § Invariants](security-model.md#invariants)
 - **No scope creep** — MVP is done; backlog items are in [`../ROADMAP.md`](../ROADMAP.md)
 
 ## Change workflow
@@ -35,7 +35,7 @@ After editing classification: update **both** `core/fwlive-log.js` and the LuCI 
 
 ## Feed / package changes
 
-- `Makefile` — `LUCI_DEPENDS`, version, maintainer
+- `Makefile` — `LUCI_DEPENDS`, version, maintainer. `PKG_VERSION` and `APP_VERSION` in `fwlive/constants.js` must match
 - `menu.d` — path `admin/status/fwlive`
 - `rpcd/acl.d` — grant `fwlive.rules`, `fwlive.poll`, `fwlive.resolve`, `fwlive.logging_status` (read); `fwlive.enable_wan_logging`, `fwlive.disable_wan_logging` (write). Do **not** grant `ubus log.read` — poll performs filtered log reads inside the root rpcd plugin
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -4,6 +4,7 @@
 
 - **Small steps** — one behavior per change; verify in CLI + QEMU LuCI when UI-related
 - **Parser sync** — edit `CLASSIFY_SPEC` in `core/fwlive-log.js`, mirror the same object in `htdocs/.../fwlive/log.js`, run `./scripts/gen-all.sh` (regenerates shell; gates LuCI full-spec drift), keep preserve-region presentation in parity
+- **Output encoding** — pass string children to `E()` as arrays (`E(tag, attrs, [ value ])`); the bare form assigns `innerHTML`. Applies to every renderer, including values that look constrained — see [Security model](security-model.md)
 - **No scope creep** — MVP is done; backlog items are in [`../ROADMAP.md`](../ROADMAP.md)
 
 ## Change workflow
@@ -37,6 +38,13 @@ After editing classification: update **both** `core/fwlive-log.js` and the LuCI 
 - `Makefile` — `LUCI_DEPENDS`, version, maintainer
 - `menu.d` — path `admin/status/fwlive`
 - `rpcd/acl.d` — grant `fwlive.rules`, `fwlive.poll`, `fwlive.resolve`, `fwlive.logging_status` (read); `fwlive.enable_wan_logging`, `fwlive.disable_wan_logging` (write). Do **not** grant `ubus log.read` — poll performs filtered log reads inside the root rpcd plugin
+
+## Security-relevant changes
+
+Renderers, the rpcd plugin, shell helpers, and the release pipeline all sit on a
+trust boundary. Read [Security model](security-model.md) before changing them,
+and report vulnerabilities privately per [`../../SECURITY.md`](../../SECURITY.md)
+rather than opening an issue.
 
 Package README: [`../../openwrt-feed/luci-app-fwlive/README.md`](../../openwrt-feed/luci-app-fwlive/README.md)
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -59,6 +59,37 @@ Package README: [`../../openwrt-feed/luci-app-fwlive/README.md`](../../openwrt-f
 
 Keep user docs free of QEMU/SDK detail; keep developer docs free of marketing language.
 
+### Single source of truth
+
+Every rule has exactly one **owner** document. Everything else links to it
+instead of restating it. A stale copy of a rule is worse than no copy — an
+inverted claim about output encoding survived in `architecture.md` long enough
+to be built against (#137).
+
+| Owner | Rules it owns |
+|-------|---------------|
+| [security-model.md](security-model.md) | Trust boundaries, output encoding, untrusted inputs, ACL scope, supply-chain surface |
+| [contributing.md](contributing.md) | Workflow, parser sync / codegen, package and version rules, documentation conventions |
+| [build-and-test.md](build-and-test.md) | Commands, what each gate covers, test caveats |
+| [architecture.md](architecture.md) | Module split, data path, design rationale |
+| `.cursor/skills/security-audit/SKILL.md` | Audit procedure and re-verification commands |
+| [`../../CHANGELOG.md`](../../CHANGELOG.md) | Release history — a record, never a rule source |
+
+When a rule changes, edit its owner. If the edit forces prose changes in a second
+file, that second copy is drift — consolidate it.
+
+**Restating is allowed in exactly these forms:**
+
+| Allowed | Shape |
+|---------|-------|
+| Imperative at the point of action | One sentence where the work happens (e.g. the `log.read` warning beside the ACL grant list). No rationale, no mechanics, no examples |
+| Router entry | A rule named in one line plus a link — [`../../AGENTS.md`](../../AGENTS.md) and index tables |
+| Verification command | *How* to confirm a fact may sit with the procedure that needs it, even when the fact is owned elsewhere |
+
+Everything else stays single-sourced: rationale, code samples, upstream
+behaviour, threat descriptions, and multi-step procedures. If a restatement
+needs a "because", it belongs in the owner document.
+
 ## Before publishing
 
 [`../github-publish-checklist.md`](../github-publish-checklist.md)

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -55,9 +55,12 @@ does not.
 Source: `modules/luci-base/htdocs/luci-static/resources/luci.js` in
 [openwrt/luci](https://github.com/openwrt/luci) (`dom.append` / `dom.create`).
 
-Bringing the shipped renderers into full compliance is tracked in
-[#137](https://github.com/lucas-albers-lz4/fwlive/issues/137); the rendering
-regression test is [#138](https://github.com/lucas-albers-lz4/fwlive/issues/138).
+The shipped renderers are in full compliance. Every `E()` string child is
+the array form. The sweep found 60 array-form calls and no bare-string
+sinks. The rendering regression harness
+([#138](https://github.com/lucas-albers-lz4/fwlive/issues/138), merged as
+`tests/` coverage) keeps it that way. The compliance sweep landed with
+[#137](https://github.com/lucas-albers-lz4/fwlive/issues/137).
 
 ### 2. Log data is never interpolated into a shell command string
 
@@ -120,9 +123,9 @@ part of the security boundary.
 | Feed signing keys | CI secrets, written under `umask 077` then `chmod 600`; only public keys are staged for publish |
 | Package contents | `verify-reproducible-build.sh` — determinism of our inputs within a run |
 | OpenWrt feeds | Pinned in `scripts/feeds.lock/` |
-| SDK base images | Referenced by mutable tag ([#133](https://github.com/lucas-albers-lz4/fwlive/issues/133)) |
-| GitHub Actions | Referenced by mutable tag ([#132](https://github.com/lucas-albers-lz4/fwlive/issues/132)) |
-| Fetched build helpers and lab images | No checksum verification ([#131](https://github.com/lucas-albers-lz4/fwlive/issues/131), [#134](https://github.com/lucas-albers-lz4/fwlive/issues/134)) |
+| SDK base images | Digests resolved per cell and recorded in the release manifest (no mutable-tag reliance) |
+| GitHub Actions | SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` |
+| Fetched build helpers and lab images | sha256-verified before execution; `/tmp` trust removed (fresh `mktemp` per invocation) |
 
 Never stage a secret key into `feed-staging/` — `feed_publish_copy_keys` copies
 public keys only, and all four key filenames are gitignored.

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -1,0 +1,134 @@
+# Security model
+
+What fwlive trusts, what it must never trust, and the invariants that keep the
+two apart. Read this before changing renderers, the rpcd plugin, or the release
+pipeline.
+
+Reporting a vulnerability: [`SECURITY.md`](../../SECURITY.md) — private
+disclosure, never a public issue.
+
+## Threat model in one line
+
+fwlive renders attacker-influenced text inside a **root-equivalent** browser
+session. A LuCI admin session can invoke arbitrary ubus methods, so script
+execution on the fwlive page is equivalent to root on the router.
+
+## Untrusted input inventory
+
+Every value below reaches the browser. None of it is trustworthy.
+
+| Input | Who controls it | Notes |
+|-------|-----------------|-------|
+| Firewall log message and every field parsed from it | **Any local process, any UID** | `logd` chmods its socket `0666` (ubox `log/syslog.c`), so any process can write arbitrary syslog lines. A line containing `SRC=`/`DST=` passes the firewall classifier |
+| `IN` / `OUT` / `SPT` / `DPT` / `PROTO` / `TCPFLAGS` | Same as above | Captured as `[^\s]+`, so any whitespace-free content survives parsing intact |
+| Reverse-DNS hostnames (`fwlive.resolve`) | Remote party owning the PTR record | libc restricts the character set in practice; do not rely on it |
+| URL hash filter values | Anyone who can get an admin to open a link | `applyHash()` copies `#src=…` into the filter inputs, which feed the chip renderer |
+| UCI values (`log_limit`, rule names, nft log prefixes) | Router admin, or any package writing UCI | Lower privilege distance, still not literals |
+
+The log **prefix** is admin-configured, but the rest of a log line is not — do
+not treat "the admin wrote the rule" as making a log line trustworthy.
+
+## Invariants
+
+Each one is testable. Breaking one is a security regression, not a style nit.
+
+### 1. Every `E()` string child is wrapped in an array
+
+Upstream LuCI `dom.append` branches on child type — array children become text
+nodes, bare string children are assigned to `innerHTML`:
+
+```js
+if (Array.isArray(children)) {
+    ...node.appendChild(document.createTextNode(`${children[i]}`));   // text
+}
+...
+else if (children !== null && children !== undefined) {
+    node.innerHTML = `${children}`;                                   // HTML
+}
+```
+
+So `E('td', attrs, value)` renders HTML and `E('td', attrs, [ value ])` renders
+text. **Always use the array form**, including for values that look constrained
+today — the uniform rule survives future parser changes, per-field reasoning
+does not.
+
+Source: `modules/luci-base/htdocs/luci-static/resources/luci.js` in
+[openwrt/luci](https://github.com/openwrt/luci) (`dom.append` / `dom.create`).
+
+Bringing the shipped renderers into full compliance is tracked in
+[#137](https://github.com/lucas-albers-lz4/fwlive/issues/137); the rendering
+regression test is [#138](https://github.com/lucas-albers-lz4/fwlive/issues/138).
+
+### 2. Log data is never interpolated into a shell command string
+
+`fwlive-log-filter.sh` passes messages as data through `jsonfilter`/`grep`
+stdin. Keep it that way — no `eval`, no unquoted expansion into a command.
+
+### 3. Addresses are shape-validated before reaching a subprocess
+
+`is_resolvable_address` accepts only IPv4/IPv6-shaped tokens and rejects shell
+metacharacters before `getent` runs. Its selftest asserts rejection of a literal
+`$(reboot)` token.
+
+### 4. Caller-supplied numbers are validated and clamped
+
+`poll_lines_from_input` rejects non-numeric input and clamps to
+`POLL_LINES_MAX`. Never interpolate a caller value into the `ubus call log read`
+JSON without both steps.
+
+### 5. All JSON string content passes through `json_escape`
+
+Escapes `\`, `"`, tab, CR, LF, and remaining C0 controls per RFC 8259.
+
+### 6. The ACL never grants `ubus log.read`
+
+Sessions get `fwlive.*` only; the rpcd plugin performs the privileged log read
+as root and returns filtered output. Enforced by
+`tests/fwlive-rpcd-security.test.js`.
+
+### 7. Read and write methods stay in separate ACL scopes
+
+`rules` / `poll` / `resolve` / `logging_status` are read. Only
+`enable_wan_logging` / `disable_wan_logging` are write.
+
+## Privileged surface
+
+The rpcd plugin runs as **root**. Its entire input surface is:
+
+| Method | Input | Scope |
+|--------|-------|-------|
+| `rules` | none | read |
+| `poll` | line count in `addresses[0]` | read |
+| `resolve` | address array (max `RESOLVE_MAX`) | read |
+| `logging_status` | none | read |
+| `enable_wan_logging` / `disable_wan_logging` | none | write |
+
+`__selftest` and `__rulesmap_iptables` are CLI-only and must never become ubus
+methods. `__rulesmap_iptables` reads a fixed path and rejects argv-supplied
+files.
+
+State changes touch only bit 0 of the WAN zone `log` value and roll back UCI if
+the firewall reload fails.
+
+## Supply-chain surface
+
+Release artifacts are signed and served from a binary feed, so build inputs are
+part of the security boundary.
+
+| Surface | Control |
+|---------|---------|
+| Feed signing keys | CI secrets, written under `umask 077` then `chmod 600`; only public keys are staged for publish |
+| Package contents | `verify-reproducible-build.sh` — determinism of our inputs within a run |
+| OpenWrt feeds | Pinned in `scripts/feeds.lock/` |
+| SDK base images | Referenced by mutable tag ([#133](https://github.com/lucas-albers-lz4/fwlive/issues/133)) |
+| GitHub Actions | Referenced by mutable tag ([#132](https://github.com/lucas-albers-lz4/fwlive/issues/132)) |
+| Fetched build helpers and lab images | No checksum verification ([#131](https://github.com/lucas-albers-lz4/fwlive/issues/131), [#134](https://github.com/lucas-albers-lz4/fwlive/issues/134)) |
+
+Never stage a secret key into `feed-staging/` — `feed_publish_copy_keys` copies
+public keys only, and all four key filenames are gitignored.
+
+## Running an audit
+
+Repeatable procedure, verified upstream facts, and the rendering-harness recipe:
+`.cursor/skills/security-audit/SKILL.md`. Start there rather than re-deriving
+the trust boundaries.


### PR DESCRIPTION
## Why

The audit that produced #131–#138 spent most of its time re-deriving things that should have been written down: which inputs are untrusted, how LuCI's `E()` actually handles children, and which areas had already been checked and found sound. This captures that groundwork so the next pass starts from the trust boundaries instead of rebuilding them.

It also corrects a documented claim that was **backwards**. `docs/developer/architecture.md` asserted:

> Rule labels render via LuCI `E(..., text)` (text nodes)

Upstream `dom.append` appends *array* children via `createTextNode` and assigns *bare string* children to `innerHTML`. The bare form is an HTML sink. That inverted belief is what the renderers were written against, which is why #137 exists — so leaving the doc as-is would keep reproducing the bug.

## What changed

| File | Purpose |
|---|---|
| `docs/developer/security-model.md` (new) | **Owns** the output-encoding invariant, untrusted-input inventory, and ACL scope rules. Plus privileged and supply-chain surface |
| `.cursor/skills/security-audit/SKILL.md` (new) | Audit order, re-verification commands, rendering-harness recipe, severity calibration, disclosure rules, known-good list |
| `AGENTS.md` (new) | Router for agents — one-line imperative per rule linking to its canonical section |
| `docs/developer/build-and-test.md` | **Owns** commands; adds the link-checker step and the renderer-tests-do-not-render caveat |
| `docs/developer/contributing.md` | **Owns** parser sync and package/version rules; adds `PKG_VERSION`/`APP_VERSION` sync and a security-relevant-changes pointer |
| `docs/developer/architecture.md` | Corrected the output-encoding row; both security rows now point at the security model |
| `docs/{README.md,developer/README.md}`, `CHANGELOG.md` | Navigation and changelog entries |

## Single source of truth

The first pass at this PR restated the same rules in four places. Four copies is four chances to drift, and a stale copy is worse than none — the doc bug being fixed here was exactly that failure. Second commit gives every rule one owner:

| Owner | Rules |
|---|---|
| `security-model.md` | Output encoding, untrusted-input inventory, ACL scope |
| `contributing.md` | Parser sync / codegen, package and version rules |
| `build-and-test.md` | Commands, renderer-test caveat |
| `security-audit` skill | Only what is unique to auditing |

`AGENTS.md` dropped from 83 to 64 lines as a result. Net across both commits: **87 insertions against 105 deletions**.

Deliberate exception: short imperatives still appear at the point of action — the `log.read` warning where the ACL is edited, the version note where `PKG_VERSION` is bumped. Stripping those to bare links trades readability for purity. What is deduplicated is substantive explanation, not the one-line reminder.

## What makes the next audit faster

- **Re-verification commands instead of restated facts** — the LuCI `innerHTML` semantics and the `logd 0666` socket permission each carry the exact `curl`/`rg` that proves them, so they are cheap to re-confirm and never re-guessed. Including that `dom.js` does not exist on the 24.10 branch (`dom` lives in `luci.js`), which cost real time to discover.
- **A known-good list** — the audited-sound invariants are named so a future pass does not re-litigate them without new evidence. Re-reading known-good shell is the main way an audit runs out of time before reaching the frontend.
- **The harness recipe** — including that test values must be whitespace-free, because the `[^\s]+` field parser truncates anything with spaces mid-token. That detail is the difference between a working proof and a false negative.
- **Severity calibration and disclosure split** — vulnerabilities to a private advisory per `SECURITY.md`, hardening to public issues, one atomic issue per fix.

## Disclosure note

Written as **invariants and audit method**, not as a vulnerability report. No payloads, no exploit paths — those stay in the private draft advisory until its fix ships, along with the validated regression harness (see #138). The `E()` semantics and the `logd` socket mode are public upstream facts and are required to state the invariant at all, so including them discloses nothing new.

## Test plan

- [x] `./scripts/fwlive-linkcheck.sh` — 366 internal links, 0 broken; anchors verified including the double-hyphen form GitHub generates for headings like `## Parser sync / codegen`
- [x] `npm test` — full host suite passes
- [x] Verified `innerHTML`, `createTextNode`, and the `logd 0666` fact each appear in exactly one document
- [ ] Doc review — #140 (accuracy, disclosure boundary, and known-good-list correctness; the AGENTS.md duplication question raised there is now resolved by the second commit)

**Note on red CI:** the `test` job fails on `FAIL: https://opnsense.org/ -> 000` from the link checker's external-URL pass. That link is in `ATTRIBUTION.md` and is untouched here; curl code `000` means no HTTP response was received (network/TLS/timeout), which the checker wrongly treats as a broken link. Pre-existing and tracked with a fix in #141 — it passes on re-run.

Docs-only: no shipped code, no `PKG_VERSION` change.
