### PR TITLE
ux: make Simple-view row expand discoverable (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Simple view: hint line and Time tooltip mention row click to expand the full message (#118)
+
 ## [v0.1.32] — 2026-08-11
 
 ### Security

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
@@ -107,11 +107,15 @@ function buildColumnCell(col, row, state, callbacks) {
 		: log.formatActionLabel(row.action);
 
 	switch (col) {
-	case 'time':
-		return E('td', { 'class': columnCellClass(col) },
+	case 'time': {
+		const timeAttrs = { 'class': columnCellClass(col) };
+		if (state.viewMode === 'simple')
+			timeAttrs.title = _('Click a row for the full message');
+		return E('td', timeAttrs,
 			[ state.viewMode === 'simple'
 				? log.formatTimestampCompact(row.timestamp)
 				: log.formatTimestampLocal(row.timestamp) ]);
+	}
 	case 'action':
 		return E('td', { 'class': log.actionRowClass(row.action) }, [ actionCell ]);
 	case 'rule':

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -1572,7 +1572,7 @@ return view.extend({
 			]),
 			E('div', { 'id': 'fwlive-chips', 'class': 'fwlive-chips' }, []),
 			E('p', { 'class': 'fwlive-hint-line' },
-				[ _('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message') ]),
+				[ _('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message') ]),
 			E('div', {
 				'id': 'fwlive-empty',
 				'class': 'fwlive-empty',

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -1572,7 +1572,7 @@ return view.extend({
 			]),
 			E('div', { 'id': 'fwlive-chips', 'class': 'fwlive-chips' }, []),
 			E('p', { 'class': 'fwlive-hint-line' },
-				[ _('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings') ]),
+				[ _('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message') ]),
 			E('div', {
 				'id': 'fwlive-empty',
 				'class': 'fwlive-empty',
@@ -1593,7 +1593,7 @@ return view.extend({
 						E('li', {}, [ _('Display options hides Limit, row tint, hostnames, and chip style.') ]),
 						E('li', {}, [ _('The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap.') ]),
 						E('li', { 'id': 'fwlive-manual-test' }, []),
-						E('li', {}, [ _('Click a row to see the full log line (Simple view).') ]),
+						E('li', {}, [ _('Click a row (Time or other non-link cells) to see the full log line (Simple view).') ]),
 						E('li', {}, [ _('Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead.') ]),
 						E('li', {}, [ _('Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels.') ]),
 						E('li', {}, [ _('Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way.') ]),

--- a/openwrt-feed/luci-app-fwlive/po/de/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/de/luci-app-fwlive.po
@@ -86,12 +86,16 @@ msgid "Clear all"
 msgstr "Alle lÃ¶schen"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
-msgstr "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
+msgstr "Zelle anklicken zum Filtern · ≠ auf einem Chip zum Ausschließen · Strg+Klick auf eine Regel für Firewall-Einstellungen · Zeile anklicken für die vollständige Meldung"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row to see the full log line (Simple view)."
-msgstr "Klicken Sie auf eine Zeile, um die vollstÃ¤ndige Log-Zeile zu sehen (Einfache Ansicht)."
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr "Klicken Sie auf eine Zeile (Zeit oder andere Nicht-Link-Zellen), um die vollständige Log-Zeile zu sehen (Einfache Ansicht)."
+
+#: htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr "Zeile anklicken für die vollständige Meldung"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1592
 msgid "Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead."

--- a/openwrt-feed/luci-app-fwlive/po/de/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/de/luci-app-fwlive.po
@@ -86,8 +86,8 @@ msgid "Clear all"
 msgstr "Alle lÃ¶schen"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
-msgstr "Zelle anklicken zum Filtern · ≠ auf einem Chip zum Ausschließen · Strg+Klick auf eine Regel für Firewall-Einstellungen · Zeile anklicken für die vollständige Meldung"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
+msgstr "Zelle anklicken zum Filtern · ≠ auf einem Chip zum Ausschließen · Strg+Klick auf eine Regel für Firewall-Einstellungen · in der Einfachen Ansicht Zeile anklicken für die vollständige Meldung"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
 msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."

--- a/openwrt-feed/luci-app-fwlive/po/ru/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/ru/luci-app-fwlive.po
@@ -86,12 +86,16 @@ msgid "Clear all"
 msgstr "ÐÑÐ¸ÑÑÐ¸ÑÑ Ð²ÑÑ"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
-msgstr "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
+msgstr "Щёлкните ячейку для фильтра · ≠ на чипе для исключения · Ctrl+щелчок по правилу для настроек МЭ · щелкните строку для полного сообщения"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row to see the full log line (Simple view)."
-msgstr "ÐÐ°Ð¶Ð¼Ð¸ÑÐµ Ð½Ð° ÑÑÑÐ¾ÐºÑ, ÑÑÐ¾Ð±Ñ ÑÐ²Ð¸Ð´ÐµÑÑ Ð¿Ð¾Ð»Ð½ÑÑ ÑÑÑÐ¾ÐºÑ Ð¶ÑÑÐ½Ð°Ð»Ð° (ÐÑÐ¾ÑÑÐ¾Ð¹ Ð²Ð¸Ð´)."
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr "Щёлкните строку (Время или другие ячейки без ссылки), чтобы увидеть полную строку журнала (Простой вид)."
+
+#: htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr "Щёлкните строку для полного сообщения"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1592
 msgid "Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead."

--- a/openwrt-feed/luci-app-fwlive/po/ru/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/ru/luci-app-fwlive.po
@@ -86,8 +86,8 @@ msgid "Clear all"
 msgstr "ÐÑÐ¸ÑÑÐ¸ÑÑ Ð²ÑÑ"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
-msgstr "Щёлкните ячейку для фильтра · ≠ на чипе для исключения · Ctrl+щелчок по правилу для настроек МЭ · щелкните строку для полного сообщения"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
+msgstr "Щёлкните ячейку для фильтра · ≠ на чипе для исключения · Ctrl+щелчок по правилу для настроек МЭ · в Простом виде щёлкните строку для полного сообщения"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
 msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."

--- a/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot
+++ b/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot
@@ -85,7 +85,7 @@ msgid "Clear all"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591

--- a/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot
+++ b/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot
@@ -85,11 +85,15 @@ msgid "Clear all"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row to see the full log line (Simple view)."
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr ""
+
+#: htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
 msgstr ""
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1592

--- a/openwrt-feed/luci-app-fwlive/po/zh_Hans/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/zh_Hans/luci-app-fwlive.po
@@ -86,12 +86,16 @@ msgid "Clear all"
 msgstr "æ"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
-msgstr "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
+msgstr "点击单元格筛选 · 芯片上的 ≠ 排除 · Ctrl+点击规则打开防火墙设置 · 点击行查看完整消息"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row to see the full log line (Simple view)."
-msgstr "ç¹å»è¡å¯æ¥çå®æ´æ¥å¿è¡ï¼ç®åè§å¾ï¼ã"
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr "点击一行（时间或其他非链接单元格）可查看完整日志行（简单视图）。"
+
+#: htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr "点击行可查看完整消息"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1592
 msgid "Click an IP, action, or protocol to filter; click ≠ on a filter chip to exclude that value instead."

--- a/openwrt-feed/luci-app-fwlive/po/zh_Hans/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/zh_Hans/luci-app-fwlive.po
@@ -86,8 +86,8 @@ msgid "Clear all"
 msgstr "æ"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · click a row for the full message"
-msgstr "点击单元格筛选 · 芯片上的 ≠ 排除 · Ctrl+点击规则打开防火墙设置 · 点击行查看完整消息"
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
+msgstr "点击单元格筛选 · 芯片上的 ≠ 排除 · Ctrl+点击规则打开防火墙设置 · 在简单视图中点击行查看完整消息"
 
 #: htdocs/luci-static/resources/view/status/fwlive.js:1591
 msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."

--- a/tests/fwlive-modules-smoke.test.js
+++ b/tests/fwlive-modules-smoke.test.js
@@ -193,6 +193,35 @@ table.renderRows(body, {
 });
 assert.strictEqual(body.innerHTML, '');
 assert.ok(body._n >= 1);
+
+const simpleBody = {
+	innerHTML: 'rows',
+	children: [],
+	appendChild: function(n) { this.children.push(n); this.innerHTML = ''; },
+};
+table.renderRows(simpleBody, {
+	rows: [row],
+	columns: ['time', 'action'],
+	viewMode: 'simple',
+	messageLayout: 'wrap',
+	expandedRowId: null,
+	rowTint: false,
+	showHostnames: false,
+	hostnameCache: null,
+	firewallBackend: 'nft'
+}, {
+	onRowClick: function() {},
+	onFilterClick: function() {},
+	actionRowTintClass: function() { return ''; }
+});
+assert.ok(simpleBody.children.length >= 1);
+const simpleTr = simpleBody.children[0];
+assert.strictEqual(simpleTr.tag, 'tr');
+const timeTd = simpleTr.children.find(function(c) {
+	return c.tag === 'td' && c.attrs && c.attrs.class === 'fwlive-time';
+});
+assert.ok(timeTd, 'simple view should render a time cell');
+assert.strictEqual(String(timeTd.attrs.title), 'Click a row for the full message');
 console.log('fwlive-modules smoke: table OK');
 
 /* --- buffer --- */


### PR DESCRIPTION
## Summary
- Extends the always-visible hint line with `· click a row for the full message`
- Adds the same short tooltip on the Simple-view Time cell
- Aligns the Help bullet to mention Time / non-link cells; updates POT + de/ru/zh_Hans
- Smoke test asserts Simple Time `td` carries the tooltip title

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [ ] Optional QEMU: hint visible, Time hover, row expand, filter links still win

Closes #118

Made with [Cursor](https://cursor.com)