### PR TITLE
fix(security): WAN-logging UCI pending guard + named zone (S4 / #168)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fwlive-feed.rsa.pub.*
 
 # Node dev deps (screenshot capture only — not shipped in .ipk)
 node_modules/
+__pycache__/

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -115,16 +115,15 @@ methods. `__rulesmap_iptables` reads a fixed path and rejects argv-supplied
 files.
 
 The `uci set` touches only bit 0 of the WAN zone `log` value, and UCI is rolled
-back if the firewall reload fails. The **commit** is wider than the set:
-`uci commit firewall` publishes any delta already staged in `/tmp/.uci/firewall`
-by another CLI actor ([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)).
-An unprivileged user cannot stage such a delta — `/tmp/.uci` is `0700` (libuci
-`UCI_DIRMODE`) — which is what keeps that finding Low.
+back if the firewall reload fails. Before `uci set` / commit, the toggle refuses
+when `uci changes firewall` is non-empty (`firewall_changes_pending`) so a
+package-wide commit cannot publish unrelated staged deltas
+([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)). Zone lookup
+accepts both anonymous `@zone[N]` and named sections.
 
-Serialization of the toggle depends on a lock file that is currently created
-world-readable, so any local UID can hold it and, with no BusyBox `flock -w`,
-block both toggles until reboot
-([#167](https://github.com/lucas-albers-lz4/fwlive/issues/167)).
+Serialization of the toggle uses a lock file created/tightened to `0600` so
+unprivileged UIDs cannot take `LOCK_EX` ([#167](https://github.com/lucas-albers-lz4/fwlive/issues/167)).
+BusyBox still has no `flock -w`; a stuck *root* holder can block callers indefinitely.
 
 ## Supply-chain surface
 

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -66,10 +66,10 @@ should carry a note saying what would raise it.
 | Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` |
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
-| Signing secrets are mode 0600 | **not in force** | [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) — reproduced at 0644 |
-| Fetched build helpers verified before execution | **partial** | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) — `usign` is cloned unpinned and executed |
+| Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
+| Fetched build helpers verified before execution | `host` | `tests/fetch-pin-gate.test.sh` — usign commit-pinned; `get-sdk.sh` sha256-verified |
 | WAN toggle changes only the zone `log` bit | `host` | `tests/fwlive-logging.test.sh` — pending-delta refuse; named + anonymous zone lookup |
-| The WAN logging lock cannot be held by an unprivileged user | **not in force** | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) — lock file is 0644 |
+| The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` Part D — create+tighten to 0600 |
 
 ## Open findings
 

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -66,18 +66,18 @@ should carry a note saying what would raise it.
 | Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` |
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
-| Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
-| Fetched build helpers verified before execution | `host` | `tests/fetch-pin-gate.test.sh` — usign commit-pinned; `get-sdk.sh` sha256-verified |
-| WAN toggle changes only the zone `log` bit | **partial** | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) — the `uci commit` is package-wide |
-| The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` — lock created/tightened to `0600` |
+| Signing secrets are mode 0600 | **not in force** | [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) — reproduced at 0644 |
+| Fetched build helpers verified before execution | **partial** | [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) — `usign` is cloned unpinned and executed |
+| WAN toggle changes only the zone `log` bit | `host` | `tests/fwlive-logging.test.sh` — pending-delta refuse; named + anonymous zone lookup |
+| The WAN logging lock cannot be held by an unprivileged user | **not in force** | [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) — lock file is 0644 |
 
 ## Open findings
 
 | ID | Severity | Issue | Summary |
 |----|----------|-------|---------|
-| S4 | Low | [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) | `uci commit firewall` publishes any delta staged in `/tmp/.uci/firewall`, not just our bit; and a named `config zone 'wan'` is invisible to `find_wan_zone_section` |
 
-Recommended order (remaining): S4. S1/S2/S3 closed.
+(no open findings from the 2026-08-12 wave)
+
 
 ## Accepted residuals
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -571,6 +571,8 @@ return view.extend({
 			if (!res || !res.ok) {
 				if (res && res.error === 'nf_log_missing')
 					this.loggingNotice = _('Cannot enable logging until kernel log modules are installed.');
+				else if (res && res.error === 'firewall_changes_pending')
+					this.loggingNotice = _('Another change is staged for the firewall; apply or revert it first.');
 				else
 					this.loggingNotice = _('Could not enable logging.');
 				await this.loadLoggingStatus();
@@ -605,7 +607,10 @@ return view.extend({
 		try {
 			const res = await callFwliveDisableLogging();
 			if (!res || !res.ok) {
-				this.loggingNotice = _('Could not disable logging.');
+				if (res && res.error === 'firewall_changes_pending')
+					this.loggingNotice = _('Another change is staged for the firewall; apply or revert it first.');
+				else
+					this.loggingNotice = _('Could not disable logging.');
 				await this.loadLoggingStatus();
 				return;
 			}

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -44,12 +44,17 @@ release_wan_log_lock() {
 
 find_wan_zone_section() {
 	# Match anonymous (@zone[N]) and named (e.g. wan) sections whose name option
-	# is 'wan'. Guard that the section type is zone (issue #168).
-	zone=$(uci -q show firewall 2>/dev/null \
-		| sed -n "s/^firewall\.\([^.]*\)\.name='wan'$/\1/p" | head -1)
-	[ -n "$zone" ] || return 0
-	[ "$(uci -q get "firewall.${zone}" 2>/dev/null)" = "zone" ] || return 0
-	printf '%s' "$zone"
+	# is 'wan'. Prefer the first section whose type is zone (issue #168); skip
+	# non-zone sections that happen to share name='wan'.
+	_zones=$(uci -q show firewall 2>/dev/null \
+		| sed -n "s/^firewall\.\([^.]*\)\.name='wan'$/\1/p")
+	for zone in $_zones; do
+		[ -n "$zone" ] || continue
+		[ "$(uci -q get "firewall.${zone}" 2>/dev/null)" = "zone" ] || continue
+		printf '%s' "$zone"
+		return 0
+	done
+	return 0
 }
 
 firewall_changes_pending() {
@@ -218,6 +223,9 @@ commit_wan_log_change() {
 	if uci commit firewall; then
 		return 0
 	fi
+	# Drop our staged log delta so a later toggle is not stuck on
+	# firewall_changes_pending from this package's own orphaned write.
+	uci -q revert firewall 2>/dev/null || true
 	printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"uci_commit_failed"}' "$zone_json"
 	return 1
 }
@@ -252,8 +260,11 @@ reload_and_report_wan_log() {
 				# the pre-commit value. (If a concurrent toggle committed the
 				# same value, the toggle is idempotent: the state intent is
 				# identical, so restoring previous is the correct rollback.)
-				restore_wan_zone_log "$zone" "$previous"
-				logger -t fwlive "$fail_msg" 2>/dev/null || true
+				if restore_wan_zone_log "$zone" "$previous"; then
+					logger -t fwlive "$fail_msg" 2>/dev/null || true
+				else
+					logger -t fwlive "Firewall reload failed; WAN log rollback skipped (pending changes or restore failed)" 2>/dev/null || true
+				fi
 			else
 				# A concurrent toggle changed the value after our commit; do
 				# not clobber it. Log the divergence and leave the newer value.

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -43,7 +43,18 @@ release_wan_log_lock() {
 }
 
 find_wan_zone_section() {
-	uci -q show firewall 2>/dev/null | sed -n "s/^firewall\.\(@zone\[[0-9]*\]\)\.name='wan'$/\1/p" | head -1
+	# Match anonymous (@zone[N]) and named (e.g. wan) sections whose name option
+	# is 'wan'. Guard that the section type is zone (issue #168).
+	zone=$(uci -q show firewall 2>/dev/null \
+		| sed -n "s/^firewall\.\([^.]*\)\.name='wan'$/\1/p" | head -1)
+	[ -n "$zone" ] || return 0
+	[ "$(uci -q get "firewall.${zone}" 2>/dev/null)" = "zone" ] || return 0
+	printf '%s' "$zone"
+}
+
+firewall_changes_pending() {
+	pending="$(uci -q changes firewall 2>/dev/null)"
+	[ -n "$pending" ]
 }
 
 wan_zone_log_value() {
@@ -184,6 +195,11 @@ restore_wan_zone_log() {
 	zone="$1"
 	previous="$2"
 	[ -n "$zone" ] || return 1
+	# Refuse to publish unrelated staged firewall deltas (issue #168).
+	if firewall_changes_pending; then
+		logger -t fwlive "WAN log rollback skipped: firewall changes pending" 2>/dev/null || true
+		return 1
+	fi
 	if [ -z "$previous" ]; then
 		uci -q delete "firewall.${zone}.log" 2>/dev/null || true
 	else
@@ -279,6 +295,12 @@ enable_wan_logging() {
 		return 0
 	fi
 
+	if firewall_changes_pending; then
+		release_wan_log_lock
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_changes_pending"}' "$zone_json"
+		return 0
+	fi
+
 	current=$(wan_zone_log_value "$zone")
 	if wan_filter_log_enabled "$current"; then
 		release_wan_log_lock
@@ -319,6 +341,12 @@ disable_wan_logging() {
 	# from the latest committed value; a concurrent toggle cannot interleave.
 	if ! acquire_wan_log_lock; then
 		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"lock_failed"}' "$zone_json"
+		return 0
+	fi
+
+	if firewall_changes_pending; then
+		release_wan_log_lock
+		printf '{"ok":false,"changed":false,"wan_zone":%s,"error":"firewall_changes_pending"}' "$zone_json"
 		return 0
 	fi
 

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -63,6 +63,103 @@ esac
 unset -f uci
 ok "restore_wan_zone_log stubs"
 
+# find_wan_zone_section: named zone + anonymous zone (issue #168)
+uci() {
+	case "$*" in
+		'-q show firewall')
+			cat <<'EOF'
+firewall.wan=zone
+firewall.wan.name='wan'
+firewall.wan.network='wan'
+firewall.@zone[1]=zone
+firewall.@zone[1].name='lan'
+EOF
+			;;
+		'-q get firewall.wan')
+			printf 'zone\n'
+			;;
+		*) return 1 ;;
+	esac
+}
+got=$(find_wan_zone_section)
+[ "$got" = "wan" ] || die "named wan zone expected 'wan', got '$got'"
+ok "find_wan_zone_section named zone"
+
+uci() {
+	case "$*" in
+		'-q show firewall')
+			cat <<'EOF'
+firewall.@zone[0]=zone
+firewall.@zone[0].name='wan'
+firewall.@zone[1]=zone
+firewall.@zone[1].name='lan'
+EOF
+			;;
+		'-q get firewall.@zone[0]')
+			printf 'zone\n'
+			;;
+		*) return 1 ;;
+	esac
+}
+got=$(find_wan_zone_section)
+[ "$got" = "@zone[0]" ] || die "anonymous wan zone expected @zone[0], got '$got'"
+ok "find_wan_zone_section anonymous zone"
+
+# firewall_changes_pending + enable refuse (issue #168)
+PENDING_STAGED=1
+UCI_COMMITTED=0
+uci() {
+	case "$*" in
+		'-q changes firewall')
+			[ "$PENDING_STAGED" = 1 ] && printf "firewall.@rule[0].name='staged'\n"
+			;;
+		'-q show firewall')
+			printf "firewall.@zone[0]=zone\nfirewall.@zone[0].name='wan'\n"
+			;;
+		'-q get firewall.@zone[0]')
+			printf 'zone\n'
+			;;
+		'-q get firewall.@zone[0].log')
+			printf ''
+			;;
+		'set firewall.@zone[0].log='*)
+			die "uci set must not run when changes pending"
+			;;
+		'commit firewall')
+			UCI_COMMITTED=1
+			;;
+		*) return 0 ;;
+	esac
+}
+check_nf_log_ipv4() { return 0; }
+check_nf_log_ipv6() { return 0; }
+acquire_wan_log_lock() { return 0; }
+release_wan_log_lock() { return 0; }
+out=$(enable_wan_logging)
+case "$out" in
+	*'"error":"firewall_changes_pending"'*) ;;
+	*) die "enable with pending expected firewall_changes_pending, got: $out" ;;
+esac
+[ "$UCI_COMMITTED" = "0" ] || die "pending enable must not commit"
+ok "enable refuses when firewall changes pending"
+
+# restore refuses when pending (does not commit staged delta)
+UCI_LOG=()
+uci() {
+	UCI_LOG+=("$*")
+	case "$*" in
+		'-q changes firewall') printf "firewall.@rule[0]=rule\n" ;;
+		*) return 0 ;;
+	esac
+}
+restore_wan_zone_log '@zone[0]' '' || true
+joined="${UCI_LOG[*]}"
+case "$joined" in
+	*'commit firewall'*) die "restore must not commit while pending: $joined" ;;
+esac
+ok "restore_wan_zone_log skips commit when pending"
+unset -f uci check_nf_log_ipv4 check_nf_log_ipv6 acquire_wan_log_lock release_wan_log_lock
+
 sh "$RPCD" __selftest >/dev/null || die "rpcd __selftest"
 ok "rpcd __selftest"
 

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -105,6 +105,30 @@ got=$(find_wan_zone_section)
 [ "$got" = "@zone[0]" ] || die "anonymous wan zone expected @zone[0], got '$got'"
 ok "find_wan_zone_section anonymous zone"
 
+# Non-zone name=wan before a real zone must not abort lookup.
+uci() {
+	case "$*" in
+		'-q show firewall')
+			cat <<'EOF'
+firewall.fwd=forwarding
+firewall.fwd.name='wan'
+firewall.@zone[0]=zone
+firewall.@zone[0].name='wan'
+EOF
+			;;
+		'-q get firewall.fwd')
+			printf 'forwarding\n'
+			;;
+		'-q get firewall.@zone[0]')
+			printf 'zone\n'
+			;;
+		*) return 1 ;;
+	esac
+}
+got=$(find_wan_zone_section)
+[ "$got" = "@zone[0]" ] || die "skip non-zone name=wan expected @zone[0], got '$got'"
+ok "find_wan_zone_section skips non-zone name=wan"
+
 # firewall_changes_pending + enable refuse (issue #168)
 PENDING_STAGED=1
 UCI_COMMITTED=0


### PR DESCRIPTION
## Summary
- `find_wan_zone_section` matches named and anonymous WAN zones; type-check `zone`
- Refuse enable/disable (and skip rollback commit) when `uci changes firewall` is non-empty
- Surface `firewall_changes_pending` in LuCI
- Host tests for named/anonymous lookup and pending refuse

Closes #168

## Test plan
- [x] `bash tests/fwlive-logging.test.sh`

Made with [Cursor](https://cursor.com)