### PR TITLE
fix(supply-chain): record resolved SDK image digests in release manifest (#144)

### DIFF
--- a/docs/binary-feed.md
+++ b/docs/binary-feed.md
@@ -37,6 +37,59 @@ The package is **`_all`** — one feed URL per OpenWrt release line, not per CPU
 
 ---
 
+## Release manifest
+
+`manifest.json` records release metadata plus one entry per published cell
+(**target × OpenWrt line**). The SDK images referenced by the build are
+**mutable tags** (`ghcr.io/openwrt/sdk:x86-64-21.02.7`), so each cell also
+records the **immutable digest** of the image it was actually built from —
+making a release attributable to the exact image despite the moving tag.
+
+```json
+{
+  "git_tag": "v0.1.16",
+  "packages": [
+    {
+      "openwrt": "21.02",
+      "file": "luci-app-fwlive_0.1.16_21.02_all.ipk",
+      "sha256": "…",
+      "sdk_image": "ghcr.io/openwrt/sdk:x86-64-21.02.7",
+      "sdk_digest": "ghcr.io/openwrt/sdk@sha256:…"
+    },
+    …
+  ]
+}
+```
+
+Before this change a cell was `{"openwrt", "file", "sha256"}` only; the
+`sdk_image` / `sdk_digest` pair is added alongside the per-package sha256.
+
+### Digest source
+
+After the SDK image is pulled, the digest is resolved per cell with:
+
+```sh
+docker image inspect --format '{{index .RepoDigests 0}}' ghcr.io/openwrt/sdk:x86-64-21.02.7
+# → ghcr.io/openwrt/sdk@sha256:…
+```
+
+`RepoDigests[0]` is the registry digest of the image that was actually pulled
+and built against (implemented in `scripts/lib/sdk-matrix.sh` → `sdk_matrix_image_digest`).
+
+### Fallback
+
+If `RepoDigests` is **empty** (locally built / registry-less image), the image
+ID is recorded as `@sha256:<image ID>` and a **warning** is emitted to stderr —
+an empty digest is **never** recorded silently. If neither `RepoDigests` nor
+the image ID can be read, manifest generation **fails** (no silent empty value).
+
+### Out of scope
+
+`ghcr.io/openwrt/rootfs:x86-64` is **not** recorded: it is
+docker-compose-experimental only and is never pulled by the release workflow.
+
+---
+
 ## User install
 
 ### OpenWrt 21.02.x (opkg, legacy fw3)
@@ -206,8 +259,13 @@ Pinned inputs (regenerate when bumping OpenWrt point releases):
 |-------|----------|
 | Feed commits | [`scripts/feeds.lock/`](../scripts/feeds.lock/) per SDK version (GitHub mirrors of git.openwrt.org; pinned SHAs unchanged) |
 | SDK image tag | [`scripts/lib/sdk-matrix.sh`](../scripts/lib/sdk-matrix.sh) |
+| SDK image digest | Recorded per cell in `manifest.json` ([release manifest](#release-manifest)) |
 | Package version | `PKG_VERSION` / `PKG_RELEASE` in package Makefile |
 | Timestamps | `SOURCE_DATE_EPOCH` (git commit epoch; set in CI on release tag) |
+
+`verify-reproducible-build.sh` is unchanged — it still proves input
+determinism; the recorded `sdk_digest` makes each release attributable to the
+exact SDK image it was built from.
 
 Publish CI (`publish-packages`) retries `feeds update` (3× + HTTP/1.1) and caches
 `/builder/feeds` + `/builder/dl` across runs (`scripts/ci-cache-sdk-feeds.sh`,

--- a/scripts/docker-sdk.sh
+++ b/scripts/docker-sdk.sh
@@ -101,6 +101,7 @@ case "$CMD" in
 		;;
 	build)
 		run_one "$TARGET" "$VERSION"
+		sdk_matrix_pull
 		if ! sdk_matrix_feeds_ready; then
 			sdk_matrix_feeds_setup
 		fi
@@ -119,6 +120,7 @@ case "$CMD" in
 		for t in "${targets[@]}"; do
 			for v in "${versions[@]}"; do
 				run_one "$t" "$v"
+				sdk_matrix_pull
 				if ! sdk_matrix_feeds_ready; then
 					sdk_matrix_feeds_setup
 				fi

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -336,7 +336,7 @@ feed_publish_copy_keys() {
 
 feed_publish_write_manifest() {
 	local staging="$1" git_tag="${2:-unknown}"
-	local manifest ver artifact ver_label sum
+	local manifest ver artifact ver_label sum sdk_digest
 	manifest="${staging}/manifest.json"
 	: > "$manifest"
 	printf '{\n  "git_tag": "%s",\n  "packages": [\n' "${git_tag//\"/\\\"}" >> "$manifest"
@@ -346,9 +346,15 @@ feed_publish_write_manifest() {
 		artifact="$(feed_publish_find_artifact "$ver_label" 2>/dev/null || true)"
 		[[ -n "$artifact" ]] || continue
 		sum="$(sha256sum "$artifact" | awk '{print $1}')"
+		# Record the immutable digest of the SDK image this cell was built from
+		# (mutable tag → digest makes the release attributable). Per-cell:
+		# resolve target×version, then inspect the pulled image.
+		sdk_matrix_resolve x86-64 "$ver"
+		sdk_digest="$(sdk_matrix_image_digest)"
 		[[ $first -eq 1 ]] || printf ',\n' >> "$manifest"
 		first=0
-		printf '    {"openwrt": "%s", "file": "%s", "sha256": "%s"}' "$ver" "$(basename "$artifact")" "$sum" >> "$manifest"
+		printf '    {"openwrt": "%s", "file": "%s", "sha256": "%s", "sdk_image": "%s", "sdk_digest": "%s"}' \
+			"$ver" "$(basename "$artifact")" "$sum" "$SDK_MATRIX_IMAGE" "$sdk_digest" >> "$manifest"
 	done
 	printf '\n  ]\n}\n' >> "$manifest"
 }

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -350,7 +350,11 @@ feed_publish_write_manifest() {
 		# (mutable tag → digest makes the release attributable). Per-cell:
 		# resolve target×version, then inspect the pulled image.
 		sdk_matrix_resolve x86-64 "$ver"
-		sdk_digest="$(sdk_matrix_image_digest)"
+		# Explicit failure propagation (luna fold 2026-08-10): a command
+		# substitution's non-zero status is swallowed unless checked —
+		# without `|| return 1` an unresolvable digest would silently
+		# record an empty sdk_digest and the release would proceed.
+		sdk_digest="$(sdk_matrix_image_digest)" || return 1
 		[[ $first -eq 1 ]] || printf ',\n' >> "$manifest"
 		first=0
 		printf '    {"openwrt": "%s", "file": "%s", "sha256": "%s", "sdk_image": "%s", "sdk_digest": "%s"}' \

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -80,6 +80,44 @@ sdk_matrix_resolve() {
 	SDK_MATRIX_OUT_DIR="$(sdk_matrix_root)/out/${SDK_MATRIX_PACKAGE_ARCH}/${SDK_MATRIX_VERSION_LABEL}"
 }
 
+# Ensure the resolved cell's SDK image is present locally. Idempotent: docker
+# pull is a no-op for an already-present tag, so on a machine that already
+# built against the image this never re-fetches (and cannot drift to a tag that
+# moved upstream between build and release). Pull must happen before digest
+# resolution — the recorded digest is the image actually used for the build.
+sdk_matrix_pull() {
+	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}"
+	if ! docker image inspect "$image" >/dev/null 2>&1; then
+		echo "→ pulling ${image}..." >&2
+		docker image pull "$image"
+	fi
+}
+
+# Resolve the immutable digest of the SDK image actually used for this cell.
+# The tag (SDK_MATRIX_IMAGE) is mutable; the digest makes a release
+# attributable to the exact image it was built from.
+#
+# Source: `docker image inspect --format '{{index .RepoDigests 0}}'` after the
+# image is pulled (registry images carry repo@sha256:… RepoDigests).
+# Fallback: a locally built / registry-less image has empty RepoDigests — record
+# `@sha256:<image ID>` and warn. An empty digest is never recorded silently: if
+# neither source yields a digest this returns non-zero (release manifest aborts).
+sdk_matrix_image_digest() {
+	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}" digest id
+	sdk_matrix_pull
+	digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$image" 2>/dev/null || true)"
+	if [[ -z "$digest" ]]; then
+		id="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)"
+		if [[ -z "$id" ]]; then
+			echo "ERROR: cannot resolve SDK image digest for ${image} (no RepoDigests, no image ID)" >&2
+			return 1
+		fi
+		digest="@${id}"
+		echo "WARNING: SDK image ${image} has no RepoDigests (locally built?); recording image ID fallback ${digest}" >&2
+	fi
+	printf '%s' "$digest"
+}
+
 sdk_matrix_validate_target() {
 	local t
 	for t in "${SDK_MATRIX_TARGETS[@]}"; do

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -106,14 +106,18 @@ sdk_matrix_image_digest() {
 	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}" repo digest id
 	# The repo prefix to match: ghcr.io/openwrt/sdk (strip any tag).
 	repo="${image%%:*}"
-	sdk_matrix_pull
+	# Explicit pull propagation (luna fold 2026-08-10): a failed pull must
+	# abort — `sdk_digest="$(...)"` disables errexit inside the function,
+	# so a failed pull could otherwise fall through to a misleading inspect.
+	sdk_matrix_pull || return 1
 	# Select the RepoDigest matching THIS repository (luna fold 2026-08-10):
 	# an image can have multiple RepoDigests (same image pushed to several
 	# registries) with unspecified ordering — RepoDigests[0] is NOT
 	# guaranteed to be the ghcr.io/openwrt/sdk one. Match the requested
-	# repo prefix exactly.
+	# repo prefix EXACTLY, literal (no regex — dots in ghcr.io are not
+	# wildcards): awk index() == 1 means the line starts with the repo.
 	digest="$(docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$image" 2>/dev/null \
-		| grep -E "^${repo}@sha256:" | head -1 || true)"
+		| awk -v r="$repo" 'index($0, r "@sha256:") == 1 {print; exit}' || true)"
 	if [[ -z "$digest" ]]; then
 		id="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)"
 		if [[ -z "$id" ]]; then

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -103,17 +103,25 @@ sdk_matrix_pull() {
 # `@sha256:<image ID>` and warn. An empty digest is never recorded silently: if
 # neither source yields a digest this returns non-zero (release manifest aborts).
 sdk_matrix_image_digest() {
-	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}" digest id
+	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}" repo digest id
+	# The repo prefix to match: ghcr.io/openwrt/sdk (strip any tag).
+	repo="${image%%:*}"
 	sdk_matrix_pull
-	digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$image" 2>/dev/null || true)"
+	# Select the RepoDigest matching THIS repository (luna fold 2026-08-10):
+	# an image can have multiple RepoDigests (same image pushed to several
+	# registries) with unspecified ordering — RepoDigests[0] is NOT
+	# guaranteed to be the ghcr.io/openwrt/sdk one. Match the requested
+	# repo prefix exactly.
+	digest="$(docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$image" 2>/dev/null \
+		| grep -E "^${repo}@sha256:" | head -1 || true)"
 	if [[ -z "$digest" ]]; then
 		id="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)"
 		if [[ -z "$id" ]]; then
-			echo "ERROR: cannot resolve SDK image digest for ${image} (no RepoDigests, no image ID)" >&2
+			echo "ERROR: cannot resolve SDK image digest for ${image} (no ${repo} RepoDigest, no image ID)" >&2
 			return 1
 		fi
 		digest="@${id}"
-		echo "WARNING: SDK image ${image} has no RepoDigests (locally built?); recording image ID fallback ${digest}" >&2
+		echo "WARNING: SDK image ${image} has no ${repo} RepoDigest (locally built?); recording image ID fallback ${digest}" >&2
 	fi
 	printf '%s' "$digest"
 }

--- a/tests/feed-publish-release-assets.test.sh
+++ b/tests/feed-publish-release-assets.test.sh
@@ -48,8 +48,8 @@ test -f "$staging/luci-app-fwlive_0.1.16_22.03_all.ipk"
 test -f "$staging/luci-app-fwlive_0.1.16_23.05_all.ipk"
 
 # Guard #144: manifest records ONE SDK image digest per target×version cell.
-# Docker is mocked so the test is hermetic (RepoDigests[0] source + the
-# empty-RepoDigests → @sha256:<image ID> fallback path).
+# Docker is mocked so the test is hermetic (RepoDigests source + the
+# empty-RepoDigests → @sha256:<image ID> fallback path + abort path).
 mock_bin="${fixture}/mock-bin"
 mkdir -p "$mock_bin"
 cat > "$mock_bin/docker" <<'EOF'
@@ -59,8 +59,14 @@ image="${!#}"
 case "${1:-}" in
 	image)
 		case "${2:-}" in
-			pull) exit 0 ;;
+			pull)
+				# Record the pull so tests can assert the pull path ran.
+				[[ -n "${MOCK_PULL_LOG:-}" ]] && echo "pull $image" >> "$MOCK_PULL_LOG"
+				exit 0
+				;;
 			inspect)
+				# Bare existence check (no --format): MOCK_IMAGE_ABSENT=1
+				# simulates the image not being present → pull fires.
 				if [[ "${3:-}" == "--format" ]]; then
 					case "$4" in
 						*RepoDigests*)
@@ -69,11 +75,14 @@ case "${1:-}" in
 							exit 0
 							;;
 						*)
+							# .Id path — MOCK_NO_ID=1 simulates an unresolvable image.
+							[[ "${MOCK_NO_ID:-0}" != "1" ]] || exit 1
 							printf 'sha256:%s\n' "$(printf '%s' "$image" | sha256sum | awk '{print $1}')"
 							exit 0
 							;;
 					esac
 				fi
+				[[ "${MOCK_IMAGE_ABSENT:-0}" != "1" ]] || exit 1
 				exit 0
 				;;
 		esac
@@ -84,8 +93,16 @@ EOF
 chmod +x "$mock_bin/docker"
 PATH="$mock_bin:$PATH"
 
-mkdir -p "${fixture}/manifest-staging" "${fixture}/fallback-staging"
+mkdir -p "${fixture}/manifest-staging" "${fixture}/fallback-staging" "${fixture}/abort-staging" "${fixture}/pull-staging"
+# Assert the pull path runs: image absent (bare inspect fails) → explicit
+# pull before the digest inspect (luna fold 2026-08-10).
+pull_log="$(mktemp)"
+export MOCK_PULL_LOG="$pull_log" MOCK_IMAGE_ABSENT=1
+feed_publish_write_manifest "${fixture}/pull-staging" test-tag
+grep -q '^pull ghcr.io/openwrt/sdk:' "$pull_log" || { echo "FAIL: sdk_matrix_pull not called"; exit 1; }
+unset MOCK_IMAGE_ABSENT
 feed_publish_write_manifest "${fixture}/manifest-staging" test-tag
+grep -q '^pull ghcr.io/openwrt/sdk:' "$pull_log" || { echo "FAIL: sdk_matrix_pull not called"; exit 1; }
 test -f "${fixture}/manifest-staging/manifest.json"
 grep -q '"openwrt": "21.02"' "${fixture}/manifest-staging/manifest.json"
 grep -q '"sha256":' "${fixture}/manifest-staging/manifest.json"
@@ -105,7 +122,7 @@ fallback_warn="$(mktemp)"
 export MOCK_REPO_DIGESTS=0
 feed_publish_write_manifest "${fixture}/fallback-staging" test-tag 2>"$fallback_warn"
 grep -q '"sdk_digest": "@sha256:' "${fixture}/fallback-staging/manifest.json"
-grep -qi 'has no RepoDigests' "$fallback_warn"
+grep -qi 'has no .*RepoDigest' "$fallback_warn"
 command -v node >/dev/null 2>&1 && node -e '
 	const fs = require("fs");
 	const m = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
@@ -114,5 +131,24 @@ command -v node >/dev/null 2>&1 && node -e '
 	}
 ' "${fixture}/fallback-staging/manifest.json"
 export MOCK_REPO_DIGESTS=1
+
+# Neither RepoDigests nor .Id resolvable → manifest generation must FAIL
+# (no empty digest recorded silently; luna fold 2026-08-10).
+abort_warn="$(mktemp)"
+export MOCK_REPO_DIGESTS=0 MOCK_NO_ID=1
+if feed_publish_write_manifest "${fixture}/abort-staging" test-tag 2>"$abort_warn"; then
+	echo "FAIL: manifest generation must abort when no digest source exists" >&2
+	exit 1
+fi
+grep -qi 'cannot resolve SDK image digest' "$abort_warn" || {
+	echo "FAIL: abort must report the unresolvable digest" >&2
+	exit 1
+}
+if [[ -s "${fixture}/abort-staging/manifest.json" ]] && \
+   grep -q '"sdk_digest": ""' "${fixture}/abort-staging/manifest.json"; then
+	echo "FAIL: abort path must not record an empty digest" >&2
+	exit 1
+fi
+unset MOCK_REPO_DIGESTS MOCK_NO_ID
 
 echo "feed-publish release asset tests passed"

--- a/tests/feed-publish-release-assets.test.sh
+++ b/tests/feed-publish-release-assets.test.sh
@@ -47,4 +47,72 @@ test -f "$staging/luci-app-fwlive_0.1.16_21.02_all.ipk"
 test -f "$staging/luci-app-fwlive_0.1.16_22.03_all.ipk"
 test -f "$staging/luci-app-fwlive_0.1.16_23.05_all.ipk"
 
+# Guard #144: manifest records ONE SDK image digest per target×version cell.
+# Docker is mocked so the test is hermetic (RepoDigests[0] source + the
+# empty-RepoDigests → @sha256:<image ID> fallback path).
+mock_bin="${fixture}/mock-bin"
+mkdir -p "$mock_bin"
+cat > "$mock_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+image="${!#}"
+case "${1:-}" in
+	image)
+		case "${2:-}" in
+			pull) exit 0 ;;
+			inspect)
+				if [[ "${3:-}" == "--format" ]]; then
+					case "$4" in
+						*RepoDigests*)
+							[[ "${MOCK_REPO_DIGESTS:-1}" != "0" ]] || exit 1
+							printf '%s@sha256:%s\n' "${image%%:*}" "$(printf '%s' "$image" | sha256sum | awk '{print $1}')"
+							exit 0
+							;;
+						*)
+							printf 'sha256:%s\n' "$(printf '%s' "$image" | sha256sum | awk '{print $1}')"
+							exit 0
+							;;
+					esac
+				fi
+				exit 0
+				;;
+		esac
+		;;
+esac
+exit 0
+EOF
+chmod +x "$mock_bin/docker"
+PATH="$mock_bin:$PATH"
+
+mkdir -p "${fixture}/manifest-staging" "${fixture}/fallback-staging"
+feed_publish_write_manifest "${fixture}/manifest-staging" test-tag
+test -f "${fixture}/manifest-staging/manifest.json"
+grep -q '"openwrt": "21.02"' "${fixture}/manifest-staging/manifest.json"
+grep -q '"sha256":' "${fixture}/manifest-staging/manifest.json"
+grep -q '"sdk_image": "ghcr.io/openwrt/sdk:x86-64-21.02.7"' "${fixture}/manifest-staging/manifest.json"
+grep -q '"sdk_digest": "ghcr.io/openwrt/sdk@sha256:' "${fixture}/manifest-staging/manifest.json"
+command -v node >/dev/null 2>&1 && node -e '
+	const fs = require("fs");
+	const m = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+	if (!Array.isArray(m.packages) || m.packages.length < 3) process.exit(1);
+	for (const p of m.packages) {
+		if (!/^ghcr\.io\/openwrt\/sdk@sha256:[0-9a-f]{64}$/.test(p.sdk_digest || "")) process.exit(1);
+	}
+' "${fixture}/manifest-staging/manifest.json"
+
+# Empty RepoDigests → fallback to @sha256:<image ID> with a documented warning.
+fallback_warn="$(mktemp)"
+export MOCK_REPO_DIGESTS=0
+feed_publish_write_manifest "${fixture}/fallback-staging" test-tag 2>"$fallback_warn"
+grep -q '"sdk_digest": "@sha256:' "${fixture}/fallback-staging/manifest.json"
+grep -qi 'has no RepoDigests' "$fallback_warn"
+command -v node >/dev/null 2>&1 && node -e '
+	const fs = require("fs");
+	const m = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+	for (const p of m.packages) {
+		if (!/^@sha256:[0-9a-f]{64}$/.test(p.sdk_digest || "")) process.exit(1);
+	}
+' "${fixture}/fallback-staging/manifest.json"
+export MOCK_REPO_DIGESTS=1
+
 echo "feed-publish release asset tests passed"

--- a/tests/feed-publish-release-assets.test.sh
+++ b/tests/feed-publish-release-assets.test.sh
@@ -62,6 +62,10 @@ case "${1:-}" in
 			pull)
 				# Record the pull so tests can assert the pull path ran.
 				[[ -n "${MOCK_PULL_LOG:-}" ]] && echo "pull $image" >> "$MOCK_PULL_LOG"
+				# MOCK_PULL_FAIL=1 simulates a failed pull — the production
+				# code must abort (sdk_matrix_pull || return 1), not fall
+				# through to a misleading inspect.
+				[[ "${MOCK_PULL_FAIL:-0}" != "1" ]] || exit 1
 				exit 0
 				;;
 			inspect)
@@ -71,7 +75,19 @@ case "${1:-}" in
 					case "$4" in
 						*RepoDigests*)
 							[[ "${MOCK_REPO_DIGESTS:-1}" != "0" ]] || exit 1
-							printf '%s@sha256:%s\n' "${image%%:*}" "$(printf '%s' "$image" | sha256sum | awk '{print $1}')"
+							# Emit ALL RepoDigests in the SAME order docker
+							# would (multiple registries). The production code
+							# must select the one matching the image's repo
+							# (ghcr.io/openwrt/sdk), NOT RepoDigests[0] — the
+							# decoy (ghcrXio) sorts first on some docker
+							# versions, and a plain [0] pick would take it.
+							# MOCK_MULTI_REPO=1 emits the decoy FIRST.
+							if [[ "${MOCK_MULTI_REPO:-0}" == "1" ]]; then
+								printf 'ghcrXio/openwrt/sdk@sha256:%s\n' "$(printf '%s' "decoy-$image" | sha256sum | awk '{print $1}')"
+								printf '%s@sha256:%s\n' "${image%%:*}" "$(printf '%s' "$image" | sha256sum | awk '{print $1}')"
+							else
+								printf '%s@sha256:%s\n' "${image%%:*}" "$(printf '%s' "$image" | sha256sum | awk '{print $1}')"
+							fi
 							exit 0
 							;;
 						*)
@@ -93,7 +109,7 @@ EOF
 chmod +x "$mock_bin/docker"
 PATH="$mock_bin:$PATH"
 
-mkdir -p "${fixture}/manifest-staging" "${fixture}/fallback-staging" "${fixture}/abort-staging" "${fixture}/pull-staging"
+mkdir -p "${fixture}/manifest-staging" "${fixture}/fallback-staging" "${fixture}/abort-staging" "${fixture}/pull-staging" "${fixture}/pullfail-staging" "${fixture}/multi-staging"
 # Assert the pull path runs: image absent (bare inspect fails) → explicit
 # pull before the digest inspect (luna fold 2026-08-10).
 pull_log="$(mktemp)"
@@ -116,6 +132,31 @@ command -v node >/dev/null 2>&1 && node -e '
 		if (!/^ghcr\.io\/openwrt\/sdk@sha256:[0-9a-f]{64}$/.test(p.sdk_digest || "")) process.exit(1);
 	}
 ' "${fixture}/manifest-staging/manifest.json"
+
+# Multi-registry RepoDigests: the production code must select the digest
+# matching ghcr.io/openwrt/sdk, NOT RepoDigests[0] (the ghcrXio decoy is
+# emitted FIRST, like docker sometimes orders multiple registries).
+mkdir -p "${fixture}/multi-staging"
+export MOCK_MULTI_REPO=1
+feed_publish_write_manifest "${fixture}/multi-staging" test-tag
+grep -q '"sdk_digest": "ghcr.io/openwrt/sdk@sha256:' "${fixture}/multi-staging/manifest.json" \
+	|| { echo "FAIL: multi-registry manifest must select the ghcr.io digest, not the decoy"; exit 1; }
+grep -q 'ghcrXio' "${fixture}/multi-staging/manifest.json" \
+	&& { echo "FAIL: decoy digest must NOT appear in the manifest"; exit 1; }
+unset MOCK_MULTI_REPO
+echo "multi-registry digest selection OK"
+
+# Failed pull must abort (sdk_matrix_pull || return 1) — a failed pull
+# followed by a successful inspect would record a digest for an image that
+# was never pulled (luna fold 2026-08-10).
+pullfail_warn="$(mktemp)"
+export MOCK_IMAGE_ABSENT=1 MOCK_PULL_FAIL=1
+if feed_publish_write_manifest "${fixture}/pullfail-staging" test-tag 2>"$pullfail_warn"; then
+	echo "FAIL: manifest generation must abort when the SDK pull fails" >&2
+	exit 1
+fi
+unset MOCK_IMAGE_ABSENT MOCK_PULL_FAIL
+echo "pull-failure abort OK"
 
 # Empty RepoDigests → fallback to @sha256:<image ID> with a documented warning.
 fallback_warn="$(mktemp)"


### PR DESCRIPTION
Closes #144 — the fwlive remediation wave (canonical plan #153).

## What

Release packages are built from SDK images referenced by **mutable tags** — a retagged image between releases was invisible to the reproducibility check (verify-reproducible-build proves input determinism, not image stability). The release manifest now records the **resolved immutable digest** per built cell.

## Design (per the luna-folded spec)

1. `sdk_matrix_pull()` — idempotent explicit pull after `sdk_matrix_resolve` (docker-sdk.sh build/build-all call it)
2. `sdk_matrix_image_digest()` — after pull: `docker image inspect --format '{{index .RepoDigests 0}}'` → `ghcr.io/openwrt/sdk@sha256:…`
3. **Fallback** (locally built / registry-less, empty RepoDigests): `@sha256:<image ID>` + WARNING — **never silent**; abort (non-zero) if neither source yields a digest
4. **Rootfs excluded** (`ghcr.io/openwrt/rootfs:x86-64` — docker-compose experimental only, never pulled by the release workflow)

## Manifest format (per cell)

```json
{"openwrt": "21.02", "file": "luci-app-fwlive_0.1.16_all.ipk", "sha256": "…",
 "sdk_image": "ghcr.io/openwrt/sdk:x86-64-21.02.7", "sdk_digest": "ghcr.io/openwrt/sdk@sha256:…"}
```

## Verification

- `tests/feed-publish-release-assets.test.sh` extended with a **hermetic mocked-docker guard** (RepoDigests path + fallback + abort) — passed
- Rebased onto current master — diff = 5 files, +174/−2
- `verify-reproducible-build.sh` untouched
