### PR TITLE
docs(security): add review ledger; correct two falsified control claims

### DIFF
--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -7,7 +7,14 @@ description: Audit the fwlive repository for security issues — LuCI frontend i
 
 Repeatable audit procedure. Read
 [`docs/developer/security-model.md`](../../../docs/developer/security-model.md)
-for the trust boundaries and invariants; this file is the *how*.
+for the trust boundaries and invariants, and
+[`docs/developer/security-review.md`](../../../docs/developer/security-review.md)
+for what has already been checked, with what proof, and what is open. This file
+is the *how*.
+
+A pass owes the ledger a coverage-map update, a proof class for every control it
+touches, and its non-findings — see
+[security-review.md § Review procedure](../../../docs/developer/security-review.md#review-procedure).
 
 ## Order of work
 
@@ -130,10 +137,34 @@ mutable tag (especially any step receiving a secret), fetched-and-executed
 helpers without a checksum, predictable temp paths in the signing path, and
 whether any secret can reach `feed-staging/`.
 
-Confirm key files stay ignored:
+Confirm key files stay ignored — and their temp siblings too, which is how
+[#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) got past this
+check:
 
 ```sh
 git check-ignore -v opkg-secret.key apk-secret.rsa public.key fwlive-feed.rsa.pub
+git check-ignore -v opkg-secret.key.tmp apk-secret.rsa.tmp
+```
+
+**Run the key path; do not read it.** A `chmod 600` in the source proves the
+call exists, not that the mode survives the rest of the function:
+
+```sh
+( umask 022                     # GitHub runner default, not your shell's
+  source scripts/lib/feed-keys.sh
+  OPKG_SECRET=… APK_SECRET=… OPKG_PUB=… APK_PUB=… feed_keys_write_from_env "$d"
+  stat -c '%n %a' "$d"/opkg-secret.key "$d"/apk-secret.rsa
+  find "$d" -name '*.tmp' )
+```
+
+Do this for **both** documented secret formats — one-line paste and base64 —
+because they take different code paths through `feed-keys.sh`.
+
+Every `> "$f.tmp"` followed by `mv "$f.tmp" "$f"` is a mode-loss candidate,
+anywhere in the repo:
+
+```sh
+rg -n '>\s*"\$\{?\w+\}?\.tmp"' scripts openwrt-feed
 ```
 
 ## Severity calibration
@@ -172,15 +203,30 @@ gh api /repos/{owner}/{repo}/security-advisories --jq '.[] | "\(.ghsa_id) \(.sta
 ## Known-good — do not re-litigate without new evidence
 
 Invariants 2–7 in [`security-model.md`](../../../docs/developer/security-model.md)
-were each audited and found correctly implemented, as were the
-`__rulesmap_iptables` fixed-path guard, the WAN-log bit-0-only manipulation with
-UCI rollback, and secret-key file permissions plus gitignore coverage.
+were each audited and found correctly implemented, as was the
+`__rulesmap_iptables` fixed-path guard.
 
 Re-examine them only with new evidence — a code change in the area, or a concrete
 bypass. Spending the pass re-reading known-good shell is the main way an audit
 runs out of time before reaching the frontend.
 
-Open items are tracked as issues — check them before re-reporting:
+**Two entries were removed from this list on 2026-08-12**, and the reason
+matters more than the bugs:
+
+| Was listed as known-good | What running it showed |
+|--------------------------|------------------------|
+| Secret-key file permissions plus gitignore coverage | Secrets land 0644 in both documented formats, and `*.tmp` is not ignored ([#165](https://github.com/lucas-albers-lz4/fwlive/issues/165)) |
+| WAN-log bit-0-only manipulation with UCI rollback | The `set` is bit-0-only; the `uci commit firewall` is package-wide ([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)) |
+
+Both were cleared by reading the code and finding the right-looking line. That
+is the failure mode this list creates: it converts one reader's impression into
+a standing instruction not to look. Before adding an entry here, state what was
+*executed* to clear it, and prefer a test in `tests/` — an entry with a test
+behind it never needs this list.
+
+Open items are tracked as issues, and the current state with severities and
+recommended order is in
+[`security-review.md` § Open findings](../../../docs/developer/security-review.md#open-findings):
 
 ```sh
 gh issue list --label security --label supply-chain --state open

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,12 @@ Breaking any of these fails CI or ships a security regression.
 | Task | Read first |
 |------|------------|
 | Any change | [contributing.md](docs/developer/contributing.md) |
-| Renderers, rpcd plugin, shell helpers, release pipeline | [security-model.md](docs/developer/security-model.md) |
+| Renderers, rpcd plugin, shell helpers, release pipeline | [security-model.md](docs/developer/security-model.md), then [security-review.md](docs/developer/security-review.md) for what is open against it |
 | Classification or parsing | [architecture.md](docs/developer/architecture.md) |
-| A security audit | `security-audit` skill in `.cursor/skills/` |
+| A security audit | [security-review.md](docs/developer/security-review.md) for state, then the `security-audit` skill in `.cursor/skills/` for procedure |
+
+A change to the rpcd plugin, the ACL, the shell helpers, or the release pipeline
+updates [security-review.md](docs/developer/security-review.md) in the same PR.
 
 ## Commands and testing
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -38,6 +38,7 @@ Documentation for **building, testing, and extending** `luci-app-fwlive` and the
 | Publish checklist | [`../github-publish-checklist.md`](../github-publish-checklist.md) |
 | Feed layout (no submodule split) | [architecture.md § Feed layout decision](architecture.md#feed-layout-decision) |
 | Trust boundaries & security invariants | [security-model.md](security-model.md) |
+| Security review state (coverage, proofs, open findings) | [security-review.md](security-review.md) |
 | Agent orientation (invariants, commands) | [`../../AGENTS.md`](../../AGENTS.md) |
 
 ## User documentation

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -69,6 +69,7 @@ to be built against (#137).
 | Owner | Rules it owns |
 |-------|---------------|
 | [security-model.md](security-model.md) | Trust boundaries, output encoding, untrusted inputs, ACL scope, supply-chain surface |
+| [security-review.md](security-review.md) | Review state — surface coverage, proof class per control, open findings, accepted residuals |
 | [contributing.md](contributing.md) | Workflow, parser sync / codegen, package and version rules, documentation conventions |
 | [build-and-test.md](build-and-test.md) | Commands, what each gate covers, test caveats |
 | [architecture.md](architecture.md) | Module split, data path, design rationale |

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -7,6 +7,10 @@ pipeline.
 Reporting a vulnerability: [`SECURITY.md`](../../SECURITY.md) — private
 disclosure, never a public issue.
 
+Whether a control below is actually *proven*, and what is currently open against
+it: [security-review.md](security-review.md). This document says what must be
+true; that one says what has been checked and how hard.
+
 ## Threat model in one line
 
 fwlive renders attacker-influenced text inside a **root-equivalent** browser
@@ -110,8 +114,17 @@ The rpcd plugin runs as **root**. Its entire input surface is:
 methods. `__rulesmap_iptables` reads a fixed path and rejects argv-supplied
 files.
 
-State changes touch only bit 0 of the WAN zone `log` value and roll back UCI if
-the firewall reload fails.
+The `uci set` touches only bit 0 of the WAN zone `log` value, and UCI is rolled
+back if the firewall reload fails. The **commit** is wider than the set:
+`uci commit firewall` publishes any delta already staged in `/tmp/.uci/firewall`
+by another CLI actor ([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)).
+An unprivileged user cannot stage such a delta — `/tmp/.uci` is `0700` (libuci
+`UCI_DIRMODE`) — which is what keeps that finding Low.
+
+Serialization of the toggle depends on a lock file that is currently created
+world-readable, so any local UID can hold it and, with no BusyBox `flock -w`,
+block both toggles until reboot
+([#167](https://github.com/lucas-albers-lz4/fwlive/issues/167)).
 
 ## Supply-chain surface
 
@@ -120,15 +133,29 @@ part of the security boundary.
 
 | Surface | Control |
 |---------|---------|
-| Feed signing keys | CI secrets, written under `umask 077` then `chmod 600`; only public keys are staged for publish |
+| Feed signing keys | CI secrets, written under `umask 077` then `chmod 600`; only public keys are staged for publish. **The mode does not currently survive** — see below |
 | Package contents | `verify-reproducible-build.sh` — determinism of our inputs within a run |
 | OpenWrt feeds | Pinned in `scripts/feeds.lock/` |
 | SDK base images | Digests resolved per cell and recorded in the release manifest (no mutable-tag reliance) |
 | GitHub Actions | SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` |
-| Fetched build helpers and lab images | sha256-verified before execution; `/tmp` trust removed (fresh `mktemp` per invocation) |
+| Fetched build helpers and lab images | sha256-verified or commit-pinned before execution — **except `usign`**, see below; `/tmp` trust removed (fresh `mktemp` per invocation) |
 
 Never stage a secret key into `feed-staging/` — `feed_publish_copy_keys` copies
-public keys only, and all four key filenames are gitignored.
+public keys only, and all four key filenames are gitignored. The `${f}.tmp`
+siblings that `feed-keys.sh` creates are **not** covered by that gitignore
+([#165](https://github.com/lucas-albers-lz4/fwlive/issues/165)).
+
+Two rows above are aspirational rather than in force, both reproduced on
+2026-08-12:
+
+- Signing secrets end at **0644**, not 0600. `feed-keys.sh` normalizes the key
+  *after* the `chmod`, and its `> "${f}.tmp"` + `mv` carries the temp file's
+  umask-derived mode onto the destination
+  ([#165](https://github.com/lucas-albers-lz4/fwlive/issues/165)).
+- `feed_publish_ensure_usign` clones `openwrt/usign` at an unpinned `master`,
+  builds it, and puts it on `PATH` to **sign the feed** — no SHA, no checksum,
+  twenty lines from the commit-pinned `ipkg-make-index.sh`
+  ([#166](https://github.com/lucas-albers-lz4/fwlive/issues/166)).
 
 ## Running an audit
 

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,0 +1,208 @@
+# Security review state
+
+What has been reviewed, when, with what strength of proof, and what is still
+open. This document is the **record**; it owns no rules.
+
+| Read this for | Go here |
+|---------------|---------|
+| What we trust, invariants, ACL scope, supply-chain surface | [security-model.md](security-model.md) |
+| How to run a pass, re-verification commands | [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) |
+| Whether a surface was checked, and whether a control is *proven* | this file |
+
+Start here before a pass. Do not re-derive the trust boundaries, and do not
+reopen an accepted residual without new evidence.
+
+## Why a ledger and not just a model
+
+`security-model.md` states what must be true. It cannot tell you whether anyone
+checked, or how hard they checked. That gap is not theoretical: two entries on
+the Known-good list were falsified in the 2026-08-12 pass, both because the
+original conclusion came from reading a line of code rather than executing it.
+A claim with no proof class attached is a belief.
+
+## Proof classes
+
+Every control carries one. The class is the *weakest* evidence the control
+currently rests on.
+
+| Class | Means | Example |
+|-------|-------|---------|
+| `host` | Asserted by a test in `tests/`, run by `./scripts/fwlive-test.sh` in PR CI | ACL does not grant `ubus log.*` |
+| `lab` | Demonstrated against a running QEMU guest | Live ACL enforcement on a real rpcd |
+| `manual` | Confirmed by inspection or a one-off run, not re-checked automatically | Anything with no test behind it |
+
+`manual` is not a failure — some things cannot be cheaply automated — but a
+`manual` control on a security boundary is a standing invitation to drift, and
+should carry a note saying what would raise it.
+
+## Surface coverage map
+
+| Surface | Last reviewed | Depth | Notes |
+|---------|---------------|-------|-------|
+| Frontend rendering sinks (`E()` string children) | 2026-08-12 | Sweep + harness | Re-swept; no bare-string sinks. Regression harness from [#138](https://github.com/lucas-albers-lz4/fwlive/issues/138) |
+| Untrusted-input trace (log fields, PTR, URL hash, UCI) | 2026-08-12 | Read | No change since the inventory in security-model.md |
+| rpcd plugin + ACL scope | 2026-08-12 | Read + selftest | `__`-prefixed methods absent from `list`; read/write split intact |
+| Shell helpers — injection and quoting | 2026-08-12 | Read | No log data reaches a command string |
+| Shell helpers — **file modes and lock ownership** | 2026-08-12 | Reproduced | New: [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) |
+| Shell helpers — **UCI commit scope and zone grammar** | 2026-08-12 | Read + upstream check | New: [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) |
+| Release pipeline — secrets and key handling | 2026-08-12 | Reproduced | New: [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) |
+| Release pipeline — fetch pinning | 2026-08-12 | Read | New: [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) |
+| Workflow inputs into `run:` bodies | 2026-08-12 | Read | Clean — inputs pass through `env:`, actions SHA-pinned |
+
+## Controls in force
+
+| Control | Proof class | Where |
+|---------|-------------|-------|
+| Sessions never receive `ubus log.*` | `host` | `tests/fwlive-rpcd-security.test.js` |
+| Read and write ACL scopes stay separate | `host` | same |
+| Caller line count validated and clamped | `host` | rpcd `__selftest` |
+| Addresses shape-validated before `getent` | `host` | rpcd `__selftest`, incl. a literal `$(reboot)` token |
+| JSON string content escaped per RFC 8259 | `host` | rpcd `__selftest` |
+| WAN log toggle serialized against concurrent callers | `host` | `tests/fwlive-logging-lock.test.sh` (32-trial race) |
+| Reload failure rolls back the UCI write | `host` | same |
+| `resolve` bounded by a wall-clock budget | `manual` | `RESOLVE_BUDGET`; no test asserts the bound |
+| `poll` bounded by `POLL_LINES_MAX` | `host` | rpcd `__selftest` |
+| Every `E()` string child is array-wrapped | `host` | rendering harness ([#138](https://github.com/lucas-albers-lz4/fwlive/issues/138)) |
+| Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` |
+| `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
+| Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
+| Signing secrets are mode 0600 | **not in force** | [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) — reproduced at 0644 |
+| Fetched build helpers verified before execution | **partial** | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) — `usign` is cloned unpinned and executed |
+| WAN toggle changes only the zone `log` bit | **partial** | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) — the `uci commit` is package-wide |
+| The WAN logging lock cannot be held by an unprivileged user | **not in force** | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) — lock file is 0644 |
+
+## Open findings
+
+| ID | Severity | Issue | Summary |
+|----|----------|-------|---------|
+| S1 | Medium | [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) | `feed-keys.sh` tmp+`mv` discards `chmod 600`; signing secrets land 0644 in both documented storage formats. Partial secret left in `${f}.tmp`, and `*.tmp` is not gitignored |
+| S2 | Medium | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) | `feed_publish_ensure_usign` clones `openwrt/usign` at an unpinned `master`, builds it, and uses it to sign the feed. Class sibling: `get-sdk.sh` fetches an SDK tarball with no checksum |
+| S3 | Low-Medium | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) | `/var/lock/fwlive-logging.lock` is created 0644; any local UID can take `LOCK_EX` on a read-only fd and, with no BusyBox `flock -w`, wedge both toggles until reboot |
+| S4 | Low | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) | `uci commit firewall` publishes any delta staged in `/tmp/.uci/firewall`, not just our bit; and a named `config zone 'wan'` is invisible to `find_wan_zone_section` |
+
+Recommended order: S1 → S2 → S3 → S4. S1 and S2 are release-path and land
+before the next tag; S3 is a mode fix with a host test; S4 is the largest
+behavior change and benefits from going last.
+
+## Accepted residuals
+
+Known, judged acceptable. Reopen only with new evidence.
+
+| Residual | Why accepted |
+|----------|--------------|
+| Any local UID can inject syslog lines that pass the firewall classifier | `logd` chmods its socket 0666 upstream (ubox `log/syslog.c`). Not fixable from this package; the consequence is forged rows in the view, and every field is already rendered as text |
+| `date +%s` can jump under NTP sync, over- or under-running `RESOLVE_BUDGET` | Worker starvation is still prevented, which is the property the budget exists for |
+| A LuCI admin session is root-equivalent | Structural to LuCI. It is the reason script execution on this page is treated as a root compromise, not a lesser bug |
+| `feed_publish_ensure_usign` leaves its build dir for the process lifetime | `PATH` points into it and `usign` is called later; the name is unpredictable per invocation, and `/tmp` is reaped on reboot |
+
+## What this pass could not prove
+
+Honest gaps, so the next pass starts here rather than rediscovering them.
+
+| Property | Status | What would prove it |
+|----------|--------|---------------------|
+| `resolve` really returns within its budget on a loaded router | cannot-prove on host | Lab: flood `fwlive.resolve` with unresolvable addresses, measure wall time |
+| The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host | Lab: hold the lock from an unprivileged shell, call the toggle, observe rpcd |
+| `uci commit firewall` scope on a live device | prove-next | Lab: stage an unrelated `firewall` delta over SSH, toggle logging, check whether it committed |
+| Signing keys stay 0600 through a full publish | prove-next | The host test in [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) covers the library; a real run also passes through `validate-feed-keys.sh` |
+
+## Review procedure
+
+The *how* lives in
+[`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md).
+This section covers only what a pass owes this file.
+
+A pass is not finished until it has:
+
+1. Updated the coverage map dates for every surface it actually looked at — and
+   left the others alone. A date that means "someone glanced at it" is worse
+   than a stale one.
+2. Given every new control a proof class, and downgraded any existing control
+   whose proof it could not locate.
+3. Filed each finding as its own issue at implementable quality — mechanism,
+   location, blast radius, fix sketch, re-verification — and linked it here.
+4. Recorded its non-findings. A surface examined and found clean is a result;
+   without it the next pass pays for the same reading twice.
+5. Corrected any claim it falsified, in the document that **owns** the claim,
+   in the same PR. A ledger that contradicts `security-model.md` is worse than
+   either one alone.
+
+A feature PR touching the rpcd plugin, the ACL, the shell helpers, or the
+release pipeline updates this file in the same PR.
+
+## Rules this repo adopted after being bitten
+
+Each earned by a real finding. They are cheap to apply and they generalize past
+the specific bug.
+
+### 1. A control that names a file mode needs a `stat` assertion
+
+Reading `chmod 600` proves the call exists, not that the mode survives to the
+end of the function. S1 sat behind a literal `chmod 600` that a later `mv`
+undid, and it was on the Known-good list. If a control says "0600", a test says
+`stat -c %a`.
+
+### 2. Fix the class, not the site
+
+S2 exists because [#131](https://github.com/lucas-albers-lz4/fwlive/issues/131)
+pinned one fetched helper and left its neighbour — twenty lines apart in the
+same file — unpinned. When a finding is an instance of a pattern, grep for the
+pattern before closing it, and record the sweep in the issue.
+
+### 3. Ask the platform; never re-implement its grammar
+
+S4's zone lookup and the parser divergence in the sibling repo
+([usrmanage#108](https://github.com/lucas-albers-lz4/usrmanage/issues/108)) are
+the same bug: an ad-hoc regex over a platform format, narrower than the real
+parser, deciding something that matters. Call `uci`/`getent`/`fw4`, or fail
+closed on input the pattern cannot fully model.
+
+### 4. Verify against upstream source, not against our own documentation
+
+Every 2026-08-12 finding came from checking OpenWrt sources — `rpcd/uci.c` for
+per-session save directories, `uci.h` for `UCI_DIRMODE`, `flock(2)` for locking
+on read-only descriptors. Two of them also *reduced* a severity we would
+otherwise have overstated. Our docs are a summary of a past reading; upstream is
+the fact.
+
+## Audit history
+
+### 2026-08-12 — Supply chain, file modes, and UCI scope
+
+**Scope.** Release pipeline key handling and fetch pinning; on-device file modes
+and lock ownership; UCI commit scope and zone lookup. Frontend sinks and the ACL
+were re-swept but not the focus — the audit skill correctly calls the frontend
+highest-yield, and it was found clean again.
+
+**Method.** Read-only, plus host reproductions and upstream source checks
+(`rpcd/uci.c`, `uci.h`, `flock(2)`, `libuci` file modes). Prompted by an audit of
+the sibling repo `usrmanage`, whose findings suggested three classes to look for
+here: temp-file mode loss, unswept fix classes, and hand-parsed platform formats.
+All three were present.
+
+**Result.** Four findings: S1–S4 above. Two of them falsify entries previously
+recorded as settled — the Known-good list asserted "secret-key file permissions"
+and "WAN-log bit-0-only manipulation", and both were derived by reading rather
+than running. The Known-good list and the supply-chain table are corrected in
+the same PR as this file.
+
+**Non-findings**, so the next pass can skip them:
+
+- Frontend sinks: the Step 1 sweep returns four `E()` calls with bare-identifier
+  children (`table.js:99`, `chips.js:94`, `logging.js:202`, `fwlive.js:1578`);
+  all four pass arrays or element nodes. No `innerHTML` write has a non-empty
+  right-hand side.
+- ACL: read/write split intact; no `ubus log.*` grant; `__selftest` and
+  `__rulesmap_iptables` remain unreachable through `list`/`call`.
+- Workflows: no `${{ }}` interpolation into `run:` bodies — inputs are routed
+  through `env:`. All three actions are SHA-pinned, including the one receiving
+  `FEED_DEPLOY_KEY`.
+- `is_resolvable_address`, `poll_lines_from_input`, and `json_escape` hold under
+  their selftests; the escaped-quote capture in the nft prefix regex is correct.
+- `/tmp/.uci` is `0700` (libuci `UCI_DIRMODE`), so an unprivileged user cannot
+  stage a firewall delta for S4 to commit. This is what keeps S4 at Low.
+
+**Cross-repo.** S3 also exists in `usrmanage`
+([usrmanage#111](https://github.com/lucas-albers-lz4/usrmanage/issues/111)),
+where the blast radius is larger because the same lock guards every user-management
+mutator.


### PR DESCRIPTION
## Summary

**Docs only — no code changes.** Remediation is tracked in #165–#168.

fwlive already documents what must be true ([`security-model.md`](docs/developer/security-model.md)) and how to check it (the `security-audit` skill). Nothing recorded *what had been checked, when, and with what strength of evidence*. This PR adds that layer and fixes the claims that turned out not to hold.

The gap is not theoretical. The skill's Known-good list — a standing instruction not to look — carried two entries that were cleared by reading a plausible-looking line rather than running it. Both fail when run.

## New: `docs/developer/security-review.md`

Owns review **state**, not rules, so it does not collide with the single-source-of-truth table in `contributing.md`:

- **Surface coverage map** — what was looked at, when, and how deeply
- **Proof class on every control** — `host` (a test in `tests/`), `lab` (a QEMU guest), `manual` (inspection only). The class is the *weakest* evidence the control rests on, which makes `manual` controls on security boundaries visible instead of implied
- **Open findings S1–S4** with severity and a recommended order
- **Accepted residuals** — the 0666 `logd` socket, NTP jump in `RESOLVE_BUDGET`, LuCI admin being root-equivalent — so they stop being rediscovered
- **What this pass could not prove**, separated into `prove-next` and `cannot-prove-on-host`
- **Review procedure** — what a pass owes the ledger, including recording non-findings
- **Four rules** the findings earned

Registered in the ownership table, the developer README index, and the `AGENTS.md` router.

## Corrections, in the documents that own the claims

| Document | Claim | Reality |
|----------|-------|---------|
| `security-model.md` supply-chain table | Signing keys "written under `umask 077` then `chmod 600`" | Land at **0644** in both documented secret formats (#165) |
| `security-model.md` supply-chain table | "Fetched build helpers … sha256-verified before execution" | `usign` is `git clone`d at an unpinned `master`, built, and used to **sign the feed** (#166) |
| `security-model.md` privileged surface | "State changes touch only bit 0 of the WAN zone `log` value" | The `set` is bit-0-only; the `uci commit firewall` is package-wide (#168) |
| `security-audit` skill, Known-good | "secret-key file permissions plus gitignore coverage" | Removed — falsified by #165 |
| `security-audit` skill, Known-good | "WAN-log bit-0-only manipulation with UCI rollback" | Removed — falsified by #168 |

The skill now also records *why* those entries were wrong, and asks that a new Known-good entry state what was executed to clear it.

## Skill additions (step 5)

- Run the key path instead of reading it: `umask 022`, call `feed_keys_write_from_env`, `stat -c %a` the results, for **both** secret storage formats (they take different code paths)
- `git check-ignore` the `.tmp` siblings, not just the four key names — that omission is how #165 got past this exact check
- A grep for the `> "$f.tmp"` + `mv` mode-loss shape across the repo

## Method note

Every finding came from checking OpenWrt sources rather than our own docs: `rpcd/uci.c` (per-session UCI save directories), `uci.h` (`UCI_DIRMODE` 0700), `flock(2)` (locks work on read-only descriptors), `libuci` file modes. Two of those checks *reduced* a severity I would otherwise have overstated — #168 was going to be Medium until `rpc_uci_set_savedir()` showed LuCI stages per session, and the 0700 save directory rules out an unprivileged attacker.

## Related

This pass was prompted by an audit of the sibling repo `usrmanage`, which suggested three classes to look for here — temp-file mode loss, unswept fix classes, and hand-parsed platform formats. All three were present. #167 also exists there as [usrmanage#111](https://github.com/lucas-albers-lz4/usrmanage/issues/111), with a larger blast radius.

## Test plan

- [x] `./scripts/fwlive-test.sh` passes
- [x] `./scripts/fwlive-linkcheck.sh` passes (384 internal links, 28 external, 0 broken)
- [x] Issue numbers verified against the filed issues (#165–#168)
- [x] New document respects the single-source-of-truth rule — it owns review state, links for every rule it references, and is registered in the ownership table
- [ ] Reviewer sanity-check: the ledger and `security-model.md` now agree, and neither asserts a control the reproductions contradict

Made with [Cursor](https://cursor.com)