### PR TITLE
ci(security): SHA-pin all GitHub Actions + env-input routing (#143, #146)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4

--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
         with:
           node-version: '22'
       - name: Install shellcheck and busybox

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -33,15 +33,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
 
       - name: Resolve release tag
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            tag="${{ github.event.inputs.tag }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$TAG"
           else
             tag="${GITHUB_REF#refs/tags/}"
           fi
@@ -76,7 +79,7 @@ jobs:
 
       # #122: reuse feed clones + dl/ across publishes (lock hash = cache key).
       - name: Cache SDK feeds and dl
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .cache/sdk-feeds
           key: sdk-feeds-${{ runner.os }}-${{ hashFiles('scripts/feeds.lock/**') }}
@@ -111,7 +114,7 @@ jobs:
         run: ./scripts/publish-packages.sh feed-staging
 
       - name: Deploy to GitHub Pages (fwlive-packages)
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:
           deploy_key: ${{ secrets.FEED_DEPLOY_KEY }}
           external_repository: ${{ env.FWLIVE_PACKAGES_REPO }}
@@ -184,7 +187,7 @@ jobs:
       OWRT_QEMU_ACCEL: tcg
       OWRT_VALIDATE_SSH_WAIT_X86: "900"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
@@ -200,7 +203,8 @@ jobs:
       - name: Feed smoke (single reference cell)
         env:
           FWLIVE_FEED_BASE_URL: ${{ env.FWLIVE_FEED_BASE_URL }}
+          SMOKE_VERSION: ${{ github.event.inputs.smoke_version || '24.10' }}
         run: |
-          ver="${{ github.event.inputs.smoke_version || '24.10' }}"
+          ver="$SMOKE_VERSION"
           echo "Feed smoke OpenWrt version: $ver"
           ./scripts/validate-feed-smoke.sh --version "$ver"


### PR DESCRIPTION
Closes #143 + #146 — the fwlive remediation wave (canonical plan #153). One bundled PR (both classes touch `.github/workflows/`).

## Part A — #143: SHA-pin all GitHub Actions

Every action referenced by mutable tag → commit SHA + version comment. **8 pins, all verified against upstream peeled tags** (`git ls-remote refs/tags/X^{}`):

| Action | SHA | Version |
|---|---|---|
| `peaceiris/actions-gh-pages` (holds **FEED_DEPLOY_KEY**) | `84c30a85c19949d7eee79c4ff27748b70285e453` | v4.1.0 |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7 |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4 |
| `actions/dependency-review-action` | `2031cfc080254a8a887f58cffee85186f0e49e48` | v4 |
| `actions/setup-node` | `249970729cb0ef3589644e2896645e5dc5ba9c38` | v6 |

No version upgrades — current tags pinned only.

## Part B — #146: dispatch inputs via env, not inline shell

- `publish-packages.yml:41-52` (Resolve release tag): `tag` + `event_name` now pass via `env:`, referenced as `$TAG`/`$EVENT_NAME` in the `run:` body
- `publish-packages.yml:203-210` (Feed smoke): `smoke_version` via `env:` → `$SMOKE_VERSION`
- The `ref:` interpolations at `:39`/`:179` are YAML `with:` values (not shell injection sites) — left as-is

## ACs

- [x] 0 mutable tag references remain (grep `@v`/`@main`/`@master` = 0)
- [x] FEED_DEPLOY_KEY consumer SHA-pinned
- [x] 0 `${{ github.event.inputs.* }}` inside `run:` blocks (env: only)
- [x] All 3 workflow YAML files parse (PyYAML)
