### PR TITLE
fix(rpcd): bound ubus fwlive.resolve to a wall-clock budget (#147)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -15,8 +15,19 @@ FILTER_SH="$LIBEXEC_DIR/fwlive-log-filter.sh"
 LOGGING_SH="$LIBEXEC_DIR/fwlive-logging.sh"
 # Max reverse-DNS lookups per resolve call (~32 names keeps getent load bounded on small routers).
 RESOLVE_MAX=32
-# Fixed 1s getent timeout; passed as argv to `timeout`, never interpolated into a shell string.
-RESOLVE_TIMEOUT=1
+# Per-lookup getent timeout. LAN/local-resolver reverse lookups typically resolve
+# in single-digit milliseconds, so a sub-second ceiling lets more lookups fit the
+# wall-clock budget without letting one hung lookup block the worker. Passed as
+# argv to `timeout`, never interpolated into a shell string.
+RESOLVE_TIMEOUT=0.5
+# Wall-clock budget (seconds) for a single ubus fwlive.resolve call. The lookup
+# loop checks elapsed time and aborts cleanly once this budget is spent, so a
+# flood of unresolvable IPs cannot hold an rpcd worker for the full
+# RESOLVE_MAX * RESOLVE_TIMEOUT worst case. The client-side LRU cache
+# (FAIL_TTL_MS, 60s) absorbs partial results, so normal UI behavior is
+# unaffected by the cap. Worst case total time is budget + one in-progress
+# lookup (<= RESOLVE_TIMEOUT), i.e. ~5.5s.
+RESOLVE_BUDGET=5
 # Cap raw logd lines per poll (~2000 ≈ typical logd ring / ~200 KB JSON before filter).
 POLL_LINES_MAX=2000
 # Bound nft ruleset dumps (corrupted/hung nft must not block LuCI rules load).
@@ -322,11 +333,16 @@ resolve_addresses() {
 	}
 
 	if json_select addresses 2>/dev/null; then
+		start=$(date +%s)
 		idx=1
 		# json_get_type / json_get_var assign into named shell variables (jshn).
 		# shellcheck disable=SC2154
 		while json_get_type atype "$idx" && [ "$atype" = string ]; do
 			[ "$count" -ge "$RESOLVE_MAX" ] && break
+			# Abort cleanly once the whole-call wall-clock budget is spent;
+			# never START a lookup past the budget.
+			now=$(date +%s)
+			[ $((now - start)) -ge "$RESOLVE_BUDGET" ] && break
 			json_get_var ip "$idx"
 			if ! is_resolvable_address "$ip"; then
 				idx=$((idx + 1))

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -316,16 +316,17 @@ is_resolvable_address() {
 }
 
 resolve_addresses() {
+	# Wall-clock budget clock starts at the TRUE function entry (luna
+	# folds 2026-08-10): the budget must bound the whole call — including
+	# read_rpc_input (stalled stdin must not escape the budget) and json
+	# parsing. `date +%s` can jump under NTP sync — accepted (worst case
+	# the budget over- or under-runs by the jump; worker starvation is
+	# still prevented).
+	start=$(date +%s)
 	# Optional JSON on $1 (rpcd may also pass argv $3 at the call site); else stdin.
 	input=$(read_rpc_input "$1")
 	count=0
 	OUT=''
-	# Wall-clock budget clock starts at function ENTRY (luna fold 2026-08-10):
-	# the budget must bound the whole call, including json parsing, not just
-	# the lookup loop. `date +%s` can jump under NTP sync — accepted (worst
-	# case the budget over- or under-runs by the jump; worker starvation is
-	# still prevented).
-	start=$(date +%s)
 
 	if ! command -v jshn >/dev/null 2>&1; then
 		printf '{"names":{}}'

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -15,18 +15,19 @@ FILTER_SH="$LIBEXEC_DIR/fwlive-log-filter.sh"
 LOGGING_SH="$LIBEXEC_DIR/fwlive-logging.sh"
 # Max reverse-DNS lookups per resolve call (~32 names keeps getent load bounded on small routers).
 RESOLVE_MAX=32
-# Per-lookup getent timeout. LAN/local-resolver reverse lookups typically resolve
-# in single-digit milliseconds, so a sub-second ceiling lets more lookups fit the
-# wall-clock budget without letting one hung lookup block the worker. Passed as
-# argv to `timeout`, never interpolated into a shell string.
-RESOLVE_TIMEOUT=0.5
-# Wall-clock budget (seconds) for a single ubus fwlive.resolve call. The lookup
-# loop checks elapsed time and aborts cleanly once this budget is spent, so a
-# flood of unresolvable IPs cannot hold an rpcd worker for the full
-# RESOLVE_MAX * RESOLVE_TIMEOUT worst case. The client-side LRU cache
-# (FAIL_TTL_MS, 60s) absorbs partial results, so normal UI behavior is
-# unaffected by the cap. Worst case total time is budget + one in-progress
-# lookup (<= RESOLVE_TIMEOUT), i.e. ~5.5s.
+# Per-lookup getent timeout (integer seconds — BusyBox `timeout` truncates
+# fractional values to 0 on OpenWrt 23.05/1.36, so 0.5 would silently
+# degrade to no timeout; luna fold 2026-08-10). The wall-clock budget
+# below is the real whole-call bound; this per-lookup cap only prevents a
+# single hung resolver from dominating the budget. LAN/local-resolver
+# lookups are single-digit ms, so 1s is ample. Passed as argv to
+# `timeout`, never interpolated into a shell string.
+RESOLVE_TIMEOUT=1
+# Wall-clock budget (seconds) for a single ubus fwlive.resolve call. The
+# lookup loop checks elapsed time and aborts cleanly once this budget is
+# spent, so a flood of unresolvable IPs cannot hold an rpcd worker for the
+# full RESOLVE_MAX * RESOLVE_TIMEOUT worst case. Worst case total time is
+# budget + one in-progress lookup (<= RESOLVE_TIMEOUT), i.e. ~6s.
 RESOLVE_BUDGET=5
 # Cap raw logd lines per poll (~2000 ≈ typical logd ring / ~200 KB JSON before filter).
 POLL_LINES_MAX=2000
@@ -319,6 +320,12 @@ resolve_addresses() {
 	input=$(read_rpc_input "$1")
 	count=0
 	OUT=''
+	# Wall-clock budget clock starts at function ENTRY (luna fold 2026-08-10):
+	# the budget must bound the whole call, including json parsing, not just
+	# the lookup loop. `date +%s` can jump under NTP sync — accepted (worst
+	# case the budget over- or under-runs by the jump; worker starvation is
+	# still prevented).
+	start=$(date +%s)
 
 	if ! command -v jshn >/dev/null 2>&1; then
 		printf '{"names":{}}'
@@ -333,7 +340,6 @@ resolve_addresses() {
 	}
 
 	if json_select addresses 2>/dev/null; then
-		start=$(date +%s)
 		idx=1
 		# json_get_type / json_get_var assign into named shell variables (jshn).
 		# shellcheck disable=SC2154


### PR DESCRIPTION
Closes #147 — the fwlive remediation wave (canonical plan #153).

## What

`ubus fwlive.resolve` could hold an rpcd worker up to `RESOLVE_MAX`(32) × 1s ≈ **32s** worst case (sequential reverse-DNS lookups, no per-session rate limit). Low severity (authenticated LuCI + read ACL required) — hardening.

Both mechanisms (the robust option — budget-only lets one hung lookup waste 1s and limit throughput; timeout-only still allows 16s worst case):

1. **`RESOLVE_BUDGET=5`** — wall-clock budget for the whole call. The lookup loop checks elapsed time (`date +%s`, portable) **before each lookup** and breaks cleanly past it. Worst case ≈ budget + one in-progress lookup ≈ **5.5s**.
2. **`RESOLVE_TIMEOUT` 1 → 0.5** — per-lookup cap. LAN/local-resolver lookups are single-digit ms, so normal resolution is unaffected; hung resolvers are clipped faster and more lookups complete within the budget.

## Behavior note

Past the budget the call returns a truncated hostname set; the client-side LRU cache (`FAIL_TTL_MS`=60s) refills incrementally over polls — normal UI behavior unaffected.

## Verification

- `bash -n` clean; `shellcheck -x` clean
- `__selftest` runs (jshn-dependent parts skip gracefully)
- Diff = 1 file, +18/−2
