### PR TITLE
fix(security): pin usign + checksum get-sdk.sh (S2 / #166)

### DIFF
--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -138,18 +138,14 @@ part of the security boundary.
 | OpenWrt feeds | Pinned in `scripts/feeds.lock/` |
 | SDK base images | Digests resolved per cell and recorded in the release manifest (no mutable-tag reliance) |
 | GitHub Actions | SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` |
-| Fetched build helpers and lab images | sha256-verified or commit-pinned before execution — **except `usign`**, see below; `/tmp` trust removed (fresh `mktemp` per invocation) |
+| Fetched build helpers and lab images | sha256-verified or commit-pinned before execution; `/tmp` trust removed (fresh `mktemp` per invocation). `usign` is commit-pinned via `USIGN_PIN_SHA` ([#166](https://github.com/lucas-albers-lz4/fwlive/issues/166)); `get-sdk.sh` verifies upstream `sha256sums` |
 
 Never stage a secret key into `feed-staging/` — `feed_publish_copy_keys` copies
 public keys only, and all four key filenames plus `*.tmp` are gitignored.
 
-One row above is aspirational rather than in force, reproduced on
-2026-08-12:
+Signing-secret mode (previously #165) and usign pinning (#166) are in force:
 
-- `feed_publish_ensure_usign` clones `openwrt/usign` at an unpinned `master`,
-  builds it, and puts it on `PATH` to **sign the feed** — no SHA, no checksum,
-  twenty lines from the commit-pinned `ipkg-make-index.sh`
-  ([#166](https://github.com/lucas-albers-lz4/fwlive/issues/166)).
+`feed_publish_ensure_usign` previously cloned unpinned `master` ([#166](https://github.com/lucas-albers-lz4/fwlive/issues/166)); it now fetches `USIGN_PIN_SHA`.
 
 Signing-secret mode (previously #165) is restored: normalize/decode use
 `mktemp` under `umask 077`, and `chmod 600` runs again after those rewrites.

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -67,7 +67,7 @@ should carry a note saying what would raise it.
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
-| Fetched build helpers verified before execution | **partial** | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) — `usign` is cloned unpinned and executed |
+| Fetched build helpers verified before execution | `host` | `tests/fetch-pin-gate.test.sh` — usign commit-pinned; `get-sdk.sh` sha256-verified |
 | WAN toggle changes only the zone `log` bit | **partial** | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) — the `uci commit` is package-wide |
 | The WAN logging lock cannot be held by an unprivileged user | **not in force** | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) — lock file is 0644 |
 
@@ -75,11 +75,10 @@ should carry a note saying what would raise it.
 
 | ID | Severity | Issue | Summary |
 |----|----------|-------|---------|
-| S2 | Medium | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) | `feed_publish_ensure_usign` clones `openwrt/usign` at an unpinned `master`, builds it, and uses it to sign the feed. Class sibling: `get-sdk.sh` fetches an SDK tarball with no checksum |
 | S3 | Low-Medium | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) | `/var/lock/fwlive-logging.lock` is created 0644; any local UID can take `LOCK_EX` on a read-only fd and, with no BusyBox `flock -w`, wedge both toggles until reboot |
 | S4 | Low | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) | `uci commit firewall` publishes any delta staged in `/tmp/.uci/firewall`, not just our bit; and a named `config zone 'wan'` is invisible to `find_wan_zone_section` |
 
-Recommended order (remaining): S2 → S3 → S4. S1 closed.
+Recommended order (remaining): S3 → S4. S1/S2 closed.
 
 ## Accepted residuals
 

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -80,6 +80,9 @@ bash tests/feed-publish-release-assets.test.sh
 echo "== fwlive feed-keys mode (0600) ==" >&2
 bash tests/feed-keys-mode.test.sh
 
+echo "== fwlive fetch-pin gate ==" >&2
+bash tests/fetch-pin-gate.test.sh
+
 echo "== fwlive logging lock (race) ==" >&2
 bash tests/fwlive-logging-lock.test.sh
 

--- a/scripts/get-sdk.sh
+++ b/scripts/get-sdk.sh
@@ -11,12 +11,46 @@ set -euo pipefail
 RELEASE="${RELEASE:-24.10.5}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TAR="openwrt-sdk-${RELEASE}-armsr-armv8_gcc-13.3.0_musl.Linux-x86_64.tar.zst"
-URL="https://downloads.openwrt.org/releases/${RELEASE}/targets/armsr/armv8/${TAR}"
+BASE="https://downloads.openwrt.org/releases/${RELEASE}/targets/armsr/armv8"
+URL="${BASE}/${TAR}"
+
+# Same shape as download-openwrt-*.sh — verify against upstream sha256sums
+# before extraction (issue #166 class sibling).
+verify_downloaded_sha256() {
+	local file="$1" name="$2" manifest="$3" expected actual
+	expected="$(awk -v n="$name" '$2 == "*" n {print $1; exit}' "$manifest")"
+	if [[ -z "$expected" ]]; then
+		rm -f "$file"
+		echo "verify: sha256sums has no entry for '${name}' — cannot verify, aborting" >&2
+		exit 1
+	fi
+	if ! command -v sha256sum >/dev/null 2>&1; then
+		echo "verify: 'sha256sum' not available — cannot verify '${name}'" >&2
+		rm -f "$file"
+		exit 1
+	fi
+	actual="$(sha256sum "$file" | awk '{print $1}')"
+	if [[ "$actual" != "$expected" ]]; then
+		rm -f "$file"
+		echo "verify: sha256 MISMATCH for '${name}'" >&2
+		echo "  expected: ${expected}" >&2
+		echo "  actual:   ${actual}" >&2
+		exit 1
+	fi
+	echo "verify: ${name} OK (${expected})" >&2
+}
 
 mkdir -p "${ROOT}/.sdk"
 cd "${ROOT}/.sdk"
+
+SUM_MANIFEST="$(mktemp -t fwlive-sdk-sha256sums.XXXXXX)"
+trap 'rm -f "${SUM_MANIFEST}"' EXIT
+echo "Fetching sha256sums from ${BASE}/ ..."
+curl -fsSL -o "${SUM_MANIFEST}" "${BASE}/sha256sums"
+
 echo "Fetching ${URL} ..."
 curl -fsSL -o "${TAR}" "${URL}"
+verify_downloaded_sha256 "${TAR}" "${TAR}" "${SUM_MANIFEST}"
 echo "Extracting ..."
 tar -xf "${TAR}"
 echo "Done. SDK root:"

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -96,24 +96,54 @@ feed_publish_stage_release_assets() {
 	done
 }
 
+# Pinned usign revision for host-side opkg feed signing (no fixed /tmp path;
+# fresh build per call). Same pin as the sibling usrmanage feed-publish helper.
+# Resolved via: git ls-remote https://github.com/openwrt/usign master
+USIGN_PIN_SHA='c4c72b1b07945ee192361dc751291a7c98d6adcd'
+
 feed_publish_ensure_usign() {
 	if command -v usign >/dev/null 2>&1; then
 		return 0
 	fi
-	# Build into a fresh, unpredictable mktemp -d each invocation. This removes
-	# the fixed /tmp path trust (issue #131): no pre-existing /tmp/fwlive-usign-
-	# build can be hijacked, since there is no fixed path to pre-create.
-	local build_dir
-	build_dir="$(mktemp -d "${TMPDIR:-/tmp}/fwlive-usign.XXXXXX")"
-	# The build dir intentionally lives for the process lifetime: PATH
-	# points into it and usign is invoked later by the caller. It is a
-	# random per-process name (no fixed path to pre-create = no hijack
-	# window); /tmp is reaped on reboot. Cleanup belongs to the caller's
-	# trap, not this lib (it cannot know when the last usign use happens).
-	echo "→ building usign (isolated build dir)..." >&2
-	git clone --depth 1 https://github.com/openwrt/usign.git "${build_dir}/src"
-	make -C "${build_dir}/src" -j"$(nproc 2>/dev/null || echo 2)" >/dev/null
-	ln -sf "${build_dir}/src/usign" "${build_dir}/usign"
+	# Prefer the SDK's host usign when a prior docker-sdk build left it on disk.
+	local sdk_usign root
+	root="$(feed_publish_root)"
+	for sdk_usign in \
+		"${root}/.sdk"/openwrt-sdk-*/staging_dir/host/bin/usign \
+		/builder/staging_dir/host/bin/usign; do
+		if [[ -x "$sdk_usign" ]]; then
+			export PATH="$(dirname "$sdk_usign"):${PATH}"
+			command -v usign >/dev/null && return 0
+		fi
+	done
+	local build_dir rc
+	command -v cmake >/dev/null 2>&1 || {
+		echo "usign build needs cmake (pinned ${USIGN_PIN_SHA}); install cmake or put usign on PATH" >&2
+		return 1
+	}
+	# Fresh unpredictable mktemp -d each invocation (issue #131 / #166): no
+	# fixed /tmp path to pre-create, and the source is commit-pinned.
+	build_dir="$(mktemp -d "${TMPDIR:-/tmp}/fwlive-usign.XXXXXX")" || return 1
+	echo "→ building pinned usign (${USIGN_PIN_SHA}) in ${build_dir}..." >&2
+	rc=0
+	(
+		set -e
+		git init -q "${build_dir}/src"
+		git -C "${build_dir}/src" remote add origin "https://github.com/openwrt/usign.git"
+		git -C "${build_dir}/src" fetch -q --depth 1 origin "${USIGN_PIN_SHA}"
+		git -C "${build_dir}/src" checkout -q "${USIGN_PIN_SHA}"
+		test "$(git -C "${build_dir}/src" rev-parse HEAD)" = "${USIGN_PIN_SHA}"
+		cmake -S "${build_dir}/src" -B "${build_dir}/build" >/dev/null
+		make -C "${build_dir}/build" -j"$(nproc 2>/dev/null || echo 2)" >/dev/null
+		ln -sf "${build_dir}/build/usign" "${build_dir}/usign"
+	) || rc=1
+	if [[ "$rc" -ne 0 ]]; then
+		rm -rf "$build_dir"
+		echo "usign build failed (pinned ${USIGN_PIN_SHA})" >&2
+		return 1
+	fi
+	# Build dir lives for the process lifetime: PATH points into it and usign
+	# is invoked later. Random per-process name; /tmp reaped on reboot.
 	export PATH="${build_dir}:${PATH}"
 	command -v usign >/dev/null
 }

--- a/tests/fetch-pin-gate.test.sh
+++ b/tests/fetch-pin-gate.test.sh
@@ -1,40 +1,82 @@
 #!/usr/bin/env bash
-# Grep gate: fetched helpers in scripts/ must be commit-pinned or sha256-verified
-# before execution (issue #166). Fail if an unpinned git clone of usign (or a
-# curl-to-file without an adjacent verify) reappears.
+# Semantic gate: fetched helpers in scripts/ must be commit-pinned or
+# sha256-verified before execution (issue #166). Negative fixtures must fail.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fail=0
+ok() { echo "ok: $*"; }
+bad() { echo "FAIL: $*" >&2; fail=1; }
 
-# Unpinned usign clone (the S2 defect shape).
+# Unpinned usign clone (the S2 defect shape) must not appear in scripts/.
 if grep -RIn --include='*.sh' -E 'git[[:space:]]+clone.*openwrt/usign' \
 	"$ROOT/scripts" 2>/dev/null \
 	| grep -v 'USIGN_PIN_SHA\|fetch.*USIGN_PIN\|pinned usign' >/dev/null; then
-	echo "FAIL: unpinned openwrt/usign git clone in scripts/" >&2
+	bad "unpinned openwrt/usign git clone in scripts/"
 	grep -RIn --include='*.sh' -E 'git[[:space:]]+clone.*openwrt/usign' "$ROOT/scripts" >&2 || true
-	fail=1
 else
-	echo "ok: no unpinned openwrt/usign clone"
+	ok "no unpinned openwrt/usign clone"
 fi
 
-# feed_publish_ensure_usign must reference the pin.
-if grep -q "USIGN_PIN_SHA=" "$ROOT/scripts/lib/feed-publish.sh" \
-	&& grep -q 'fetch.*USIGN_PIN_SHA\|origin "\${USIGN_PIN_SHA}"\|origin "${USIGN_PIN_SHA}"' \
-		"$ROOT/scripts/lib/feed-publish.sh"; then
-	echo "ok: feed_publish_ensure_usign is commit-pinned"
+# feed_publish_ensure_usign: pin constant + fetch/checkout/HEAD check (not comments).
+_fp="$ROOT/scripts/lib/feed-publish.sh"
+if grep -qE "^USIGN_PIN_SHA='[0-9a-f]{40}'$" "$_fp" \
+	&& grep -qE 'git -C .* fetch .* origin "\$\{USIGN_PIN_SHA\}"' "$_fp" \
+	&& grep -qE 'git -C .* checkout .* "\$\{USIGN_PIN_SHA\}"' "$_fp" \
+	&& grep -qE 'rev-parse HEAD.*=.*"\$\{USIGN_PIN_SHA\}"' "$_fp"; then
+	ok "feed_publish_ensure_usign fetch/checkout/HEAD pin"
 else
-	echo "FAIL: feed_publish_ensure_usign missing USIGN_PIN_SHA fetch" >&2
-	fail=1
+	bad "feed_publish_ensure_usign missing semantic USIGN_PIN_SHA pin"
 fi
 
-# get-sdk.sh must verify sha256 before extract.
-if grep -q 'verify_downloaded_sha256' "$ROOT/scripts/get-sdk.sh" \
-	&& grep -q 'sha256sums' "$ROOT/scripts/get-sdk.sh"; then
-	echo "ok: get-sdk.sh verifies sha256sums"
+# get-sdk.sh: verify_downloaded_sha256 must appear before tar -xf.
+_gs="$ROOT/scripts/get-sdk.sh"
+_verify_line=$(grep -n 'verify_downloaded_sha256' "$_gs" | head -1 | cut -d: -f1)
+_tar_line=$(grep -n 'tar -xf' "$_gs" | head -1 | cut -d: -f1)
+if [ -n "$_verify_line" ] && [ -n "$_tar_line" ] && [ "$_verify_line" -lt "$_tar_line" ]; then
+	ok "get-sdk.sh verifies before tar extract"
 else
-	echo "FAIL: get-sdk.sh missing sha256 verification" >&2
-	fail=1
+	bad "get-sdk.sh verify not before tar -xf (verify=$_verify_line tar=$_tar_line)"
+fi
+
+# Negative fixtures: gate logic must reject decoy/comment-only and extract-first shapes.
+_neg=$(mktemp -d)
+trap 'rm -rf "$_neg"' EXIT
+
+cat > "$_neg/bad-usign.sh" <<'EOF'
+#!/usr/bin/env bash
+# USIGN_PIN_SHA='deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+# fetch USIGN_PIN_SHA
+git init -q src
+git -C src fetch -q --depth 1 origin master
+git -C src checkout -q master
+EOF
+
+cat > "$_neg/bad-get-sdk.sh" <<'EOF'
+#!/usr/bin/env bash
+# verify_downloaded_sha256 lives only in a comment / dead stub
+verify_downloaded_sha256() { :; }
+# sha256sums mentioned here but unused
+tar -xf "$TAR"
+verify_downloaded_sha256 "$TAR" "$TAR" /dev/null
+EOF
+
+# Decoy comment + unpinned fetch must not satisfy the semantic pin checks.
+if grep -qE "^USIGN_PIN_SHA='[0-9a-f]{40}'$" "$_neg/bad-usign.sh" \
+	&& grep -qE 'git -C .* fetch .* origin "\$\{USIGN_PIN_SHA\}"' "$_neg/bad-usign.sh"; then
+	bad "negative usign fixture unexpectedly matched pin checks"
+else
+	ok "negative usign fixture rejected by pin checks"
+fi
+
+_nv=$(grep -n 'verify_downloaded_sha256' "$_neg/bad-get-sdk.sh" | grep -v '^#' | head -1 | cut -d: -f1 || true)
+# Call sites: first non-definition invocation after tar would fail order check.
+_n_verify_call=$(awk '/verify_downloaded_sha256 \$/{print NR; exit}' "$_neg/bad-get-sdk.sh")
+_n_tar=$(awk '/tar -xf/{print NR; exit}' "$_neg/bad-get-sdk.sh")
+if [ -n "$_n_verify_call" ] && [ -n "$_n_tar" ] && [ "$_n_verify_call" -lt "$_n_tar" ]; then
+	bad "negative get-sdk fixture unexpectedly passed order check"
+else
+	ok "negative get-sdk fixture rejected (extract before verify)"
 fi
 
 [ "$fail" = "0" ] || exit 1

--- a/tests/fetch-pin-gate.test.sh
+++ b/tests/fetch-pin-gate.test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Grep gate: fetched helpers in scripts/ must be commit-pinned or sha256-verified
+# before execution (issue #166). Fail if an unpinned git clone of usign (or a
+# curl-to-file without an adjacent verify) reappears.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail=0
+
+# Unpinned usign clone (the S2 defect shape).
+if grep -RIn --include='*.sh' -E 'git[[:space:]]+clone.*openwrt/usign' \
+	"$ROOT/scripts" 2>/dev/null \
+	| grep -v 'USIGN_PIN_SHA\|fetch.*USIGN_PIN\|pinned usign' >/dev/null; then
+	echo "FAIL: unpinned openwrt/usign git clone in scripts/" >&2
+	grep -RIn --include='*.sh' -E 'git[[:space:]]+clone.*openwrt/usign' "$ROOT/scripts" >&2 || true
+	fail=1
+else
+	echo "ok: no unpinned openwrt/usign clone"
+fi
+
+# feed_publish_ensure_usign must reference the pin.
+if grep -q "USIGN_PIN_SHA=" "$ROOT/scripts/lib/feed-publish.sh" \
+	&& grep -q 'fetch.*USIGN_PIN_SHA\|origin "\${USIGN_PIN_SHA}"\|origin "${USIGN_PIN_SHA}"' \
+		"$ROOT/scripts/lib/feed-publish.sh"; then
+	echo "ok: feed_publish_ensure_usign is commit-pinned"
+else
+	echo "FAIL: feed_publish_ensure_usign missing USIGN_PIN_SHA fetch" >&2
+	fail=1
+fi
+
+# get-sdk.sh must verify sha256 before extract.
+if grep -q 'verify_downloaded_sha256' "$ROOT/scripts/get-sdk.sh" \
+	&& grep -q 'sha256sums' "$ROOT/scripts/get-sdk.sh"; then
+	echo "ok: get-sdk.sh verifies sha256sums"
+else
+	echo "FAIL: get-sdk.sh missing sha256 verification" >&2
+	fail=1
+fi
+
+[ "$fail" = "0" ] || exit 1
+echo "fetch-pin gate: ok"


### PR DESCRIPTION
## Summary
- Port usrmanage-style `USIGN_PIN_SHA` fetch into `feed_publish_ensure_usign` (no unpinned `git clone`)
- Prefer PATH / SDK host `usign` before building
- `get-sdk.sh` verifies against upstream `sha256sums` before extract
- Grep gate: `tests/fetch-pin-gate.test.sh`

Closes #166

## Test plan
- [x] `bash tests/fetch-pin-gate.test.sh`
- [ ] `./scripts/fwlive-test.sh`

Made with [Cursor](https://cursor.com)