### PR TITLE
fix(security): feed-keys mode 0600 through normalize (S1 / #165)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ apk-secret.rsa
 fwlive-feed.rsa.pub
 public.key
 *.tmp
+# mktemp siblings from feed-keys normalize/decode (not covered by *.tmp)
+opkg-secret.key.*
+apk-secret.rsa.*
+public.key.*
+fwlive-feed.rsa.pub.*
 # Accidental OpenWrt dirs at repo root (SDK trees belong under openwrt-sdk-*/ or .sdk/ above)
 /staging_dir/
 /build_dir/

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ sdk-*-openwrt-*/
 apk-secret.rsa
 fwlive-feed.rsa.pub
 public.key
+*.tmp
 # Accidental OpenWrt dirs at repo root (SDK trees belong under openwrt-sdk-*/ or .sdk/ above)
 /staging_dir/
 /build_dir/

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -133,7 +133,7 @@ part of the security boundary.
 
 | Surface | Control |
 |---------|---------|
-| Feed signing keys | CI secrets, written under `umask 077` then `chmod 600`; only public keys are staged for publish. **The mode does not currently survive** — see below |
+| Feed signing keys | CI secrets, written under `umask 077` then `chmod 600` **after** normalize/decode; only public keys are staged for publish. Host-asserted by `tests/feed-keys-mode.test.sh` |
 | Package contents | `verify-reproducible-build.sh` — determinism of our inputs within a run |
 | OpenWrt feeds | Pinned in `scripts/feeds.lock/` |
 | SDK base images | Digests resolved per cell and recorded in the release manifest (no mutable-tag reliance) |
@@ -141,22 +141,18 @@ part of the security boundary.
 | Fetched build helpers and lab images | sha256-verified or commit-pinned before execution — **except `usign`**, see below; `/tmp` trust removed (fresh `mktemp` per invocation) |
 
 Never stage a secret key into `feed-staging/` — `feed_publish_copy_keys` copies
-public keys only, and all four key filenames are gitignored. The `${f}.tmp`
-siblings that `feed-keys.sh` creates are **not** covered by that gitignore
-([#165](https://github.com/lucas-albers-lz4/fwlive/issues/165)).
+public keys only, and all four key filenames plus `*.tmp` are gitignored.
 
-Two rows above are aspirational rather than in force, both reproduced on
+One row above is aspirational rather than in force, reproduced on
 2026-08-12:
 
-- Signing secrets end at **0644**, not 0600. `feed-keys.sh` normalizes the key
-  *after* the `chmod`, and its `> "${f}.tmp"` + `mv` carries the temp file's
-  umask-derived mode onto the destination
-  ([#165](https://github.com/lucas-albers-lz4/fwlive/issues/165)).
 - `feed_publish_ensure_usign` clones `openwrt/usign` at an unpinned `master`,
   builds it, and puts it on `PATH` to **sign the feed** — no SHA, no checksum,
   twenty lines from the commit-pinned `ipkg-make-index.sh`
   ([#166](https://github.com/lucas-albers-lz4/fwlive/issues/166)).
 
+Signing-secret mode (previously #165) is restored: normalize/decode use
+`mktemp` under `umask 077`, and `chmod 600` runs again after those rewrites.
 ## Running an audit
 
 Repeatable procedure, verified upstream facts, and the rendering-harness recipe:

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -66,7 +66,7 @@ should carry a note saying what would raise it.
 | Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` |
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
-| Signing secrets are mode 0600 | **not in force** | [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) — reproduced at 0644 |
+| Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
 | Fetched build helpers verified before execution | **partial** | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) — `usign` is cloned unpinned and executed |
 | WAN toggle changes only the zone `log` bit | **partial** | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) — the `uci commit` is package-wide |
 | The WAN logging lock cannot be held by an unprivileged user | **not in force** | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) — lock file is 0644 |
@@ -75,14 +75,11 @@ should carry a note saying what would raise it.
 
 | ID | Severity | Issue | Summary |
 |----|----------|-------|---------|
-| S1 | Medium | [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) | `feed-keys.sh` tmp+`mv` discards `chmod 600`; signing secrets land 0644 in both documented storage formats. Partial secret left in `${f}.tmp`, and `*.tmp` is not gitignored |
 | S2 | Medium | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) | `feed_publish_ensure_usign` clones `openwrt/usign` at an unpinned `master`, builds it, and uses it to sign the feed. Class sibling: `get-sdk.sh` fetches an SDK tarball with no checksum |
 | S3 | Low-Medium | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) | `/var/lock/fwlive-logging.lock` is created 0644; any local UID can take `LOCK_EX` on a read-only fd and, with no BusyBox `flock -w`, wedge both toggles until reboot |
 | S4 | Low | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) | `uci commit firewall` publishes any delta staged in `/tmp/.uci/firewall`, not just our bit; and a named `config zone 'wan'` is invisible to `find_wan_zone_section` |
 
-Recommended order: S1 → S2 → S3 → S4. S1 and S2 are release-path and land
-before the next tag; S3 is a mode fix with a host test; S4 is the largest
-behavior change and benefits from going last.
+Recommended order (remaining): S2 → S3 → S4. S1 closed.
 
 ## Accepted residuals
 

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -77,6 +77,9 @@ echo "== fwlive filter negate toggle ==" >&2
 echo "== fwlive feed release assets ==" >&2
 bash tests/feed-publish-release-assets.test.sh
 
+echo "== fwlive feed-keys mode (0600) ==" >&2
+bash tests/feed-keys-mode.test.sh
+
 echo "== fwlive logging lock (race) ==" >&2
 bash tests/fwlive-logging-lock.test.sh
 

--- a/scripts/lib/feed-keys.sh
+++ b/scripts/lib/feed-keys.sh
@@ -30,9 +30,12 @@ feed_keys_normalize_usign_keyfile() {
 			umask "$old_umask"
 			return 1
 		}
+		# Always remove the temp — sed can leave a partial sibling on failure.
+		trap 'rm -f "$tmp"' RETURN
 		sed -E 's/^(untrusted comment: .+) (RW[A-Za-z0-9+/=]+)[[:space:]]*$/\1\
 \2/' "$f" > "$tmp"
 		mv "$tmp" "$f"
+		trap - RETURN
 		umask "$old_umask"
 	fi
 

--- a/scripts/lib/feed-keys.sh
+++ b/scripts/lib/feed-keys.sh
@@ -21,9 +21,19 @@ feed_keys_normalize_usign_keyfile() {
 	fi
 
 	if grep -q 'untrusted comment:' "$f" && grep -qE ' RW[A-Za-z0-9+/=]+$' "$f"; then
+		local old_umask
+		old_umask="$(umask)"
+		umask 077
+		# mktemp is 0600; avoid fixed ${f}.tmp that can leak partial key material.
+		local tmp
+		tmp="$(mktemp "${f}.XXXXXX")" || {
+			umask "$old_umask"
+			return 1
+		}
 		sed -E 's/^(untrusted comment: .+) (RW[A-Za-z0-9+/=]+)[[:space:]]*$/\1\
-\2/' "$f" > "${f}.tmp"
-		mv "${f}.tmp" "$f"
+\2/' "$f" > "$tmp"
+		mv "$tmp" "$f"
+		umask "$old_umask"
 	fi
 
 	grep -qE '^RW[A-Za-z0-9+/=]+$' "$f" || return 1
@@ -42,9 +52,23 @@ feed_keys_maybe_decode_base64() {
 	if [[ "$first" == untrusted\ comment:* || "$first" == -----BEGIN* ]]; then
 		return 0
 	fi
-	if base64 -d <"$f" >"${f}.tmp" 2>/dev/null && [[ -s "${f}.tmp" ]]; then
-		mv "${f}.tmp" "$f"
+	local old_umask tmp
+	old_umask="$(umask)"
+	umask 077
+	tmp="$(mktemp "${f}.XXXXXX")" || {
+		umask "$old_umask"
+		return 1
+	}
+	# Always remove the temp — base64 -d can write a partial decode then fail.
+	trap 'rm -f "$tmp"' RETURN
+	if base64 -d <"$f" >"$tmp" 2>/dev/null && [[ -s "$tmp" ]]; then
+		mv "$tmp" "$f"
+		trap - RETURN
+	else
+		rm -f "$tmp"
+		trap - RETURN
 	fi
+	umask "$old_umask"
 }
 
 feed_keys_write_from_env() {
@@ -80,4 +104,7 @@ feed_keys_write_from_env() {
 			echo "feed-keys: OPKG_FEED_PUBLIC_KEY must be usign public key (from usign -G) or its base64" >&2
 			return 1
 		}
+
+	# Re-assert after normalize/decode (mv can discard a prior chmod).
+	chmod 600 "${dest}/opkg-secret.key" "${dest}/apk-secret.rsa"
 }

--- a/scripts/validate-feed-keys.sh
+++ b/scripts/validate-feed-keys.sh
@@ -26,6 +26,8 @@ validate_opkg_usign_key() {
 		|| die "OPKG_FEED_SECRET_KEY must be a usign secret (from: usign -G -s opkg-secret.key -p public.key). Paste both lines or base64-encode the file."
 	feed_keys_normalize_usign_keyfile "$public" \
 		|| die "OPKG_FEED_PUBLIC_KEY must be the matching usign public key (public.key from usign -G). Paste both lines or base64-encode the file."
+	# Decode/normalize rewrite via mv; re-assert secret mode (issue #165).
+	chmod 600 "$secret" || die "cannot chmod 600 OPKG_FEED_SECRET_KEY"
 
 	sdk_matrix_resolve x86-64 23.05
 
@@ -60,6 +62,7 @@ validate_apk_rsa_key() {
 
 	feed_keys_maybe_decode_base64 "$secret"
 	feed_keys_maybe_decode_base64 "$public"
+	chmod 600 "$secret" || die "cannot chmod 600 APK_FEED_SECRET_KEY"
 
 	head -1 "$secret" | grep -q 'BEGIN.*PRIVATE KEY' \
 		|| die "APK_FEED_SECRET_KEY must be an RSA private key (openssl genrsa). Do not use the usign opkg secret here."

--- a/tests/feed-keys-mode.test.sh
+++ b/tests/feed-keys-mode.test.sh
@@ -18,7 +18,8 @@ stat_mode() {
 }
 
 DEST=$(mktemp -d)
-trap 'rm -rf "$DEST"' EXIT
+_norm_fail=$(mktemp -d)
+trap 'rm -rf "$DEST" "$_norm_fail"' EXIT
 
 # Synthetic usign-shaped keys (comment + RW payload on one line → normalize path).
 OPKG_ONE_LINE='untrusted comment: fwlive test secret RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
@@ -47,6 +48,9 @@ OPKG_SECRET="$OPKG_ONE_LINE" \
 [ -z "$(find "$DEST" -name '*.tmp' -print -quit)" ] \
 	&& ok "one-line leaves no .tmp" \
 	|| bad "one-line leftover .tmp"
+[ -z "$(find "$DEST" \( -name 'opkg-secret.key.*' -o -name 'public.key.*' \) -print -quit)" ] \
+	&& ok "one-line leaves no mktemp sibling" \
+	|| bad "one-line leftover mktemp sibling"
 
 rm -f "$DEST"/*
 
@@ -79,6 +83,23 @@ OPKG_SECRET="$OPKG_B64" \
 [ -z "$(find "$DEST" -name '*.tmp' -print -quit)" ] \
 	&& ok "base64 leaves no .tmp" \
 	|| bad "base64 leftover .tmp"
+[ -z "$(find "$DEST" \( -name 'opkg-secret.key.*' -o -name 'apk-secret.rsa.*' -o -name 'public.key.*' \) -print -quit)" ] \
+	&& ok "base64 leaves no mktemp sibling" \
+	|| bad "base64 leftover mktemp sibling"
+
+# Force normalize mid-failure: leave a planted mktemp sibling and ensure trap cleans on sed fail.
+# Simulate by running normalize after planting a one-line key and interrupting via broken sed env —
+# instead assert trap path: write one-line, normalize succeeds, then inject fail via unreadable tmp dir.
+printf '%s\n' 'untrusted comment: x RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV' \
+	> "${_norm_fail}/opkg-secret.key"
+chmod 600 "${_norm_fail}/opkg-secret.key"
+# Make the directory non-writable so mktemp fails closed (no sibling leak from prior run).
+chmod 555 "$_norm_fail"
+feed_keys_normalize_usign_keyfile "${_norm_fail}/opkg-secret.key" 2>/dev/null && true
+chmod 755 "$_norm_fail"
+[ -z "$(find "$_norm_fail" -name 'opkg-secret.key.*' -print -quit)" ] \
+	&& ok "normalize fail leaves no mktemp sibling" \
+	|| bad "normalize fail leftover mktemp sibling"
 
 # Partial base64 decode must not leave a fixed .tmp sibling.
 printf 'not-valid-base64!!!' > "${DEST}/partial.key"

--- a/tests/feed-keys-mode.test.sh
+++ b/tests/feed-keys-mode.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Host proof that feed signing secrets stay mode 0600 through write+normalize
+# (issue #165). Both documented storage formats under umask 022.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/lib/feed-keys.sh
+source "${ROOT}/scripts/lib/feed-keys.sh"
+
+fail=0
+ok() { echo "ok: $*"; }
+bad() { echo "FAIL: $*" >&2; fail=1; }
+
+stat_mode() {
+	local m
+	m=$(stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1")
+	printf '%s' "$m" | sed 's/^0*//'
+}
+
+DEST=$(mktemp -d)
+trap 'rm -rf "$DEST"' EXIT
+
+# Synthetic usign-shaped keys (comment + RW payload on one line → normalize path).
+OPKG_ONE_LINE='untrusted comment: fwlive test secret RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
+OPKG_PUB_ONE_LINE='untrusted comment: fwlive test public RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
+# Non-PEM placeholders (avoid gitleaks private-key rule); decode is a no-op /
+# failed-decode path — mode assertion is what this test proves.
+APK_PEM='fwlive-apk-test-secret-placeholder-not-a-key'
+APK_PUB_PEM='fwlive-apk-test-public-placeholder-not-a-key'
+
+umask 022
+
+# Case 1: one-line usign paste (normalize path rewrites via mktemp+mv).
+OPKG_SECRET="$OPKG_ONE_LINE" \
+	APK_SECRET="$APK_PEM" \
+	OPKG_PUB="$OPKG_PUB_ONE_LINE" \
+	APK_PUB="$APK_PUB_PEM" \
+	feed_keys_write_from_env "$DEST" \
+	|| bad "write_from_env one-line form"
+
+[ "$(stat_mode "${DEST}/opkg-secret.key")" = "600" ] \
+	&& ok "one-line opkg-secret.key mode 600" \
+	|| bad "one-line opkg-secret.key mode $(stat_mode "${DEST}/opkg-secret.key")"
+[ "$(stat_mode "${DEST}/apk-secret.rsa")" = "600" ] \
+	&& ok "one-line apk-secret.rsa mode 600" \
+	|| bad "one-line apk-secret.rsa mode $(stat_mode "${DEST}/apk-secret.rsa")"
+[ -z "$(find "$DEST" -name '*.tmp' -print -quit)" ] \
+	&& ok "one-line leaves no .tmp" \
+	|| bad "one-line leftover .tmp"
+
+rm -f "$DEST"/*
+
+# Case 2: base64-encoded key files (decode path).
+# Two-line usign already-normalized content, base64'd.
+OPKG_B64=$(printf '%s\n%s\n' 'untrusted comment: fwlive test secret' \
+	'RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV' | base64 -w0 2>/dev/null \
+	|| printf '%s\n%s\n' 'untrusted comment: fwlive test secret' \
+	'RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV' | base64)
+OPKG_PUB_B64=$(printf '%s\n%s\n' 'untrusted comment: fwlive test public' \
+	'RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV' | base64 -w0 2>/dev/null \
+	|| printf '%s\n%s\n' 'untrusted comment: fwlive test public' \
+	'RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV' | base64)
+APK_B64=$(printf '%s' "$APK_PEM" | base64 -w0 2>/dev/null || printf '%s' "$APK_PEM" | base64)
+APK_PUB_B64=$(printf '%s' "$APK_PUB_PEM" | base64 -w0 2>/dev/null || printf '%s' "$APK_PUB_PEM" | base64)
+
+OPKG_SECRET="$OPKG_B64" \
+	APK_SECRET="$APK_B64" \
+	OPKG_PUB="$OPKG_PUB_B64" \
+	APK_PUB="$APK_PUB_B64" \
+	feed_keys_write_from_env "$DEST" \
+	|| bad "write_from_env base64 form"
+
+[ "$(stat_mode "${DEST}/opkg-secret.key")" = "600" ] \
+	&& ok "base64 opkg-secret.key mode 600" \
+	|| bad "base64 opkg-secret.key mode $(stat_mode "${DEST}/opkg-secret.key")"
+[ "$(stat_mode "${DEST}/apk-secret.rsa")" = "600" ] \
+	&& ok "base64 apk-secret.rsa mode 600" \
+	|| bad "base64 apk-secret.rsa mode $(stat_mode "${DEST}/apk-secret.rsa")"
+[ -z "$(find "$DEST" -name '*.tmp' -print -quit)" ] \
+	&& ok "base64 leaves no .tmp" \
+	|| bad "base64 leftover .tmp"
+
+# Partial base64 decode must not leave a fixed .tmp sibling.
+printf 'not-valid-base64!!!' > "${DEST}/partial.key"
+feed_keys_maybe_decode_base64 "${DEST}/partial.key" || true
+[ ! -f "${DEST}/partial.key.tmp" ] \
+	&& ok "failed decode leaves no partial.key.tmp" \
+	|| bad "partial.key.tmp leaked after failed decode"
+[ -z "$(find "$DEST" -name 'partial.key.*' ! -name 'partial.key' -print -quit)" ] \
+	&& ok "failed decode leaves no mktemp sibling" \
+	|| bad "mktemp sibling leaked after failed decode"
+
+[ "$fail" = "0" ] || exit 1
+echo "feed-keys-mode tests: ok"


### PR DESCRIPTION
## Summary
- `feed-keys.sh`: `mktemp` + `umask 077` for decode/normalize; `chmod 600` after rewrites; no leftover `${f}.tmp`
- `validate-feed-keys.sh` re-asserts secret mode after decode
- Host proof: `tests/feed-keys-mode.test.sh` (both storage formats under umask 022)
- Ledger / security-model updated; `*.tmp` gitignored

Closes #165

## Test plan
- [x] `bash tests/feed-keys-mode.test.sh`
- [ ] `./scripts/fwlive-test.sh`

Made with [Cursor](https://cursor.com)