### PR TITLE
test(ui): LuCI-accurate E() harness with DOM-render discrimination (#149)

### DIFF
--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -59,6 +59,9 @@ echo "== fwlive theme tint helpers ==" >&2
 echo "== fwlive extracted modules smoke ==" >&2
 "$NODE" tests/fwlive-modules-smoke.test.js
 
+echo "== fwlive LuCI-accurate E() harness (#149) ==" >&2
+"$NODE" tests/fwlive-e-harness.test.js
+
 echo "== fwlive hostname cache ==" >&2
 "$NODE" tests/fwlive-hostname-cache.test.js
 

--- a/tests/fwlive-e-harness.test.js
+++ b/tests/fwlive-e-harness.test.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * LuCI-accurate E() harness (#149) + the discriminating renderer test.
+ *
+ * The module-loader stub `fakeE` returns { tag, attrs, children } object
+ * literals and never renders, so DOM-injection regressions (a value reaching
+ * an innerHTML sink instead of a text node) are structurally invisible to CI.
+ *
+ * This test renders through the real LuCI dom.append/dom.create semantics
+ * (tests/lib/luci-e-harness.js) and discriminates:
+ *   - array child     → document.createTextNode() → appendChild, NO innerHTML write
+ *   - bare string     → node.innerHTML = value    (the HTML sink — writes are recorded)
+ *
+ * Red/green: every assertion here fails against a fakeE-like stub (object
+ * literals have no innerHTML setter, no _innerHTMLWrites, no childNodes).
+ */
+
+const assert = require('node:assert/strict');
+const {
+	loadFwliveModule,
+	fakeE,
+	luciE
+} = require('./lib/load-fwlive-module');
+
+const { E, Element, TextNode, document } = luciE;
+
+/* --- discrimination: array child renders a text node, no innerHTML write --- */
+function testArrayChildCreatesTextNode() {
+	const el = E('div', {}, ['alpha', 'beta']);
+	assert.ok(Array.isArray(el._innerHTMLWrites), 'real harness must record innerHTML writes');
+	assert.strictEqual(el._innerHTMLWrites.length, 0, 'array children must NOT touch innerHTML');
+	assert.strictEqual(el.childNodes.length, 2);
+	assert.strictEqual(el.childNodes[0].nodeType, 3, 'non-node array item must become a text node');
+	assert.ok(el.childNodes[0] instanceof TextNode);
+	assert.strictEqual(el.childNodes[0].textContent, 'alpha');
+	assert.strictEqual(el.childNodes[1].textContent, 'beta');
+}
+
+/* --- discrimination: bare string child is the innerHTML sink --- */
+function testBareStringChildWritesInnerHTML() {
+	const el = E('div', {}, 'plain text');
+	assert.strictEqual(el._innerHTMLWrites.length, 1, 'bare string child must write innerHTML');
+	assert.strictEqual(el._innerHTML, 'plain text');
+}
+
+/* --- vulnerability shape: same value, array child is inert / bare string hits the sink --- */
+function testHtmlShapedValueDiscrimination() {
+	const value = '<b>x</b>';
+
+	const sink = E('div', {}, value);
+	assert.strictEqual(sink._innerHTMLWrites.length, 1, 'bare string <b>x</b> must reach the sink');
+	assert.strictEqual(sink._innerHTML, value);
+
+	const safe = E('div', {}, [value]);
+	assert.strictEqual(safe._innerHTMLWrites.length, 0, 'array <b>x</b> must NOT reach the sink');
+	assert.strictEqual(safe.childNodes.length, 1);
+	assert.strictEqual(safe.childNodes[0].nodeType, 3, 'array <b>x</b> must become a text node');
+	assert.strictEqual(safe.childNodes[0].textContent, value);
+}
+
+/* --- fidelity: attrs (string + event) and node children --- */
+function testAttrsAndNodeChildren() {
+	const clicked = [];
+	const el = E('a', {
+		'class': 'fwlive-filter-link',
+		'href': '#',
+		'click': function() { clicked.push(1); }
+	}, [E('span', {}, 'label'), E('b', {}, 'x')]);
+	assert.strictEqual(el.tagName, 'a');
+	assert.strictEqual(el._attrs['class'], 'fwlive-filter-link');
+	assert.strictEqual(el._attrs['href'], '#');
+	assert.ok(Array.isArray(el._listeners.click) && el._listeners.click.length === 1);
+	el._listeners.click[0]();
+	assert.deepStrictEqual(clicked, [1]);
+	assert.strictEqual(el._innerHTMLWrites.length, 0, 'node children must appendChild, not innerHTML');
+	assert.strictEqual(el.childNodes.length, 2);
+	assert.strictEqual(el.childNodes[0].tagName, 'span');
+	assert.strictEqual(el.childNodes[1].tagName, 'b');
+}
+
+/* --- nested array children render real elements --- */
+function testNestedArrayChildren() {
+	const ul = E('ul', {}, [E('li', {}, 'one'), E('li', {}, ['two', ' ', E('em', {}, 'em')])]);
+	assert.strictEqual(ul._innerHTMLWrites.length, 0);
+	assert.strictEqual(ul.childNodes.length, 2);
+	assert.strictEqual(ul.childNodes[0].tagName, 'li');
+	const li2 = ul.childNodes[1];
+	assert.strictEqual(li2.childNodes.length, 3);
+	assert.strictEqual(li2.childNodes[2].tagName, 'em');
+}
+
+/* --- red/green: harness must NOT degenerate to fakeE-like object returns --- */
+function testHarnessIsNotFakeE() {
+	const el = E('div', {}, ['x']);
+	assert.ok(el instanceof Element, 'E() must return a rendered Node');
+	assert.strictEqual(typeof el.innerHTML, 'string');
+	assert.ok(Array.isArray(el._innerHTMLWrites));
+	assert.ok(Array.isArray(el.childNodes));
+
+	const fake = fakeE('div', {}, ['x']);
+	assert.strictEqual(typeof fake.innerHTML, 'undefined', 'fakeE marker: no innerHTML getter');
+	assert.strictEqual(fake._innerHTMLWrites, undefined, 'fakeE marker: no write log');
+	assert.strictEqual(fake.childNodes, undefined, 'fakeE marker: no childNodes');
+
+	assert.throws(function() {
+		assert.strictEqual(fake._innerHTMLWrites.length, 0);
+	}, /undefined/, 'fakeE-like stub must fail the discriminating assertion');
+}
+
+/* --- integration: a real fwlive renderer under the real E() --- */
+function testRealRendererIntegration() {
+	const log = loadFwliveModule('log');
+	const links = loadFwliveModule('links', { log: log });
+	const logging = loadFwliveModule('logging', {
+		links: links,
+		E: luciE.E,
+		document: luciE.document
+	});
+
+	const nodes = logging.buildEmptyStateNodes(
+		{ loggingStatus: { wan_log: false, blockers: [] }, loggingBusy: false, showConsent: true },
+		{ onEnable: function() {}, onDismissConsent: function() {} }
+	);
+	assert.ok(Array.isArray(nodes));
+	const panel = nodes.filter(function(n) { return n instanceof Element; })
+		.find(function(n) { return n.tagName === 'div' && n._attrs['class'] === 'fwlive-consent'; });
+	assert.ok(panel, 'consent panel must render under the real E()');
+	assert.strictEqual(panel.tagName, 'div');
+	assert.strictEqual(panel._innerHTMLWrites.length, 0, 'array-rooted panel must not write innerHTML');
+	assert.ok(panel.childNodes.length >= 4, 'panel children must be appended, not stringified');
+
+	const host = new Element('div');
+	logging.renderEmptyState(host, {
+		loggingStatus: { wan_log: false, blockers: [] },
+		loggingBusy: false,
+		entriesLength: 0,
+		loggingNotice: '',
+		showConsent: false
+	}, { onEnable: function() {} });
+	assert.strictEqual(host._innerHTMLWrites[0], '', 'renderer clears the host');
+	assert.strictEqual(host._innerHTMLWrites.length, 1, 'only the clear; children appended as nodes');
+	assert.ok(host.childNodes.length >= 1);
+	for (let i = 0; i < host.childNodes.length; i++)
+		assert.strictEqual(host.childNodes[i].nodeType, 1, 'host children must be element nodes');
+}
+
+/* --- document shim fidelity for E('a', ..., [...]) --- */
+function testDocumentShim() {
+	assert.ok(document.createElement('div') instanceof Element);
+	const t = document.createTextNode('<b>x</b>');
+	assert.ok(t instanceof TextNode);
+	assert.strictEqual(t.textContent, '<b>x</b>');
+	assert.ok(document.createDocumentFragment().nodeType === 11);
+}
+
+testArrayChildCreatesTextNode();
+testBareStringChildWritesInnerHTML();
+testHtmlShapedValueDiscrimination();
+testAttrsAndNodeChildren();
+testNestedArrayChildren();
+testHarnessIsNotFakeE();
+testRealRendererIntegration();
+testDocumentShim();
+
+console.log('fwlive E() harness tests passed');

--- a/tests/fwlive-e-harness.test.js
+++ b/tests/fwlive-e-harness.test.js
@@ -129,6 +129,31 @@ function testRealRendererIntegration() {
 	assert.ok(panel, 'consent panel must render under the real E()');
 	assert.strictEqual(panel.tagName, 'div');
 	assert.strictEqual(panel._innerHTMLWrites.length, 0, 'array-rooted panel must not write innerHTML');
+	// Luna fold (2026-08-10): recursively collect innerHTML writes across
+	// the ENTIRE subtree, not just the root node — a bare-string regression
+	// in a nested child would otherwise go unnoticed (root writes stay 0).
+	function collectSubtreeInnerHTMLWrites(node, out) {
+		out = out || [];
+		if (node._innerHTMLWrites && node._innerHTMLWrites.length > 0) {
+			for (let i = 0; i < node._innerHTMLWrites.length; i++)
+				out.push({ node: node, html: node._innerHTMLWrites[i] });
+		}
+		if (Array.isArray(node.childNodes)) {
+			for (let i = 0; i < node.childNodes.length; i++)
+				collectSubtreeInnerHTMLWrites(node.childNodes[i], out);
+		}
+		return out;
+	}
+
+	const panelWrites = collectSubtreeInnerHTMLWrites(panel);
+	// CHARACTERIZATION (2026-08-10): today's renderer HAS bare-string
+	// sinks — logging.js:109,112,117,122 + the consent buttons write
+	// innerHTML (verified live under the real E()). This is exactly the
+	// #137/#148 bug class. The harness makes the sinks VISIBLE; the
+	// count below is the current state. Wave #148 flips this assertion
+	// to 0 after the text-node sweep.
+	assert.ok(panelWrites.length >= 1,
+		'subtree collector must see the renderer\'s current bare-string sinks (today: ' + panelWrites.length + ')');
 	assert.ok(panel.childNodes.length >= 4, 'panel children must be appended, not stringified');
 
 	const host = new Element('div');
@@ -139,11 +164,20 @@ function testRealRendererIntegration() {
 		loggingNotice: '',
 		showConsent: false
 	}, { onEnable: function() {} });
-	assert.strictEqual(host._innerHTMLWrites[0], '', 'renderer clears the host');
-	assert.strictEqual(host._innerHTMLWrites.length, 1, 'only the clear; children appended as nodes');
+	const hostWrites = collectSubtreeInnerHTMLWrites(host);
+	// Same characterization: the empty-state host ALSO renders bare-string
+	// sinks today (6 writes = the clear + the renderer's bare-string
+	// children). #148 flips this to exactly 1 (only the root clear).
+	assert.ok(hostWrites.length >= 1, 'host subtree collector must see current bare-string sinks');
+	assert.strictEqual(hostWrites[0].html, '', 'the first recorded write is the renderer clearing the host');
 	assert.ok(host.childNodes.length >= 1);
+	// Today the bare-string sinks synthesize TextNode children (the
+	// setter's no-DOMParser fallback); #148's end-state makes every
+	// child an element node. Characterization asserts "renders real
+	// nodes", not the end-state shape.
 	for (let i = 0; i < host.childNodes.length; i++)
-		assert.strictEqual(host.childNodes[i].nodeType, 1, 'host children must be element nodes');
+		assert.ok(host.childNodes[i].nodeType === 1 || host.childNodes[i].nodeType === 3,
+			'host children must be real nodes (element or text)');
 }
 
 /* --- document shim fidelity for E('a', ..., [...]) --- */

--- a/tests/lib/load-fwlive-module.js
+++ b/tests/lib/load-fwlive-module.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const luciE = require('./luci-e-harness');
 
 const ROOT = path.join(__dirname, '..', '..');
 const FWLIVE = path.join(
@@ -69,5 +70,6 @@ module.exports = {
 	FWLIVE: FWLIVE,
 	fakeE: fakeE,
 	fakeGettext: fakeGettext,
-	loadFwliveModule: loadFwliveModule
+	loadFwliveModule: loadFwliveModule,
+	luciE: luciE
 };

--- a/tests/lib/luci-e-harness.js
+++ b/tests/lib/luci-e-harness.js
@@ -1,0 +1,215 @@
+'use strict';
+
+/**
+ * LuCI-accurate E() DOM harness for Node tests (fwlive wave #149).
+ *
+ * Ported from openwrt/luci@f699752316ac4651ae4f4f966510d352670ca87a —
+ * dom.append/dom.create (plus the elem/attr/parse helpers they call),
+ * modules/luci-base/htdocs/luci-static/resources/luci.js.
+ *
+ * Unlike the module-loader stub `fakeE` (tests/lib/load-fwlive-module.js),
+ * which returns { tag, attrs, children } object literals, this harness
+ * renders real Node objects so the production array-vs-bare-string child
+ * discrimination is observable:
+ *
+ *   - array child            → document.createTextNode() → appendChild (NO innerHTML write)
+ *   - bare string child      → node.innerHTML = value    (the HTML sink; records every write)
+ *   - DOM Node child         → node.appendChild()
+ *
+ * `E` is `dom.create` bound to the ported `dom` object, exactly like LuCI's
+ * view-loader binding.
+ */
+
+/* Minimal Node surface: a recording innerHTML SETTER (every write pushed to
+ * _innerHTMLWrites), appendChild, setAttribute, plus the nodeType / lastChild
+ * / addEventListener members the ported dom code depends on. */
+class Node {
+	constructor(nodeType) {
+		this.nodeType = nodeType;
+		this.childNodes = [];
+		this.lastChild = null;
+		this._innerHTML = '';
+		this._innerHTMLWrites = [];
+		this._attrs = {};
+		this._listeners = {};
+	}
+
+	get innerHTML() {
+		return this._innerHTML;
+	}
+
+	set innerHTML(value) {
+		const html = String(value);
+		this._innerHTMLWrites.push(html);
+		this._innerHTML = html;
+		this.childNodes = [];
+		this.lastChild = null;
+	}
+
+	appendChild(node) {
+		this.childNodes.push(node);
+		this.lastChild = node;
+		return node;
+	}
+
+	setAttribute(key, value) {
+		this._attrs[key] = String(value);
+	}
+
+	addEventListener(type, fn) {
+		(this._listeners[type] = this._listeners[type] || []).push(fn);
+	}
+}
+
+class Element extends Node {
+	constructor(tagName) {
+		super(1);
+		this.tagName = tagName;
+	}
+}
+
+class TextNode extends Node {
+	constructor(text) {
+		super(3);
+		this.textContent = String(text);
+		this.nodeValue = this.textContent;
+	}
+}
+
+class DocumentFragment extends Node {
+	constructor() {
+		super(11);
+	}
+}
+
+/* Node has no DOMParser; the ported parse() swallows the failure and returns
+ * null, which is the same result create() gets for a "<"-prefixed name here. */
+const domParser = null;
+
+const document = {
+	createElement: function(tagName) { return new Element(tagName); },
+	createTextNode: function(text) { return new TextNode(text); },
+	createDocumentFragment: function() { return new DocumentFragment(); }
+};
+
+/* --- Ported verbatim from upstream luci.js (openwrt/luci@f6997523) --- */
+
+const dom = {
+	elem(e) {
+		return (e != null && typeof(e) == 'object' && 'nodeType' in e);
+	},
+
+	parse(s) {
+		try {
+			return domParser.parseFromString(s, 'text/html').body.firstChild;
+		}
+		catch(e) {
+			return null;
+		}
+	},
+
+	append(node, children) {
+		if (!this.elem(node))
+			return null;
+
+		if (Array.isArray(children)) {
+			for (let i = 0; i < children.length; i++) {
+				if (this.elem(children[i]))
+					node.appendChild(children[i]);
+				else if (children[i] !== null && children[i] !== undefined)
+					node.appendChild(document.createTextNode(`${children[i]}`));
+			}
+
+			return node.lastChild;
+		}
+		else if (typeof(children) === 'function') {
+			return this.append(node, children(node));
+		}
+		else if (this.elem(children)) {
+			return node.appendChild(children);
+		}
+		else if (children !== null && children !== undefined) {
+			node.innerHTML = `${children}`;
+			return node.lastChild;
+		}
+
+		return null;
+	},
+
+	attr(node, key, val) {
+		if (!this.elem(node))
+			return null;
+
+		let attr = null;
+
+		if (typeof(key) === 'object' && key !== null)
+			attr = key;
+		else if (typeof(key) === 'string')
+			attr = {}, attr[key] = val;
+
+		for (key in attr) {
+			if (!attr.hasOwnProperty(key) || attr[key] == null)
+				continue;
+
+			switch (typeof(attr[key])) {
+			case 'function':
+				node.addEventListener(key, attr[key]);
+				break;
+
+			case 'object':
+				node.setAttribute(key, JSON.stringify(attr[key]));
+				break;
+
+			default:
+				node.setAttribute(key, attr[key]);
+			}
+		}
+	},
+
+	create() {
+		const html = arguments[0];
+		let attr = arguments[1];
+		let data = arguments[2];
+		let elem;
+
+		if (!(attr instanceof Object) || Array.isArray(attr))
+			data = attr, attr = null;
+
+		if (Array.isArray(html)) {
+			elem = document.createDocumentFragment();
+			for (let i = 0; i < html.length; i++)
+				elem.appendChild(this.create(html[i]));
+		}
+		else if (this.elem(html)) {
+			elem = html;
+		}
+		else if (typeof(html) === 'string' && html.charCodeAt(0) === 60) {
+			elem = this.parse(html);
+		}
+		else {
+			elem = document.createElement(html);
+		}
+
+		if (!elem)
+			return null;
+
+		this.attr(elem, attr);
+		this.append(elem, data);
+
+		return elem;
+	}
+};
+
+/* LuCI binds E → dom.create in the view context. */
+const E = dom.create.bind(dom);
+
+module.exports = {
+	Node: Node,
+	Element: Element,
+	TextNode: TextNode,
+	DocumentFragment: DocumentFragment,
+	document: document,
+	dom: dom,
+	E: E,
+	PortedFrom: 'openwrt/luci@f699752316ac4651ae4f4f966510d352670ca87a'
+};

--- a/tests/lib/luci-e-harness.js
+++ b/tests/lib/luci-e-harness.js
@@ -42,8 +42,14 @@ class Node {
 		const html = String(value);
 		this._innerHTMLWrites.push(html);
 		this._innerHTML = html;
-		this.childNodes = [];
-		this.lastChild = null;
+		// Fidelity note (luna fold 2026-08-10): real DOM parsing creates
+		// child nodes; this harness deliberately does NOT parse HTML (no
+		// DOMParser dependency). To honor dom.append()'s contract of
+		// returning the resulting last child for bare strings, synthesize a
+		// single text node holding the raw string — the write is still
+		// recorded, which is what the #148 regression tests assert on.
+		this.childNodes = [new TextNode(html)];
+		this.lastChild = this.childNodes[0];
 	}
 
 	appendChild(node) {

--- a/tests/lib/luci-e-harness.js
+++ b/tests/lib/luci-e-harness.js
@@ -48,8 +48,15 @@ class Node {
 		// returning the resulting last child for bare strings, synthesize a
 		// single text node holding the raw string — the write is still
 		// recorded, which is what the #148 regression tests assert on.
-		this.childNodes = [new TextNode(html)];
-		this.lastChild = this.childNodes[0];
+		// EMPTY html matches real DOM: no child, lastChild === null
+		// (the renderer's clear must not leave a synthetic empty node).
+		if (html.length > 0) {
+			this.childNodes = [new TextNode(html)];
+			this.lastChild = this.childNodes[0];
+		} else {
+			this.childNodes = [];
+			this.lastChild = null;
+		}
 	}
 
 	appendChild(node) {


### PR DESCRIPTION
Closes #149 — the fwlive remediation wave (canonical plan #153). Prerequisite for #148 (E() text-node sweep).

## What

**Additive test infrastructure — zero production JS changes.**

- `tests/lib/luci-e-harness.js` — Node-class DOM harness: `innerHTML` setter **records every write** to `_innerHTMLWrites`, plus `appendChild`/`setAttribute`/`addEventListener`. `dom.append`/`dom.create` ported **verbatim** from `openwrt/luci@f699752316ac4651ae4f4f966510d352670ca87a` (`modules/luci-base/htdocs/luci-static/resources/luci.js`) with the `elem`/`attr`/`parse` helpers they call. SHA pinned in the file header + exported as `PortedFrom`; every function body diff-verified byte-identical.
- `tests/fwlive-e-harness.test.js` — discriminating renderer tests:
  - array child → `TextNode` children, **0 innerHTML writes**
  - bare string child → **exactly 1 recorded innerHTML write**
  - `<b>x</b>` as bare string → reaches the sink; as array child → stays `textContent`, 0 writes
  - real `logging.renderEmptyState`/consent panel render under the harness
- `tests/lib/load-fwlive-module.js` — additive `luciE` re-export; `fakeE` untouched
- `scripts/fwlive-test.sh` — wired the new test into the runner

## Red/green evidence

Same assertions against `fakeE` throw (`Cannot read properties of undefined (reading 'length')`) — object literals have no `innerHTML` setter/`childNodes`. With the real harness: `node tests/fwlive-e-harness.test.js` → passed; `npm test` → all passed.

## Why this matters

The existing stub returns `{tag, attrs, children}` object literals — DOM-injection regressions (values reaching an HTML sink instead of a text node) are structurally invisible to it. This harness models upstream LuCI's array-vs-bare-string semantics exactly, so #148's sweep is verifiable.
