### PR TITLE
fix(rpcd): serialize WAN logging toggles with flock (#151)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -201,16 +201,18 @@ commit_wan_log_change() {
 	return 1
 }
 
-# Firewall reload + best-effort UCI rollback on reload failure. Runs WITHOUT
-# the logging lock: the reload can take seconds and a held lock would block a
-# concurrent toggle until the holder exits (BusyBox flock has no -w timeout).
+# Firewall reload + best-effort UCI rollback on reload failure. The reload
+# itself runs WITHOUT the logging lock (it can take seconds and a held lock
+# would block a concurrent toggle until the holder exits — BusyBox flock has
+# no -w timeout).
 #
-# CONDITIONAL rollback (luna fold 2026-08-10): between this caller's commit
-# and its reload, a concurrent caller may have committed a NEWER value. The
-# rollback must only restore the pre-commit value if the CURRENT value is
-# still what THIS caller committed — otherwise restoring would clobber the
-# newer toggle. `committed` is the value this caller wrote (may be empty for
-# a delete); `previous` is the pre-commit value.
+# The ROLLBACK re-acquires the lock (luna fold 2026-08-10): read->compare->
+# restore is only atomic when no other writer can commit between the read and
+# the restore. All writers hold the same flock, so re-acquiring it makes the
+# decision-and-restore a serialized unit. The lock is held only for the few
+# uci commands of the restore (short critical section), never across the
+# reload. If the lock cannot be re-acquired, skip the rollback (report the
+# reload failure; the next toggle self-corrects).
 reload_and_report_wan_log() {
 	zone="$1"
 	previous="$2"
@@ -220,14 +222,27 @@ reload_and_report_wan_log() {
 	zone_json="$6"
 
 	if ! reload_firewall; then
-		now="$(wan_zone_log_value "$zone")"
-		if [ "$now" = "$committed" ]; then
-			restore_wan_zone_log "$zone" "$previous"
-			logger -t fwlive "$fail_msg" 2>/dev/null || true
+		# Re-acquire the logging lock so the rollback decision is atomic
+		# against concurrent toggles (no check-then-restore race).
+		if acquire_wan_log_lock; then
+			now="$(wan_zone_log_value "$zone")"
+			if [ "$now" = "$committed" ]; then
+				# Current value is still what THIS caller committed — restore
+				# the pre-commit value. (If a concurrent toggle committed the
+				# same value, the toggle is idempotent: the state intent is
+				# identical, so restoring previous is the correct rollback.)
+				restore_wan_zone_log "$zone" "$previous"
+				logger -t fwlive "$fail_msg" 2>/dev/null || true
+			else
+				# A concurrent toggle changed the value after our commit; do
+				# not clobber it. Log the divergence and leave the newer value.
+				logger -t fwlive "Firewall reload failed; WAN log changed concurrently — rollback skipped" 2>/dev/null || true
+			fi
+			release_wan_log_lock
 		else
-			# A concurrent toggle changed the value after our commit; do not
-			# clobber it. Log the divergence and leave the newer value.
-			logger -t fwlive "Firewall reload failed; WAN log changed concurrently — rollback skipped" 2>/dev/null || true
+			# Cannot re-acquire the lock: skip the rollback, report the
+			# reload failure. The next toggle self-corrects the state.
+			logger -t fwlive "Firewall reload failed; rollback lock unavailable — skipped" 2>/dev/null || true
 		fi
 		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
 		return 0

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -204,16 +204,31 @@ commit_wan_log_change() {
 # Firewall reload + best-effort UCI rollback on reload failure. Runs WITHOUT
 # the logging lock: the reload can take seconds and a held lock would block a
 # concurrent toggle until the holder exits (BusyBox flock has no -w timeout).
+#
+# CONDITIONAL rollback (luna fold 2026-08-10): between this caller's commit
+# and its reload, a concurrent caller may have committed a NEWER value. The
+# rollback must only restore the pre-commit value if the CURRENT value is
+# still what THIS caller committed — otherwise restoring would clobber the
+# newer toggle. `committed` is the value this caller wrote (may be empty for
+# a delete); `previous` is the pre-commit value.
 reload_and_report_wan_log() {
 	zone="$1"
 	previous="$2"
-	fail_msg="$3"
-	success_msg="$4"
-	zone_json="$5"
+	committed="$3"
+	fail_msg="$4"
+	success_msg="$5"
+	zone_json="$6"
 
 	if ! reload_firewall; then
-		restore_wan_zone_log "$zone" "$previous"
-		logger -t fwlive "$fail_msg" 2>/dev/null || true
+		now="$(wan_zone_log_value "$zone")"
+		if [ "$now" = "$committed" ]; then
+			restore_wan_zone_log "$zone" "$previous"
+			logger -t fwlive "$fail_msg" 2>/dev/null || true
+		else
+			# A concurrent toggle changed the value after our commit; do not
+			# clobber it. Log the divergence and leave the newer value.
+			logger -t fwlive "Firewall reload failed; WAN log changed concurrently — rollback skipped" 2>/dev/null || true
+		fi
 		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_reload_failed"}' "$zone_json"
 		return 0
 	fi
@@ -263,7 +278,7 @@ enable_wan_logging() {
 	fi
 	release_wan_log_lock
 
-	reload_and_report_wan_log "$zone" "$current" \
+	reload_and_report_wan_log "$zone" "$current" "$target" \
 		'Firewall reload failed after enable; reverted UCI WAN log' \
 		'WAN zone logging enabled' \
 		"$zone_json"
@@ -314,7 +329,7 @@ disable_wan_logging() {
 	fi
 	release_wan_log_lock
 
-	reload_and_report_wan_log "$zone" "$current" \
+	reload_and_report_wan_log "$zone" "$current" "$target" \
 		'Firewall reload failed after disable; reverted UCI WAN log' \
 		'WAN zone logging disabled' \
 		"$zone_json"

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -7,6 +7,36 @@
 NF_LOG_IPV4='/proc/sys/net/netfilter/nf_log/2'
 NF_LOG_IPV6='/proc/sys/net/netfilter/nf_log/10'
 
+# Serialize the WAN logging read->compute->set->commit window across
+# concurrent ubus write-ACL callers (#151): each toggle re-reads the current
+# firewall.<zone>.log bit, computes a target, then uci set + uci commit. Two
+# concurrent callers could otherwise interleave and last-commit-wins.
+#
+# BusyBox flock constraint: it has NO -w timeout. A stuck lock holder blocks
+# any waiter until the holder exits or the device reboots. The critical
+# section MUST stay SHORT (a few uci commands). Do NOT hold the lock across
+# the /etc/init.d/firewall reload (can take seconds); the lock is released
+# before reload, and reload-failure rollback is a best-effort UCI write
+# outside the lock.
+# Overridable for tests/containers (default is the production path).
+WAN_LOG_LOCK_FILE="${FWLIVE_WAN_LOG_LOCK_FILE:-/var/lock/fwlive-logging.lock}"
+
+# Acquire the exclusive logging lock on fd 9. Blocks until free; fails closed
+# (return 1) only if the lock file cannot be opened or flock is unavailable.
+acquire_wan_log_lock() {
+	exec 9>"$WAN_LOG_LOCK_FILE" 2>/dev/null || return 1
+	flock 9 2>/dev/null || {
+		exec 9>&-
+		return 1
+	}
+}
+
+# Release the logging lock (explicit unlock, then close fd 9).
+release_wan_log_lock() {
+	flock -u 9 2>/dev/null || true
+	exec 9>&-
+}
+
 find_wan_zone_section() {
 	uci -q show firewall 2>/dev/null | sed -n "s/^firewall\.\(@zone\[[0-9]*\]\)\.name='wan'$/\1/p" | head -1
 }
@@ -157,17 +187,30 @@ restore_wan_zone_log() {
 	uci commit firewall 2>/dev/null || true
 }
 
-commit_and_reload_wan_log() {
+# Commit the staged log bit. Caller MUST hold the logging lock; this closes
+# the read->compute->set->commit window so a concurrent toggle cannot commit
+# between our read and our write (no lost update / no stale overwrite).
+# Prints the failure JSON and returns 1 on commit failure.
+commit_wan_log_change() {
+	zone="$1"
+	zone_json="$2"
+	if uci commit firewall; then
+		return 0
+	fi
+	printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
+	return 1
+}
+
+# Firewall reload + best-effort UCI rollback on reload failure. Runs WITHOUT
+# the logging lock: the reload can take seconds and a held lock would block a
+# concurrent toggle until the holder exits (BusyBox flock has no -w timeout).
+reload_and_report_wan_log() {
 	zone="$1"
 	previous="$2"
 	fail_msg="$3"
 	success_msg="$4"
 	zone_json="$5"
 
-	if ! uci commit firewall; then
-		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
-		return 0
-	fi
 	if ! reload_firewall; then
 		restore_wan_zone_log "$zone" "$previous"
 		logger -t fwlive "$fail_msg" 2>/dev/null || true
@@ -193,22 +236,38 @@ enable_wan_logging() {
 		return 0
 	fi
 
+	# Locked critical section: read->compute->set->commit for firewall.<zone>.log.
+	# The log bit is re-read AFTER acquiring the lock so the target is computed
+	# from the latest committed value; a concurrent toggle cannot interleave.
+	if ! acquire_wan_log_lock; then
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"lock_failed"}' "$zone_json"
+		return 0
+	fi
+
 	current=$(wan_zone_log_value "$zone")
 	if wan_filter_log_enabled "$current"; then
+		release_wan_log_lock
 		printf '{"ok":true,"changed":false,"wan_zone":%s}' "$zone_json"
 		return 0
 	fi
 
 	target=$(wan_filter_log_target_value "$current")
 	if ! uci set "firewall.${zone}.log=${target}"; then
+		release_wan_log_lock
 		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_set_failed"}' "$zone_json"
 		return 0
 	fi
+	if ! commit_wan_log_change "$zone" "$zone_json"; then
+		release_wan_log_lock
+		return 0
+	fi
+	release_wan_log_lock
 
-	commit_and_reload_wan_log "$zone" "$current" \
+	reload_and_report_wan_log "$zone" "$current" \
 		'Firewall reload failed after enable; reverted UCI WAN log' \
 		'WAN zone logging enabled' \
 		"$zone_json"
+	return 0
 }
 
 disable_wan_logging() {
@@ -219,8 +278,18 @@ disable_wan_logging() {
 	fi
 
 	zone_json=$(json_null_or_string "$zone")
+
+	# Locked critical section: read->compute->set->commit for firewall.<zone>.log.
+	# The log bit is re-read AFTER acquiring the lock so the target is computed
+	# from the latest committed value; a concurrent toggle cannot interleave.
+	if ! acquire_wan_log_lock; then
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"lock_failed"}' "$zone_json"
+		return 0
+	fi
+
 	current=$(wan_zone_log_value "$zone")
 	if [ -z "$current" ] || ! wan_filter_log_enabled "$current"; then
+		release_wan_log_lock
 		printf '{"ok":true,"changed":false,"wan_zone":%s}' "$zone_json"
 		return 0
 	fi
@@ -228,20 +297,28 @@ disable_wan_logging() {
 	target=$(wan_filter_log_clear_value "$current")
 	if [ -z "$target" ]; then
 		if ! uci delete "firewall.${zone}.log"; then
+			release_wan_log_lock
 			printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_delete_failed"}' "$zone_json"
 			return 0
 		fi
 	else
 		if ! uci set "firewall.${zone}.log=${target}"; then
+			release_wan_log_lock
 			printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_set_failed"}' "$zone_json"
 			return 0
 		fi
 	fi
+	if ! commit_wan_log_change "$zone" "$zone_json"; then
+		release_wan_log_lock
+		return 0
+	fi
+	release_wan_log_lock
 
-	commit_and_reload_wan_log "$zone" "$current" \
+	reload_and_report_wan_log "$zone" "$current" \
 		'Firewall reload failed after disable; reverted UCI WAN log' \
 		'WAN zone logging disabled' \
 		"$zone_json"
+	return 0
 }
 
 run_logging_selftest() {

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -77,6 +77,9 @@ echo "== fwlive filter negate toggle ==" >&2
 echo "== fwlive feed release assets ==" >&2
 bash tests/feed-publish-release-assets.test.sh
 
+echo "== fwlive logging lock (race) ==" >&2
+bash tests/fwlive-logging-lock.test.sh
+
 echo "== fwlive rules map (iptables-save) ==" >&2
 "$NODE" tests/fwlive-rules-map.test.js
 

--- a/tests/fwlive-logging-lock.test.sh
+++ b/tests/fwlive-logging-lock.test.sh
@@ -209,4 +209,64 @@ if [ "$sweep_fail" -ne 0 ]; then
 fi
 ok "real enable/disable: 32 concurrent trials -> serial-consistent log bit, well-formed JSON"
 
+# --- Part C: reload-failure conditional rollback (luna fold 2026-08-10) -----
+# A failed reload must only roll back to the pre-commit value if the CURRENT
+# value is still what THIS caller committed. If a concurrent toggle changed it
+# after our commit, rollback must be SKIPPED (else the stale rollback clobbers
+# the newer toggle).
+# usage: $0 <logging-sh> <dir> <previous> <committed> -> writes the post-rollback value to stdout
+cat > "$WORK/rollback-child.sh" <<'EOF'
+#!/bin/sh
+. "$1"
+dir="$2"
+previous="$3"
+committed="$4"
+COMMIT_FILE="$dir/log"
+# uci stub (mirrors the child.sh one — keep it minimal for reload_and_report).
+uci() {
+	case "$1" in
+		-q)
+			case "$2" in
+				show) printf "firewall.@zone[0].name='wan'\n" ;;
+				get) cat "$COMMIT_FILE" 2>/dev/null ;;
+			esac
+			return 0
+			;;
+		set) STAGED="${2#*=}" ;;
+		delete) STAGED='' ;;
+		commit)
+			if [ -n "$STAGED" ]; then
+				printf '%s' "$STAGED" > "$COMMIT_FILE"
+			else
+				rm -f "$COMMIT_FILE"
+			fi
+			;;
+	esac
+	return 0
+}
+reload_firewall() { return 1; }   # reload ALWAYS fails in this part
+logger() { return 0; }
+# zone = wan (first zone section)
+find_wan_zone_section() { printf 'wan'; }
+wan_zone_log_value() { cat "$COMMIT_FILE" 2>/dev/null || true; }
+zone_json='{"zone":"wan"}'
+reload_and_report_wan_log wan "$previous" "$committed" fail-msg success-msg "$zone_json" >/dev/null 2>&1
+cat "$COMMIT_FILE" 2>/dev/null || true
+EOF
+chmod +x "$WORK/rollback-child.sh"
+
+# C1: current still == committed -> rollback restores the previous value.
+mkdir -p "$WORK/rb1"
+printf '1' > "$WORK/rb1/log"        # current value: 1 (what we committed)
+out=$(sh "$WORK/rollback-child.sh" "$LOGGING_SH" "$WORK/rb1" "" "1")
+[ -z "$out" ] || die "C1: expected rollback to restore previous (empty), got '$out'"
+ok "reload failure + unchanged value -> rollback restores previous"
+
+# C2: current != committed (concurrent toggle changed it) -> rollback SKIPPED.
+mkdir -p "$WORK/rb2"
+printf '2' > "$WORK/rb2/log"        # current value: 2 (NEWER commit by B)
+out=$(sh "$WORK/rollback-child.sh" "$LOGGING_SH" "$WORK/rb2" "" "1")
+[ "$out" = "2" ] || die "C2: expected rollback skipped (value stays 2), got '$out'"
+ok "reload failure + concurrent change -> rollback skipped (newer toggle preserved)"
+
 echo "fwlive-logging-lock tests passed"

--- a/tests/fwlive-logging-lock.test.sh
+++ b/tests/fwlive-logging-lock.test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Concurrency test for the WAN logging lock (#151).
+#
+# Evidence that enable/disable_wan_logging no longer lose an update when two
+# write-ACL callers race on the same zone:
+#   A) A general read-modify-write (counter) canary proves the flock helper
+#      itself serializes: WITHOUT the lock the counter loses updates, WITH
+#      the lock it never does (the harness is sensitive to lost updates).
+#   B) The REAL enable_wan_logging / disable_wan_logging functions, run
+#      concurrently against a stubbed shared UCI store, always leave the
+#      committed firewall.<zone>.log bit equal to SOME serial-execution
+#      outcome (never a torn or stale value), and every invocation reports
+#      well-formed ok/changed JSON (applied, no-op, or failed closed).
+#
+# BusyBox note: the production flock helper has no -w timeout, so the
+# critical section stays short (read->compute->set->commit); the firewall
+# reload runs outside the lock. Tests run hermetically by pointing
+# FWLIVE_WAN_LOG_LOCK_FILE at a temp path (default is /var/lock/...).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOGGING_SH="$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh"
+export FWLIVE_WAN_LOG_LOCK_FILE
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+FWLIVE_WAN_LOG_LOCK_FILE="$WORK/fwlive-logging.lock"
+
+die() { echo "fwlive-logging-lock test FAIL: $*" >&2; exit 1; }
+ok() { echo "fwlive-logging-lock test OK: $*"; }
+
+# --- Part A: canary read-modify-write counter (harness sensitivity) --------
+# usage: $0 <logging-sh> <dir> <locked|unlocked>
+cat > "$WORK/canary.sh" <<'EOF'
+#!/bin/sh
+. "$1"
+dir="$2"
+mode="$3"
+if [ "$mode" = locked ]; then
+	acquire_wan_log_lock || exit 3
+fi
+sleep 0.05
+n=$(cat "$dir/counter" 2>/dev/null || printf '0')
+sleep 0.20
+n=$((n + 1))
+printf '%s' "$n" > "$dir/counter"
+if [ "$mode" = locked ]; then
+	release_wan_log_lock
+fi
+EOF
+chmod +x "$WORK/canary.sh"
+
+run_counter() {
+	mode="$1"
+	dir="$WORK/counter-$mode"
+	mkdir -p "$dir"
+	printf '0' > "$dir/counter"
+	for _ in 1 2; do
+		sh "$WORK/canary.sh" "$LOGGING_SH" "$dir" "$mode" &
+	done
+	wait
+	cat "$dir/counter"
+}
+
+counter_lost=0
+for _ in 1 2 3 4 5; do
+	final=$(run_counter unlocked)
+	if [ "$final" -lt 2 ]; then
+		counter_lost=$((counter_lost + 1))
+	fi
+done
+[ "$counter_lost" -ge 1 ] \
+	|| die "unlocked read-modify-write never lost an update (harness not sensitive)"
+ok "unlocked read-modify-write loses updates ($counter_lost/5 rounds show lost update)"
+
+for _ in 1 2 3 4 5; do
+	final=$(run_counter locked)
+	[ "$final" -eq 2 ] || die "locked counter final=$final expected 2 (lost update under flock)"
+done
+ok "flock-serialized read-modify-write never loses an update (5/5 rounds end at 2)"
+
+# --- Part B: real functions, concurrent enable/disable on shared UCI -------
+# usage: $0 <logging-sh> <dir> <enable|disable> <seed>
+cat > "$WORK/child.sh" <<'EOF'
+#!/bin/sh
+. "$1"
+dir="$2"
+op="$3"
+seed="$4"
+
+COMMIT_FILE="$dir/log"
+STAGED=''
+
+json_escape() { cat; }
+check_nf_log_ipv4() { return 0; }
+check_nf_log_ipv6() { return 0; }
+reload_firewall() { return 0; }
+logger() { return 0; }
+
+uci() {
+	case "$1" in
+		-q)
+			case "$2" in
+				show)
+					printf "firewall.@zone[0].name='wan'\n"
+					;;
+				get)
+					cat "$COMMIT_FILE" 2>/dev/null
+					;;
+			esac
+			return 0
+			;;
+		set)
+			STAGED="${2#*=}"
+			sleep "0.0$((seed % 3 + 1))"
+			;;
+		delete)
+			STAGED=''
+			sleep "0.0$((seed % 3 + 1))"
+			;;
+		commit)
+			sleep "0.0$((seed % 3 + 1))"
+			if [ -n "$STAGED" ]; then
+				printf '%s' "$STAGED" > "$COMMIT_FILE"
+			else
+				rm -f "$COMMIT_FILE"
+			fi
+			;;
+	esac
+	return 0
+}
+
+case "$op" in
+	enable) enable_wan_logging ;;
+	disable) disable_wan_logging ;;
+esac
+EOF
+chmod +x "$WORK/child.sh"
+
+# A final committed value is a valid serial outcome if some order of the two
+# concurrent toggles (bit-0 set / bit-0 clear) could have produced it.
+final_allowed() {
+	init="$1"
+	final="$2"
+	if [ -z "$init" ]; then
+		[ "$final" = 'empty' ] || [ "$final" = '1' ]
+		return
+	fi
+	if [ "$final" = "$init" ] || [ "$final" = "$((init | 1))" ]; then
+		return 0
+	fi
+	cleared=$((init & ~1))
+	if [ "$cleared" -eq 0 ]; then
+		[ "$final" = 'empty' ]
+		return
+	fi
+	[ "$final" = "$cleared" ]
+}
+
+check_json() {
+	case "$1" in
+		'{"ok":true,'*|'{"ok":false,'*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+sweep_fail=0
+failures="$WORK/failures"
+: > "$failures"
+
+trial_id=0
+for init in '' 1 2 3; do
+	for trial in 0 1 2 3 4 5 6 7; do
+		trial_id=$((trial_id + 1))
+		dir="$WORK/t$trial_id"
+		mkdir -p "$dir"
+		if [ -z "$init" ]; then
+			rm -f "$dir/log"
+		else
+			printf '%s' "$init" > "$dir/log"
+		fi
+		if [ $((trial_id % 2)) -eq 0 ]; then
+			op1=enable; op2=disable
+		else
+			op1=disable; op2=enable
+		fi
+		sh "$WORK/child.sh" "$LOGGING_SH" "$dir" "$op1" "$((trial_id * 7))" > "$dir/out1" 2>&1 &
+		p1=$!
+		sh "$WORK/child.sh" "$LOGGING_SH" "$dir" "$op2" "$((trial_id * 13 + 3))" > "$dir/out2" 2>&1 &
+		p2=$!
+		wait "$p1" || { sweep_fail=1; echo "child1 rc=$? init=$init trial=$trial" >> "$failures"; }
+		wait "$p2" || { sweep_fail=1; echo "child2 rc=$? init=$init trial=$trial" >> "$failures"; }
+		final=$(cat "$dir/log" 2>/dev/null || true)
+		[ -n "$final" ] || final=empty
+		if ! final_allowed "$init" "$final"; then
+			sweep_fail=1
+			echo "init=$init final=$final not a serial outcome" >> "$failures"
+		fi
+		out1=$(cat "$dir/out1")
+		out2=$(cat "$dir/out2")
+		check_json "$out1" || { sweep_fail=1; echo "child1 bad json init=$init: $out1" >> "$failures"; }
+		check_json "$out2" || { sweep_fail=1; echo "child2 bad json init=$init: $out2" >> "$failures"; }
+	done
+done
+
+if [ "$sweep_fail" -ne 0 ]; then
+	cat "$failures" >&2
+	die "concurrent sweep produced an inconsistent state or malformed JSON"
+fi
+ok "real enable/disable: 32 concurrent trials -> serial-consistent log bit, well-formed JSON"
+
+echo "fwlive-logging-lock tests passed"


### PR DESCRIPTION
Closes #151 — the fwlive remediation wave (canonical plan #153). Candidate race (tracking usrmanage #61).

## What

`enable_wan_logging` / `disable_wan_logging` read `firewall.<zone>.log`, compute a target, then `uci set` + `uci commit` across separate invocations with **no lock** — two concurrent write-ACL callers race; last commit wins (lost update, not corruption; self-correcting).

- `acquire_wan_log_lock()` / `release_wan_log_lock()` over **fd 9**, `flock 9` (blocking, fails closed), `/var/lock/fwlive-logging.lock` (env-overridable `FWLIVE_WAN_LOG_LOCK_FILE` for tests)
- **Critical section**: the log-bit READ moved *inside* the lock — read → compute → set → commit (`commit_wan_log_change`) is now one serialized unit
- **Reload + rollback moved out** of the lock (`reload_and_report_wan_log`): BusyBox `flock` has NO `-w` timeout — a stuck holder blocks until exit/reboot, so the critical section stays short (~4 uci commands); constraint documented in a file comment
- New fail-closed `"error":"lock_failed"` only when the lock file can't be opened / flock unavailable

## Concurrency evidence (scripted, reproducible)

`tests/fwlive-logging-lock.test.sh` (real functions + real flock, stubbed UCI store):
- **Canary**: unlocked read-modify-write loses updates (5/5 rounds) — proves the harness detects races
- **Locked**: flock-serialized never loses an update (5/5 rounds end at 2)
- **Real toggle**: 32 concurrent enable/disable trials → serial-consistent log bit, well-formed JSON
- Wired into the runner (`npm test`)

## Verification

- `npm test` all passed; `fwlive-shellcheck.sh` OK
- Existing ACL path unchanged: `fwlive-logging.test.sh`, rpcd `__selftest`, `fwlive-rpcd-security.test.js` all pass
- Rebased onto current master — diff = 3 files, +299/−7
