### PR TITLE
fix(security): WAN-logging lock mode 0600 (S3 / #167)

### DIFF
--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -69,16 +69,15 @@ should carry a note saying what would raise it.
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
 | Fetched build helpers verified before execution | `host` | `tests/fetch-pin-gate.test.sh` — usign commit-pinned; `get-sdk.sh` sha256-verified |
 | WAN toggle changes only the zone `log` bit | **partial** | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) — the `uci commit` is package-wide |
-| The WAN logging lock cannot be held by an unprivileged user | **not in force** | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) — lock file is 0644 |
+| The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` — lock created/tightened to `0600` |
 
 ## Open findings
 
 | ID | Severity | Issue | Summary |
 |----|----------|-------|---------|
-| S3 | Low-Medium | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) | `/var/lock/fwlive-logging.lock` is created 0644; any local UID can take `LOCK_EX` on a read-only fd and, with no BusyBox `flock -w`, wedge both toggles until reboot |
 | S4 | Low | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) | `uci commit firewall` publishes any delta staged in `/tmp/.uci/firewall`, not just our bit; and a named `config zone 'wan'` is invisible to `find_wan_zone_section` |
 
-Recommended order (remaining): S3 → S4. S1/S2 closed.
+Recommended order (remaining): S4. S1/S2/S3 closed.
 
 ## Accepted residuals
 

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -23,7 +23,12 @@ WAN_LOG_LOCK_FILE="${FWLIVE_WAN_LOG_LOCK_FILE:-/var/lock/fwlive-logging.lock}"
 
 # Acquire the exclusive logging lock on fd 9. Blocks until free; fails closed
 # (return 1) only if the lock file cannot be opened or flock is unavailable.
+# Create/tighten the lock to 0600 so unprivileged UIDs cannot take LOCK_EX on
+# a world-readable fd (issue #167 / flock(2) allows exclusive locks on O_RDONLY).
 acquire_wan_log_lock() {
+	( umask 077; : >> "$WAN_LOG_LOCK_FILE" ) 2>/dev/null || return 1
+	chmod 0600 "$WAN_LOG_LOCK_FILE" 2>/dev/null || true
+	chown 0:0 "$WAN_LOG_LOCK_FILE" 2>/dev/null || true
 	exec 9>"$WAN_LOG_LOCK_FILE" 2>/dev/null || return 1
 	flock 9 2>/dev/null || {
 		exec 9>&-

--- a/tests/fwlive-logging-lock.test.sh
+++ b/tests/fwlive-logging-lock.test.sh
@@ -269,4 +269,27 @@ out=$(sh "$WORK/rollback-child.sh" "$LOGGING_SH" "$WORK/rb2" "" "1")
 [ "$out" = "2" ] || die "C2: expected rollback skipped (value stays 2), got '$out'"
 ok "reload failure + concurrent change -> rollback skipped (newer toggle preserved)"
 
+# --- Part D: lock file mode 0600 (issue #167) ---------------------------------
+stat_mode() {
+	m=$(stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1")
+	printf '%s' "$m" | sed 's/^0*//'
+}
+
+rm -f "$FWLIVE_WAN_LOG_LOCK_FILE"
+umask 022
+# shellcheck disable=SC1090
+. "$LOGGING_SH"
+acquire_wan_log_lock || die "acquire_wan_log_lock failed for mode check"
+release_wan_log_lock
+[ "$(stat_mode "$FWLIVE_WAN_LOG_LOCK_FILE")" = "600" ] \
+	|| die "lock mode $(stat_mode "$FWLIVE_WAN_LOG_LOCK_FILE") want 600"
+ok "new lock file is mode 0600"
+
+install -m 0644 /dev/null "$FWLIVE_WAN_LOG_LOCK_FILE"
+acquire_wan_log_lock || die "acquire on pre-existing 0644 failed"
+release_wan_log_lock
+[ "$(stat_mode "$FWLIVE_WAN_LOG_LOCK_FILE")" = "600" ] \
+	|| die "pre-existing 0644 lock not tightened (got $(stat_mode "$FWLIVE_WAN_LOG_LOCK_FILE"))"
+ok "pre-existing 0644 lock tightened to 0600"
+
 echo "fwlive-logging-lock tests passed"


### PR DESCRIPTION
## Summary
- `acquire_wan_log_lock` creates under `umask 077` and tightens to `0600` (upgrade path)
- Host asserts new + pre-existing 0644 lock end at 0600

Closes #167

## Test plan
- [x] `bash tests/fwlive-logging-lock.test.sh`

Made with [Cursor](https://cursor.com)