### PR TITLE
fix(ui): route all E() string children through text nodes (#148)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/Makefile
+++ b/openwrt-feed/luci-app-fwlive/Makefile
@@ -11,7 +11,7 @@ LUCI_DESCRIPTION:=Live firewall log table (nftables/fw4 and iptables LOG) with f
 LUCI_DEPENDS:=+luci-base +logd
 LUCI_PKGARCH:=all
 
-PKG_VERSION:=0.1.31
+PKG_VERSION:=0.1.32
 PKG_RELEASE:=1
 
 # Reproducible build: honor SOURCE_DATE_EPOCH from the build environment (set by docker-sdk.sh / CI).

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
@@ -26,13 +26,13 @@ function chipValueNodes(field, val, style) {
 		return [ '' ];
 
 	const valueNode = (style === 'labels' && p.negate)
-		? E('span', { 'class': 'fwlive-chip-strike' }, p.value)
+		? E('span', { 'class': 'fwlive-chip-strike' }, [ p.value ])
 		: p.value;
 
 	if (!p.negate) {
 		if (style === 'labels')
 			return [
-				E('span', { 'class': 'fwlive-chip-polarity' }, _('is')),
+				E('span', { 'class': 'fwlive-chip-polarity' }, [ _('is') ]),
 				' ',
 				log.formatFilterChipLabel(field, val)
 			];
@@ -42,14 +42,14 @@ function chipValueNodes(field, val, style) {
 	if (field === 'q' || field === 'src' || field === 'dst')
 		return [
 			field + ': ',
-			E('strong', { 'class': 'fwlive-chip-not' }, _('not')),
+			E('strong', { 'class': 'fwlive-chip-not' }, [ _('not') ]),
 			' contains ',
 			valueNode
 		];
 
 	return [
 		field + ': ',
-		E('strong', { 'class': 'fwlive-chip-not' }, _('not')),
+		E('strong', { 'class': 'fwlive-chip-not' }, [ _('not') ]),
 		' ',
 		valueNode
 	];
@@ -61,13 +61,13 @@ function chipLeadingSym(style, negated) {
 		return E('span', {
 			'class': 'fwlive-chip-sym',
 			'aria-hidden': 'true'
-		}, negated ? '≠' : '=');
+		}, [ negated ? '≠' : '=' ]);
 
 	if (style === 'labels' && negated)
 		return E('span', {
 			'class': 'fwlive-chip-sym fwlive-chip-sym-light',
 			'aria-hidden': 'true'
-		}, '≠');
+		}, [ '≠' ]);
 
 	return null;
 }
@@ -100,14 +100,14 @@ function renderFilterChips(host, state, callbacks) {
 				'type': 'button',
 				'class': 'fwlive-chip-invert',
 				'click': function(ev) { callbacks.onInvert(spec.key, ev); }
-			}, '≠')
+			}, [ '≠' ])
 		]));
 		kids.push(E('a', {
 			'href': '#',
 			'class': 'fwlive-chip-remove',
 			'title': _('Remove filter'),
 			'click': function(ev) { callbacks.onClear(spec.key, ev); }
-		}, '×'));
+		}, [ '×' ]));
 
 		chips.push(E('span', {
 			'class': 'fwlive-chip'
@@ -130,7 +130,7 @@ function renderFilterChips(host, state, callbacks) {
 		'href': '#',
 		'class': 'fwlive-chip-clear',
 		'click': function(ev) { callbacks.onClearAll(ev); }
-	}, _('Clear all')));
+	}, [ _('Clear all') ]));
 }
 
 return baseclass.extend({

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
@@ -7,7 +7,7 @@
  */
 return baseclass.extend({
 	/* Keep in sync with openwrt-feed/luci-app-fwlive/Makefile PKG_VERSION. */
-	APP_VERSION: '0.1.31',
+	APP_VERSION: '0.1.32',
 	ROW_LIMIT_OPTIONS: [ 25, 50, 100, 250, 500, 1000, 2000 ],
 	DEFAULT_ROW_LIMIT: 100,
 	/* Filter chip polarity presentation (#18): labels = A+light B default */

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js
@@ -3,7 +3,7 @@
 
 /**
  * Inline stylesheet string for luci-app-fwlive.
- * Exports CSS text for E('style', {}, css.styleText) injection — NOT a standalone .css asset.
+ * Exports CSS text for E('style', {}, [css.styleText]) injection — NOT a standalone .css asset.
  * LuCI modules must return baseclass.extend(...) — plain objects fail Class.isSubclass.
  *
  * GENERATED — do not edit. Edit fwlive.css and run: node scripts/embed-fwlive-css.js

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
@@ -34,7 +34,7 @@ function firewallZonesLink(label) {
 	return E('a', {
 		'href': firewallZonesUrl(),
 		'class': 'fwlive-filter-link'
-	}, label || _('Network → Firewall'));
+	}, [ label || _('Network → Firewall') ]);
 }
 
 /**
@@ -52,7 +52,7 @@ function filterLink(field, value, label, onFilterClick) {
 		'class': 'fwlive-filter-link',
 		'title': _('Filter by %s').format(field),
 		'click': function(ev) { onFilterClick(field, value, ev); }
-	}, label || value);
+	}, [ label || value ]);
 }
 
 /**
@@ -75,7 +75,7 @@ function addrFilterLink(field, ip, showHostnames, hostnameCache, onFilterClick) 
 		'class': 'fwlive-filter-link',
 		'title': title,
 		'click': function(ev) { onFilterClick(field, ip, ev); }
-	}, display);
+	}, [ display ]);
 }
 
 /**
@@ -119,7 +119,7 @@ function ruleAdminLink(hint, label, firewallBackend, onFilterClick) {
 			}
 			onFilterClick('q', hint, ev);
 		}
-	}, text);
+	}, [ text ]);
 }
 
 /**
@@ -135,7 +135,7 @@ function ifaceLink(value, onFilterClick) {
 		'class': 'fwlive-filter-link fwlive-iface-badge',
 		'title': _('Filter by interface'),
 		'click': function(ev) { onFilterClick('interface', value, ev); }
-	}, value);
+	}, [ value ]);
 }
 
 return baseclass.extend({

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
@@ -67,59 +67,59 @@ function renderToolbar(host, state, callbacks) {
 
 	if (blocker === 'no_wan_zone') {
 		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-			_('WAN logging unavailable: no WAN zone')));
+			[ _('WAN logging unavailable: no WAN zone') ]));
 		host.appendChild(links.firewallZonesLink());
 		return;
 	}
 
 	if (blocker === 'nf_log_missing') {
 		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-			_('WAN logging unavailable: missing kernel log modules')));
+			[ _('WAN logging unavailable: missing kernel log modules') ]));
 		return;
 	}
 
 	const limit = st.wan_log_limit || _('default 10/minute');
 	if (st.wan_log) {
 		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-			_('WAN logging: on · %s').format(limit)));
+			[ _('WAN logging: on · %s').format(limit) ]));
 		host.appendChild(E('button', {
 			'class': 'cbi-button fwlive-btn-quiet',
 			'type': 'button',
 			'title': _('WAN logging on (%s). Click to disable.').format(limit),
 			'disabled': state.loggingBusy ? '' : null,
 			'click': function() { callbacks.onDisable(); }
-		}, state.loggingBusy ? _('Disabling…') : _('WAN logging on')));
+		}, [ state.loggingBusy ? _('Disabling…') : _('WAN logging on') ]));
 		return;
 	}
 
 	host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-		_('WAN logging: off')));
+		[ _('WAN logging: off') ]));
 	host.appendChild(E('button', {
 		'class': 'cbi-button cbi-button-action',
 		'type': 'button',
 		'title': _('Enable WAN zone drop/reject logging (same as Network → Firewall).'),
 		'disabled': state.loggingBusy ? '' : null,
 		'click': function() { callbacks.onEnable(); }
-	}, state.loggingBusy ? _('Enabling…') : _('Enable logging')));
+	}, [ state.loggingBusy ? _('Enabling…') : _('Enable logging') ]));
 }
 
 function buildConsentPanel(state, callbacks) {
 	const dontShowId = 'fwlive-consent-dont-show';
 	const panel = E('div', { 'class': 'fwlive-consent', 'id': 'fwlive-consent' }, [
-		E('p', { 'class': 'fwlive-empty-title' }, _('Before you enable logging')),
+		E('p', { 'class': 'fwlive-empty-title' }, [ _('Before you enable logging') ]),
 		E('ul', { 'class': 'fwlive-consent-list' }, [
 			E('li', {}, [
-				E('strong', {}, _('Changes:')),
+				E('strong', {}, [ _('Changes:') ]),
 				' ',
 				_('sets log on the WAN firewall zone and reloads the firewall.')
 			]),
 			E('li', {}, [
-				E('strong', {}, _('Does not change:')),
+				E('strong', {}, [ _('Does not change:') ]),
 				' ',
 				_('allow/deny rules, LAN logging, or anything else.')
 			]),
 			E('li', {}, [
-				E('strong', {}, _('Undo:')),
+				E('strong', {}, [ _('Undo:') ]),
 				' ',
 				_('turn it back off with the WAN logging on control on the watch strip.')
 			])
@@ -143,7 +143,7 @@ function buildConsentPanel(state, callbacks) {
 					persistConsentDismissed();
 					callbacks.onEnable();
 				}
-			}, state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging')),
+			}, [ state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging') ]),
 			' ',
 			E('button', {
 				'class': 'cbi-button',
@@ -156,7 +156,7 @@ function buildConsentPanel(state, callbacks) {
 					if (callbacks.onDismissConsent)
 						callbacks.onDismissConsent(persist);
 				}
-			}, _('Not now')),
+			}, [ _('Not now') ]),
 			' ',
 			links.firewallZonesLink(_('I’ll configure this under Network → Firewall'))
 		])
@@ -178,7 +178,7 @@ function buildEmptyStateNodes(state, callbacks) {
 	}
 
 	if (blocker === 'no_wan_zone') {
-		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, _('No WAN zone found')));
+		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('No WAN zone found') ]));
 		nodes.push(E('p', {}, [
 			_('No WAN firewall zone found in /etc/config/firewall. Configure zones under '),
 			links.firewallZonesLink()
@@ -187,24 +187,24 @@ function buildEmptyStateNodes(state, callbacks) {
 	}
 
 	if (blocker === 'nf_log_missing') {
-		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, _('Kernel log modules missing')));
-		nodes.push(E('p', {}, _('Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall.')));
+		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('Kernel log modules missing') ]));
+		nodes.push(E('p', {}, [ _('Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall.') ]));
 		nodes.push(E('p', {}, [
-			E('code', {}, 'opkg update && opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6')
+			E('code', {}, [ 'opkg update && opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6' ])
 		]));
 		return nodes;
 	}
 
 	if (st && st.wan_log) {
-		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, _('Waiting for firewall events')));
-		nodes.push(E('p', {}, _('WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not.')));
-		nodes.push(E('p', { 'class': 'fwlive-empty-muted' }, _('If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide.')));
+		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('Waiting for firewall events') ]));
+		nodes.push(E('p', {}, [ _('WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not.') ]));
+		nodes.push(E('p', { 'class': 'fwlive-empty-muted' }, [ _('If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide.') ]));
 		nodes.push(E('p', {}, links.firewallZonesLink(_('Open firewall zone settings'))));
 		return nodes;
 	}
 
-	nodes.push(E('p', { 'class': 'fwlive-empty-title' }, _('Logging is off on this router')));
-	nodes.push(E('p', {}, _('OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules.')));
+	nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('Logging is off on this router') ]));
+	nodes.push(E('p', {}, [ _('OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules.') ]));
 
 	/* Consent bullets already spell out the effect — do not repeat it or the CTA. */
 	if (state.showConsent) {
@@ -212,8 +212,8 @@ function buildEmptyStateNodes(state, callbacks) {
 		return nodes;
 	}
 
-	nodes.push(E('p', {}, _('Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged.')));
-	nodes.push(E('p', { 'class': 'fwlive-empty-muted' }, _('Nothing changes until you click Enable.')));
+	nodes.push(E('p', {}, [ _('Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged.') ]));
+	nodes.push(E('p', { 'class': 'fwlive-empty-muted' }, [ _('Nothing changes until you click Enable.') ]));
 	nodes.push(E('p', {}, [
 		E('button', {
 			'class': 'cbi-button cbi-button-action',
@@ -223,7 +223,7 @@ function buildEmptyStateNodes(state, callbacks) {
 				persistConsentDismissed();
 				callbacks.onEnable();
 			}
-		}, state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging')),
+		}, [ state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging') ]),
 		' ',
 		links.firewallZonesLink(_('I’ll configure this under Network → Firewall'))
 	]));
@@ -246,11 +246,11 @@ function renderManualTestNodes(host, state, _callbacks) {
 	host.innerHTML = '';
 	if (state.firewallBackend === 'iptables') {
 		host.appendChild(document.createTextNode(_('Manual test (System → Terminal): ')));
-		host.appendChild(E('code', {}, 'iptables -I INPUT -p icmp --icmp-type echo-request -j LOG --log-prefix "fwlive-ping: "'));
+		host.appendChild(E('code', {}, [ 'iptables -I INPUT -p icmp --icmp-type echo-request -j LOG --log-prefix "fwlive-ping: "' ]));
 		host.appendChild(document.createTextNode(_(' then ping the router.')));
 	} else {
 		host.appendChild(document.createTextNode(_('Manual test (System → Terminal): ')));
-		host.appendChild(E('code', {}, 'nft insert rule inet fw4 input ip protocol icmp icmp type echo-request log prefix "fwlive-ping " accept'));
+		host.appendChild(E('code', {}, [ 'nft insert rule inet fw4 input ip protocol icmp icmp type echo-request log prefix "fwlive-ping " accept' ]));
 		host.appendChild(document.createTextNode(_(' then ping the router.')));
 	}
 }

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
@@ -90,7 +90,7 @@ function flowCell(row, state, callbacks) {
 
 	pushAddr(row.src, row.sport, 'src', 'sport');
 	if (parts.length && (row.dst || row.dport))
-		parts.push(E('span', { 'class': 'fwlive-flow-arrow' }, ' → '));
+		parts.push(E('span', { 'class': 'fwlive-flow-arrow' }, [ ' → ' ]));
 	pushAddr(row.dst, row.dport, 'dst', 'dport');
 
 	if (!parts.length)
@@ -109,57 +109,57 @@ function buildColumnCell(col, row, state, callbacks) {
 	switch (col) {
 	case 'time':
 		return E('td', { 'class': columnCellClass(col) },
-			state.viewMode === 'simple'
+			[ state.viewMode === 'simple'
 				? log.formatTimestampCompact(row.timestamp)
-				: log.formatTimestampLocal(row.timestamp));
+				: log.formatTimestampLocal(row.timestamp) ]);
 	case 'action':
-		return E('td', { 'class': log.actionRowClass(row.action) }, actionCell);
+		return E('td', { 'class': log.actionRowClass(row.action) }, [ actionCell ]);
 	case 'rule':
 		return E('td', { 'class': columnCellClass(col) },
-			links.ruleAdminLink(row.rule_hint, row.rule_label, state.firewallBackend, onFilterClick));
+			[ links.ruleAdminLink(row.rule_hint, row.rule_label, state.firewallBackend, onFilterClick) ]);
 	case 'iface':
 		return E('td', { 'class': columnCellClass(col) },
-			links.ifaceLink(row.interface_in, onFilterClick));
+			[ links.ifaceLink(row.interface_in, onFilterClick) ]);
 	case 'iface_in':
 	case 'iface_out':
-		return E('td', { 'class': columnCellClass(col) }, links.ifaceLink(
-			col === 'iface_in' ? row.interface_in : row.interface_out, onFilterClick));
+		return E('td', { 'class': columnCellClass(col) }, [ links.ifaceLink(
+			col === 'iface_in' ? row.interface_in : row.interface_out, onFilterClick) ]);
 	case 'dir':
-		return E('td', { 'class': columnCellClass(col) }, log.formatCell(row.direction));
+		return E('td', { 'class': columnCellClass(col) }, [ log.formatCell(row.direction) ]);
 	case 'proto':
 		return E('td', { 'class': columnCellClass(col) },
-			links.filterLink('proto', row.proto, null, onFilterClick));
+			[ links.filterLink('proto', row.proto, null, onFilterClick) ]);
 	case 'src':
 		return E('td', { 'class': columnCellClass(col) },
-			links.addrFilterLink('src', row.src, !!state.showHostnames, state.hostnameCache, onFilterClick));
+			[ links.addrFilterLink('src', row.src, !!state.showHostnames, state.hostnameCache, onFilterClick) ]);
 	case 'sport':
 		return E('td', { 'class': columnCellClass(col) },
-			links.filterLink('sport', row.sport, null, onFilterClick));
+			[ links.filterLink('sport', row.sport, null, onFilterClick) ]);
 	case 'dst':
 		return E('td', { 'class': columnCellClass(col) },
-			links.addrFilterLink('dst', row.dst, !!state.showHostnames, state.hostnameCache, onFilterClick));
+			[ links.addrFilterLink('dst', row.dst, !!state.showHostnames, state.hostnameCache, onFilterClick) ]);
 	case 'dport':
 		return E('td', { 'class': columnCellClass(col) },
-			links.filterLink('dport', row.dport, null, onFilterClick));
+			[ links.filterLink('dport', row.dport, null, onFilterClick) ]);
 	case 'flags':
-		return E('td', { 'class': columnCellClass(col) }, log.formatCell(row.flags));
+		return E('td', { 'class': columnCellClass(col) }, [ log.formatCell(row.flags) ]);
 	case 'len':
-		return E('td', { 'class': columnCellClass(col) }, row.length != null ? String(row.length) : '');
+		return E('td', { 'class': columnCellClass(col) }, [ row.length != null ? String(row.length) : '' ]);
 	case 'flow':
-		return E('td', { 'class': columnCellClass(col) }, flowCell(row, state, callbacks));
+		return E('td', { 'class': columnCellClass(col) }, [ flowCell(row, state, callbacks) ]);
 	case 'message':
 		if (state.messageLayout === 'wrap') {
 			return E('td', {
 				'class': 'fwlive-message',
 				'title': msgDisplay || ''
-			}, E('div', { 'class': 'fwlive-message-wrap' }, msgDisplay || '—'));
+			}, E('div', { 'class': 'fwlive-message-wrap' }, [ msgDisplay || '—' ]));
 		}
 		return E('td', {
 			'class': 'fwlive-message',
 			'title': msgDisplay || ''
-		}, msgDisplay || '—');
+		}, [ msgDisplay || '—' ]);
 	default:
-		return E('td', {}, '');
+		return E('td', {}, [ '' ]);
 	}
 }
 
@@ -182,7 +182,7 @@ function renderThead(host, state, _callbacks) {
 	for (let i = 0; i < columns.length; i++) {
 		const col = columns[i];
 		colgroup.appendChild(E('col', { 'class': 'fwlive-col fwlive-col-' + col.replace(/_/g, '-') }));
-		tr.appendChild(E('th', { 'class': columnCellClass(col) }, columnLabel(col)));
+		tr.appendChild(E('th', { 'class': columnCellClass(col) }, [ columnLabel(col) ]));
 	}
 }
 
@@ -214,9 +214,9 @@ function renderRows(host, state, callbacks) {
 		if (state.viewMode === 'simple' && state.expandedRowId === r.id) {
 			host.appendChild(E('tr', { 'class': 'fwlive-msg-expand' }, [
 				E('td', { 'colspan': String(columns.length) }, [
-					E('div', { 'class': 'fwlive-msg-expand-label' }, _('Message')),
+					E('div', { 'class': 'fwlive-msg-expand-label' }, [ _('Message') ]),
 					E('pre', { 'class': 'fwlive-msg-expand-body' },
-						log.formatMessageDisplay(r.message, 'wrap') || '—')
+						[ log.formatMessageDisplay(r.message, 'wrap') || '—' ])
 				])
 			]));
 		}

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -82,7 +82,7 @@ function storeValue(key, value) {
 function optionNodes(pairs) {
 	const opts = [];
 	for (let i = 0; i < pairs.length; i++)
-		opts.push(E('option', { 'value': pairs[i][0] }, pairs[i][1]));
+		opts.push(E('option', { 'value': pairs[i][0] }, [ pairs[i][1] ]));
 	return opts;
 }
 
@@ -1437,28 +1437,28 @@ return view.extend({
 
 	render() {
 		return E('div', { 'class': 'cbi-map fwlive-map', 'data-view': 'simple', 'data-row-tint': 'classic' }, [
-			E('style', {}, css.styleText),
+			E('style', {}, [css.styleText]),
 			E('h2', {}, [
 				_('Firewall Live View'),
-				E('span', { 'id': 'fwlive-backend', 'class': 'fwlive-backend' }, '')
+				E('span', { 'id': 'fwlive-backend', 'class': 'fwlive-backend' }, [ '' ])
 			]),
 			E('div', { 'id': 'fwlive-watch-strip', 'class': 'fwlive-watch-strip' }, [
 				E('div', { 'class': 'fwlive-watch-left' }, [
-					E('span', { 'id': 'fwlive-watch-dot', 'class': 'fwlive-dot fwlive-dot-on', 'aria-hidden': 'true' }, ''),
-					E('span', { 'id': 'fwlive-watch-label', 'class': 'fwlive-watch-label' }, _('Watching')),
-					E('span', { 'id': 'fwlive-status', 'class': 'fwlive-status' }, ''),
+					E('span', { 'id': 'fwlive-watch-dot', 'class': 'fwlive-dot fwlive-dot-on', 'aria-hidden': 'true' }, [ '' ]),
+					E('span', { 'id': 'fwlive-watch-label', 'class': 'fwlive-watch-label' }, [ _('Watching') ]),
+					E('span', { 'id': 'fwlive-status', 'class': 'fwlive-status' }, [ '' ]),
 					E('span', {
 						'id': 'fwlive-tint-warn',
 						'class': 'fwlive-tint-warn',
 						'title': _('Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds.')
-					}, _('Theme tint fallback'))
+					}, [ _('Theme tint fallback') ])
 				]),
 				E('div', { 'class': 'fwlive-watch-actions' }, [
 					E('button', {
 						'id': 'fwlive-pause',
 						'class': 'cbi-button fwlive-btn-ghost',
 						'type': 'button'
-					}, _('Pause')),
+					}, [ _('Pause') ]),
 					E('span', { 'id': 'fwlive-logging-bar', 'class': 'fwlive-logging-bar' }, []),
 					E('button', {
 						'id': 'fwlive-detail-toggle',
@@ -1466,23 +1466,23 @@ return view.extend({
 						'type': 'button',
 						'aria-pressed': 'false',
 						'click': this.toggleDetailView.bind(this)
-					}, _('Show Detail')),
+					}, [ _('Show Detail') ]),
 					E('button', {
 						'id': 'fwlive-msg-layout',
 						'class': 'cbi-button fwlive-btn-ghost',
 						'type': 'button',
 						'click': this.toggleMessageLayout.bind(this)
-					}, _('Message: wrap'))
+					}, [ _('Message: wrap') ])
 				])
 			]),
-			E('div', { 'id': 'fwlive-flood', 'class': 'fwlive-flood' }, ''),
+			E('div', { 'id': 'fwlive-flood', 'class': 'fwlive-flood' }, [ '' ]),
 			E('details', { 'id': 'fwlive-display-drawer', 'class': 'fwlive-display-drawer' }, [
 				E('summary', {}, [
-					E('span', { 'class': 'fwlive-drawer-sum' }, _('Display options'))
+					E('span', { 'class': 'fwlive-drawer-sum' }, [ _('Display options') ])
 				]),
 				E('div', { 'class': 'fwlive-drawer-body fwlive-drawer-grouped' }, [
 					E('div', { 'class': 'fwlive-gcol' }, [
-						E('h3', {}, _('Live')),
+						E('h3', {}, [ _('Live') ]),
 						E('label', { 'class': 'fwlive-ctl', 'for': 'fwlive-limit' }, [
 							_('Limit'),
 							E('select', {
@@ -1491,10 +1491,10 @@ return view.extend({
 							}, this.limitSelectOptions())
 						]),
 						E('p', { 'class': 'fwlive-drawer-hint' },
-							_('Live updates run until you Pause above.'))
+							[ _('Live updates run until you Pause above.') ])
 					]),
 					E('div', { 'class': 'fwlive-gcol' }, [
-						E('h3', {}, _('Row look')),
+						E('h3', {}, [ _('Row look') ]),
 						E('button', {
 							'id': 'fwlive-row-tint-toggle',
 							'class': 'cbi-button',
@@ -1502,13 +1502,13 @@ return view.extend({
 							'aria-pressed': 'true',
 							'title': _('Toggle pass/deny row background colors'),
 							'click': this.toggleRowTint.bind(this)
-						}, _('Hide row tint')),
+						}, [ _('Hide row tint') ]),
 						E('span', {
 							'id': 'fwlive-row-tint-palette-wrap',
 							'class': 'fwlive-ctl',
 							'style': 'display: inline-flex'
 						}, [
-							E('label', { 'class': 'fwlive-ctl', 'for': 'fwlive-row-tint' }, _('Palette')),
+							E('label', { 'class': 'fwlive-ctl', 'for': 'fwlive-row-tint' }, [ _('Palette') ]),
 							E('select', {
 								'id': 'fwlive-row-tint',
 								'class': 'cbi-input-select',
@@ -1524,7 +1524,7 @@ return view.extend({
 						])
 					]),
 					E('div', { 'class': 'fwlive-gcol' }, [
-						E('h3', {}, _('Filters look')),
+						E('h3', {}, [ _('Filters look') ]),
 						E('label', { 'class': 'fwlive-ctl', 'for': 'fwlive-chip-style' }, [
 							_('Chip style'),
 							E('select', {
@@ -1540,22 +1540,22 @@ return view.extend({
 				E('div', { 'class': 'fwlive-grid fwlive-grid-core' }, [
 					E('input', { 'id': 'fwlive-q', 'class': 'cbi-input-text', 'placeholder': _('Quick search') }),
 					E('select', { 'id': 'fwlive-action', 'class': 'cbi-input-select' }, [
-						E('option', { 'value': '' }, _('Any action')),
-						E('option', { 'value': 'pass' }, 'pass'),
-						E('option', { 'value': 'block' }, 'block'),
-						E('option', { 'value': 'drop' }, 'drop'),
-						E('option', { 'value': 'reject' }, 'reject'),
-						E('option', { 'value': 'unknown' }, 'unknown'),
-						E('option', { 'value': '!pass' }, _('not pass')),
-						E('option', { 'value': '!drop' }, _('not drop')),
-						E('option', { 'value': '!block' }, _('not block')),
-						E('option', { 'value': '!reject' }, _('not reject')),
-						E('option', { 'value': '!unknown' }, _('not unknown'))
+						E('option', { 'value': '' }, [ _('Any action') ]),
+						E('option', { 'value': 'pass' }, [ 'pass' ]),
+						E('option', { 'value': 'block' }, [ 'block' ]),
+						E('option', { 'value': 'drop' }, [ 'drop' ]),
+						E('option', { 'value': 'reject' }, [ 'reject' ]),
+						E('option', { 'value': 'unknown' }, [ 'unknown' ]),
+						E('option', { 'value': '!pass' }, [ _('not pass') ]),
+						E('option', { 'value': '!drop' }, [ _('not drop') ]),
+						E('option', { 'value': '!block' }, [ _('not block') ]),
+						E('option', { 'value': '!reject' }, [ _('not reject') ]),
+						E('option', { 'value': '!unknown' }, [ _('not unknown') ])
 					]),
 					E('input', { 'id': 'fwlive-proto', 'class': 'cbi-input-text', 'placeholder': _('Protocol (prefix ! to exclude)') })
 				]),
 				E('details', { 'id': 'fwlive-more-filters', 'class': 'fwlive-more-filters' }, [
-					E('summary', {}, _('More filters')),
+					E('summary', {}, [ _('More filters') ]),
 					E('div', { 'class': 'fwlive-grid fwlive-grid-extra' }, [
 						E('input', { 'id': 'fwlive-interface', 'class': 'cbi-input-text', 'placeholder': _('Interface (prefix ! to exclude)') }),
 						E('input', { 'id': 'fwlive-src', 'class': 'cbi-input-text', 'placeholder': _('Source IP contains (! to exclude)') }),
@@ -1567,7 +1567,7 @@ return view.extend({
 			]),
 			E('div', { 'id': 'fwlive-chips', 'class': 'fwlive-chips' }, []),
 			E('p', { 'class': 'fwlive-hint-line' },
-				_('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings')),
+				[ _('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings') ]),
 			E('div', {
 				'id': 'fwlive-empty',
 				'class': 'fwlive-empty',
@@ -1581,26 +1581,26 @@ return view.extend({
 			]),
 			E('div', { 'class': 'fwlive-help-row' }, [
 				E('details', { 'id': 'fwlive-help', 'class': 'fwlive-help' }, [
-					E('summary', {}, _('Help')),
+					E('summary', {}, [ _('Help') ]),
 					E('ul', {}, [
-						E('li', {}, _('The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast.')),
-						E('li', {}, _('Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing.')),
-						E('li', {}, _('Display options hides Limit, row tint, hostnames, and chip style.')),
-						E('li', {}, _('The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap.')),
+						E('li', {}, [ _('The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast.') ]),
+						E('li', {}, [ _('Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing.') ]),
+						E('li', {}, [ _('Display options hides Limit, row tint, hostnames, and chip style.') ]),
+						E('li', {}, [ _('The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap.') ]),
 						E('li', { 'id': 'fwlive-manual-test' }, []),
-						E('li', {}, _('Click a row to see the full log line (Simple view).')),
-						E('li', {}, _('Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead.')),
-						E('li', {}, _('Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels.')),
-						E('li', {}, _('Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way.')),
-						E('li', {}, _('Use Show Detail for all columns (flags, length, raw message).')),
-						E('li', {}, _('If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device).'))
+						E('li', {}, [ _('Click a row to see the full log line (Simple view).') ]),
+						E('li', {}, [ _('Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead.') ]),
+						E('li', {}, [ _('Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels.') ]),
+						E('li', {}, [ _('Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way.') ]),
+						E('li', {}, [ _('Use Show Detail for all columns (flags, length, raw message).') ]),
+						E('li', {}, [ _('If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device).') ])
 					])
 				]),
 				E('span', {
 					'id': 'fwlive-build',
 					'class': 'fwlive-build',
 					'title': 'luci-app-fwlive'
-				}, 'v' + constants.APP_VERSION)
+				}, [ 'v' + constants.APP_VERSION ])
 			])
 		]);
 	},

--- a/scripts/embed-fwlive-css.js
+++ b/scripts/embed-fwlive-css.js
@@ -33,7 +33,7 @@ function generate(cssText) {
 		'',
 		'/**',
 		' * Inline stylesheet string for luci-app-fwlive.',
-		" * Exports CSS text for E('style', {}, css.styleText) injection — NOT a standalone .css asset.",
+		" * Exports CSS text for E('style', {}, [css.styleText]) injection — NOT a standalone .css asset.",
 		' * LuCI modules must return baseclass.extend(...) — plain objects fail Class.isSubclass.',
 		' *',
 		' * GENERATED — do not edit. Edit fwlive.css and run: node scripts/embed-fwlive-css.js',

--- a/tests/fwlive-e-harness.test.js
+++ b/tests/fwlive-e-harness.test.js
@@ -146,14 +146,10 @@ function testRealRendererIntegration() {
 	}
 
 	const panelWrites = collectSubtreeInnerHTMLWrites(panel);
-	// CHARACTERIZATION (2026-08-10): today's renderer HAS bare-string
-	// sinks — logging.js:109,112,117,122 + the consent buttons write
-	// innerHTML (verified live under the real E()). This is exactly the
-	// #137/#148 bug class. The harness makes the sinks VISIBLE; the
-	// count below is the current state. Wave #148 flips this assertion
-	// to 0 after the text-node sweep.
-	assert.ok(panelWrites.length >= 1,
-		'subtree collector must see the renderer\'s current bare-string sinks (today: ' + panelWrites.length + ')');
+	// End state (#148): every string child is routed through a text node
+	// (array form), so the consent subtree must have ZERO innerHTML writes.
+	assert.strictEqual(panelWrites.length, 0,
+		'consent panel must be zero-sink after the text-node sweep');
 	assert.ok(panel.childNodes.length >= 4, 'panel children must be appended, not stringified');
 
 	const host = new Element('div');
@@ -165,19 +161,18 @@ function testRealRendererIntegration() {
 		showConsent: false
 	}, { onEnable: function() {} });
 	const hostWrites = collectSubtreeInnerHTMLWrites(host);
-	// Same characterization: the empty-state host ALSO renders bare-string
-	// sinks today (6 writes = the clear + the renderer's bare-string
-	// children). #148 flips this to exactly 1 (only the root clear).
-	assert.ok(hostWrites.length >= 1, 'host subtree collector must see current bare-string sinks');
-	assert.strictEqual(hostWrites[0].html, '', 'the first recorded write is the renderer clearing the host');
+	// End state (#148): the only innerHTML write in the whole subtree is
+	// the renderer clearing the host (''); every string child is a text node.
+	assert.strictEqual(hostWrites.length, 1,
+		'host subtree must have exactly one innerHTML write (the root clear)');
+	assert.strictEqual(hostWrites[0].html, '', 'the only write is the renderer clearing the host');
 	assert.ok(host.childNodes.length >= 1);
-	// Today the bare-string sinks synthesize TextNode children (the
-	// setter's no-DOMParser fallback); #148's end-state makes every
-	// child an element node. Characterization asserts "renders real
-	// nodes", not the end-state shape.
+	// End state (#148): every host child is an element node — the bare-string
+	// children that used to synthesize text nodes are now text nodes inside
+	// the elements, so no top-level child is a text node.
 	for (let i = 0; i < host.childNodes.length; i++)
-		assert.ok(host.childNodes[i].nodeType === 1 || host.childNodes[i].nodeType === 3,
-			'host children must be real nodes (element or text)');
+		assert.strictEqual(host.childNodes[i].nodeType, 1,
+			'host children must all be element nodes after the text-node sweep');
 }
 
 /* --- document shim fidelity for E('a', ..., [...]) --- */

--- a/tests/fwlive-theme-css.test.js
+++ b/tests/fwlive-theme-css.test.js
@@ -39,8 +39,8 @@ assert.strictEqual(
 );
 
 const text = fs.readFileSync(VIEW_PATH, 'utf8');
-if (!text.includes("E('style', {}, css.styleText)"))
-	throw new Error('fwlive.js must inject styles via css.styleText');
+if (!text.includes("E('style', {}, [css.styleText])"))
+	throw new Error('fwlive.js must inject styles via css.styleText (text-node form)');
 
 const cssMod = (function () {
 	const src = fs.readFileSync(CSS_PATH, 'utf8')


### PR DESCRIPTION
Closes #148 — the fwlive remediation wave (canonical plan #153). Mechanical change; advisory details tracked privately (GHSA-28m7-75jm-cqpf), published with/after release.

## What

Uniform rule applied at every E() call site in the shipped package: **all string children use the array (text-node) form** `E(tag, attrs, [ value ])`.

| File | Sites |
|---|---|
| `table.js` | 19 (flow-arrow, timestamp ternary, actionCell, rule/iface/addr cells, message wrap, default `''`, thead labels, expand rows) |
| `links.js` | 5 (all link helpers) |
| `chips.js` | 8 (values, polarity, symbols, buttons) |
| `logging.js` | 15 (toolbar, consent title/strongs/buttons, empty-state ps, code commands) |
| `view/status/fwlive.js` | 31 (style injection, options, headings, status spans, help list, build version) |
| `css.js` | regenerated via embed script (comment line only) |

Skipped only where children are already arrays/Node-valued (e.g. `parts`, `cells`, link-returning calls, option arrays) — verified per site.

## Regression guard

`tests/fwlive-e-harness.test.js` assertions flipped from "characterizes 6 live sinks" to the **zero-sink end state**: consent panel = 0 innerHTML writes, host subtree = exactly 1 (the root clear), all children element nodes. **Red/green proven**: reverting one site fails `consent panel must be zero-sink`; restore → green. The harness (merged #155) renders through real upstream LuCI E() semantics.

Also updated: `tests/fwlive-theme-css.test.js` guard + `scripts/embed-fwlive-css.js` emitter to the array form (regenerated css.js agrees). **PKG_VERSION 0.1.31 → 0.1.32.**

## Verification

- Harness test passed; theme-css test passed; `npm test` all passed
- Zero bare-string E() children remain (harness-verified, not grep-claimed)
