### PR TITLE
fix(supply-chain): verify sha256 of downloaded lab images + u-boot (#145)

### DIFF
--- a/scripts/download-openwrt-armsr-armv8.sh
+++ b/scripts/download-openwrt-armsr-armv8.sh
@@ -16,6 +16,65 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT="${ROOT}/lab/images"
 mkdir -p "${OUT}"
 
+# Verify a downloaded artifact against an upstream sha256sums manifest.
+# Args: <local_file> <manifest_name> <sha256sums_file> <strict>
+#   strict=1: abort if no manifest entry (disk images are always published)
+#   strict=0: note + skip if no entry (e.g. u-boot.bin on older armsr releases)
+verify_downloaded_sha256() {
+	local file="$1" name="$2" manifest="$3" strict="${4:-1}" expected actual
+	expected="$(awk -v n="$name" '$2 == "*" n {print $1; exit}' "$manifest")"
+	if [[ -z "$expected" ]]; then
+		if [[ "$strict" == 1 ]]; then
+			rm -f "$file"
+			echo "verify: sha256sums has no entry for '${name}' — cannot verify, aborting" >&2
+			exit 1
+		fi
+		echo "verify: no sha256sums entry for '${name}' (upstream has no checksum for this release) — skipping" >&2
+		return 0
+	fi
+	if ! command -v sha256sum >/dev/null 2>&1; then
+		echo "verify: 'sha256sum' not available — cannot verify '${name}'" >&2
+		rm -f "$file"
+		exit 1
+	fi
+	actual="$(sha256sum "$file" | awk '{print $1}')"
+	if [[ "$actual" != "$expected" ]]; then
+		rm -f "$file"
+		echo "verify: sha256 MISMATCH for '${name}'" >&2
+		echo "  expected: ${expected}" >&2
+		echo "  actual:   ${actual}" >&2
+		exit 1
+	fi
+	echo "verify: ${name} OK (${expected})" >&2
+}
+
+# Optional usign verification of the sha256sums manifest signature.
+# Opt-in: FWLIVE_VERIFY_SIGNATURE=1. Non-blocking — if usign or the keys are
+# unavailable the sha256 checks above are unaffected.
+maybe_verify_sha256sums_signature() {
+	[[ "${FWLIVE_VERIFY_SIGNATURE:-0}" == 1 ]] || return 0
+	local manifest="$1" base="$2" asc
+	if ! command -v usign >/dev/null 2>&1; then
+		echo "verify: FWLIVE_VERIFY_SIGNATURE=1 but 'usign' not found — signature check skipped" >&2
+		return 0
+	fi
+	if [[ -z "${FWLIVE_USIGN_KEY:-}" || ! -r "${FWLIVE_USIGN_KEY}" ]]; then
+		echo "verify: 'usign' found but FWLIVE_USIGN_KEY not set/readable — signature check skipped" >&2
+		return 0
+	fi
+	asc="$(mktemp -t fwlive-sha256sums.asc.XXXXXX)"
+	if ! curl -fsSL -o "$asc" "${base}/sha256sums.asc"; then
+		echo "verify: sha256sums.asc not published (or fetch failed) — signature check skipped" >&2
+		rm -f "$asc"; return 0
+	fi
+	if ! usign -V -m "$manifest" -p "$FWLIVE_USIGN_KEY" -x "$asc" >/dev/null 2>&1; then
+		echo "verify: usign signature check FAILED for ${base}/sha256sums" >&2
+		rm -f "$asc"; exit 1
+	fi
+	rm -f "$asc"
+	echo "verify: sha256sums.asc signature OK" >&2
+}
+
 if [[ "$RELEASE" == "snapshot" ]]; then
 	BASE="https://downloads.openwrt.org/snapshots/targets/armsr/armv8"
 	IMG_OUT="openwrt-armsr-armv8-snapshot.img"
@@ -43,8 +102,15 @@ for candidate in "${IMG_VARIANTS[@]}"; do
 done
 [[ -n "$IMG_GZ" ]] || { echo "no combined disk image found under ${BASE}/" >&2; exit 1; }
 
+SUM_MANIFEST="$(mktemp -t fwlive-armsr-sha256sums.XXXXXX)"
+trap 'rm -f "${SUM_MANIFEST}"' EXIT
+echo "Fetching sha256sums from ${BASE}/ ..."
+curl -fsSL -o "${SUM_MANIFEST}" "${BASE}/sha256sums"
+maybe_verify_sha256sums_signature "${SUM_MANIFEST}" "${BASE}"
+
 echo "Fetching ${IMG_GZ} ..."
 curl -fsSL -o "${OUT}/${IMG_GZ}" "${BASE}/${IMG_GZ}"
+verify_downloaded_sha256 "${OUT}/${IMG_GZ}" "${IMG_GZ}" "${SUM_MANIFEST}" 1
 echo "Decompressing ..."
 # Some release artifacts have trailing bytes (gzip exit 2); verify output size.
 set +e
@@ -63,6 +129,9 @@ fi
 
 echo "Fetching u-boot-qemu_armv8/u-boot.bin ..."
 curl -fsSL -o "${OUT}/${UBOOT_OUT}" "${BASE}/u-boot-qemu_armv8/u-boot.bin"
+# u-boot.bin: strict=0 — upstream omits the checksum for some releases
+# (e.g. 22.03.7); verify when present, otherwise skip with a note.
+verify_downloaded_sha256 "${OUT}/${UBOOT_OUT}" "u-boot-qemu_armv8/u-boot.bin" "${SUM_MANIFEST}" 0
 
 if [[ "${RELEASE}" == "24.10.5" ]]; then
 	ln -sf "${IMG_OUT}" "${OUT}/openwrt-armsr-armv8.img"

--- a/scripts/download-openwrt-x86-64.sh
+++ b/scripts/download-openwrt-x86-64.sh
@@ -13,6 +13,65 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT="${ROOT}/lab/images"
 mkdir -p "${OUT}"
 
+# Verify a downloaded artifact against an upstream sha256sums manifest.
+# Args: <local_file> <manifest_name> <sha256sums_file> <strict>
+#   strict=1: abort if no manifest entry (disk images are always published)
+#   strict=0: note + skip if no entry (e.g. u-boot.bin on older armsr releases)
+verify_downloaded_sha256() {
+	local file="$1" name="$2" manifest="$3" strict="${4:-1}" expected actual
+	expected="$(awk -v n="$name" '$2 == "*" n {print $1; exit}' "$manifest")"
+	if [[ -z "$expected" ]]; then
+		if [[ "$strict" == 1 ]]; then
+			rm -f "$file"
+			echo "verify: sha256sums has no entry for '${name}' — cannot verify, aborting" >&2
+			exit 1
+		fi
+		echo "verify: no sha256sums entry for '${name}' (upstream has no checksum for this release) — skipping" >&2
+		return 0
+	fi
+	if ! command -v sha256sum >/dev/null 2>&1; then
+		echo "verify: 'sha256sum' not available — cannot verify '${name}'" >&2
+		rm -f "$file"
+		exit 1
+	fi
+	actual="$(sha256sum "$file" | awk '{print $1}')"
+	if [[ "$actual" != "$expected" ]]; then
+		rm -f "$file"
+		echo "verify: sha256 MISMATCH for '${name}'" >&2
+		echo "  expected: ${expected}" >&2
+		echo "  actual:   ${actual}" >&2
+		exit 1
+	fi
+	echo "verify: ${name} OK (${expected})" >&2
+}
+
+# Optional usign verification of the sha256sums manifest signature.
+# Opt-in: FWLIVE_VERIFY_SIGNATURE=1. Non-blocking — if usign or the keys are
+# unavailable the sha256 checks above are unaffected.
+maybe_verify_sha256sums_signature() {
+	[[ "${FWLIVE_VERIFY_SIGNATURE:-0}" == 1 ]] || return 0
+	local manifest="$1" base="$2" asc
+	if ! command -v usign >/dev/null 2>&1; then
+		echo "verify: FWLIVE_VERIFY_SIGNATURE=1 but 'usign' not found — signature check skipped" >&2
+		return 0
+	fi
+	if [[ -z "${FWLIVE_USIGN_KEY:-}" || ! -r "${FWLIVE_USIGN_KEY}" ]]; then
+		echo "verify: 'usign' found but FWLIVE_USIGN_KEY not set/readable — signature check skipped" >&2
+		return 0
+	fi
+	asc="$(mktemp -t fwlive-sha256sums.asc.XXXXXX)"
+	if ! curl -fsSL -o "$asc" "${base}/sha256sums.asc"; then
+		echo "verify: sha256sums.asc not published (or fetch failed) — signature check skipped" >&2
+		rm -f "$asc"; return 0
+	fi
+	if ! usign -V -m "$manifest" -p "$FWLIVE_USIGN_KEY" -x "$asc" >/dev/null 2>&1; then
+		echo "verify: usign signature check FAILED for ${base}/sha256sums" >&2
+		rm -f "$asc"; exit 1
+	fi
+	rm -f "$asc"
+	echo "verify: sha256sums.asc signature OK" >&2
+}
+
 if [[ "$RELEASE" == "snapshot" ]]; then
 	BASE="https://downloads.openwrt.org/snapshots/targets/x86/64"
 	IMG_OUT="openwrt-x86-64-snapshot.img"
@@ -37,8 +96,15 @@ for candidate in "${IMG_VARIANTS[@]}"; do
 done
 [[ -n "$IMG_GZ" ]] || { echo "no combined disk image found under ${BASE}/" >&2; exit 1; }
 
+SUM_MANIFEST="$(mktemp -t fwlive-x86-sha256sums.XXXXXX)"
+trap 'rm -f "${SUM_MANIFEST}"' EXIT
+echo "Fetching sha256sums from ${BASE}/ ..."
+curl -fsSL -o "${SUM_MANIFEST}" "${BASE}/sha256sums"
+maybe_verify_sha256sums_signature "${SUM_MANIFEST}" "${BASE}"
+
 echo "Fetching ${IMG_GZ} ..."
 curl -fsSL -o "${OUT}/${IMG_GZ}" "${BASE}/${IMG_GZ}"
+verify_downloaded_sha256 "${OUT}/${IMG_GZ}" "${IMG_GZ}" "${SUM_MANIFEST}" 1
 echo "Decompressing ..."
 set +e
 gzip -dc "${OUT}/${IMG_GZ}" > "${OUT}/${IMG_OUT}"


### PR DESCRIPTION
Closes #145 — the fwlive remediation wave (canonical plan #153). Fixes issue #134.

## What

Both lab-image downloaders now verify artifacts against upstream `sha256sums` **before decompress/use**:

- `scripts/download-openwrt-x86-64.sh` — fetch `${BASE}/sha256sums`, verify the disk image (strict: missing entry aborts), then decompress
- `scripts/download-openwrt-armsr-armv8.sh` — same flow; disk image **strict**, `u-boot.bin` **non-strict**
- `verify_downloaded_sha256` helper: exact-match manifest lookup (`awk '$2 == "*" name'`), sha256sum compare; mismatch → delete bad file + `exit 1` (no corrupt image used)
- `maybe_verify_sha256sums_signature`: opt-in `FWLIVE_VERIFY_SIGNATURE=1` via `usign -V` (OpenWrt Nitrokey3 key `0x1D53D1877742E911`); no-op by default (non-blocking, per issue)
- `mktemp` manifest + `trap EXIT` cleanup; fail-closed if the manifest itself can't be fetched

## u-boot checksum availability (verified against real upstream)

- `u-boot-qemu_armv8/u-boot.bin` **in** `sha256sums` for 23.05.5, 24.10.5, snapshot → verified
- **Absent for 22.03.7** → documented exclusion (runtime skip + note)

## Verification

- 4 logic tests pass (match / mismatch-abort / strict-missing-abort / non-strict-missing-skip)
- `bash -n` clean on both scripts; shellcheck clean
- Rebased onto current master (post #156/#157/#158) — diff is exactly 2 files, +135
