### PR TITLE
docs: compress AGENTS.md to a brownfield hazard list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,71 +1,12 @@
 # AGENTS.md
 
-Router for coding agents. Every rule below is stated once, in the document
-linked beside it — **read the link before acting on the rule**, and edit that
-document rather than this file when a rule evolves.
+Shipped surface: `openwrt-feed/luci-app-fwlive/`. Rules live in the linked owner — edit that file, not this one. Ownership: [contributing.md § Single source of truth](docs/developer/contributing.md#single-source-of-truth).
 
-Which document owns which rule, and the narrow cases where restating one is
-allowed: [contributing.md § Single source of truth](docs/developer/contributing.md#single-source-of-truth).
-
-Humans should start at [`README.md`](README.md) and the
-[developer guide](docs/developer/README.md).
-
-## What this is
-
-`luci-app-fwlive` — a LuCI JavaScript app rendering a live table of firewall LOG
-events on OpenWrt. Client-side JS plus a small root rpcd plugin and shell
-helpers. No Lua, no daemon, no build step for the shipped JS.
-
-The shipped surface is everything under `openwrt-feed/luci-app-fwlive/`; the rest
-is docs, tests, and lab tooling. Layout:
-[developer guide § Repository map](docs/developer/README.md#repository-map).
-
-## Hard invariants
-
-Breaking any of these fails CI or ships a security regression.
-
-| Rule | Canonical source |
-|------|------------------|
-| Untrusted values reach the DOM as text nodes, never an HTML sink | [security-model.md § Invariants](docs/developer/security-model.md#invariants) |
-| Log content, hostnames, URL-hash values, and UCI values are all untrusted | [security-model.md § Untrusted input inventory](docs/developer/security-model.md#untrusted-input-inventory) |
-| `CLASSIFY_SPEC` edits go in `core/` **and** the LuCI mirror, then `gen-all.sh` | [contributing.md § Parser sync / codegen](docs/developer/contributing.md#parser-sync--codegen) |
-| Never hand-edit generated files (shell classifier, `css.js`) | [contributing.md § Parser sync / codegen](docs/developer/contributing.md#parser-sync--codegen), [build-and-test.md](docs/developer/build-and-test.md) |
-| Sessions never get `ubus log.read`; read and write ACL scopes stay separate | [security-model.md § Invariants](docs/developer/security-model.md#invariants) |
-| `PKG_VERSION` and `APP_VERSION` must match | [contributing.md § Feed / package changes](docs/developer/contributing.md#feed--package-changes) |
-
-## Before you start
-
-| Task | Read first |
-|------|------------|
-| Any change | [contributing.md](docs/developer/contributing.md) |
-| Renderers, rpcd plugin, shell helpers, release pipeline | [security-model.md](docs/developer/security-model.md), then [security-review.md](docs/developer/security-review.md) for what is open against it |
-| Classification or parsing | [architecture.md](docs/developer/architecture.md) |
-| A security audit | [security-review.md](docs/developer/security-review.md) for state, then the `security-audit` skill in `.cursor/skills/` for procedure |
-
-A change to the rpcd plugin, the ACL, the shell helpers, or the release pipeline
-updates [security-review.md](docs/developer/security-review.md) in the same PR.
-
-## Commands and testing
-
-Commands, what each gate covers, and the QEMU flow:
-[build-and-test.md](docs/developer/build-and-test.md).
-
-Two traps worth knowing before you trust a green run:
-
-- Renderer tests **do not render** — see
-  [build-and-test.md § Renderer tests do not render](docs/developer/build-and-test.md#renderer-tests-do-not-render).
-- `gen-luci-wrapper.js` is a gate, not a generator. It reports drift; it will not
-  fix it for you.
-
-## Reporting security issues
-
-Vulnerabilities go to a private advisory, never a public issue
-([`SECURITY.md`](SECURITY.md)). Hardening items are normal public issues.
-
-## Conventions
-
-- Small changes, one behavior each
-- Tabs for indentation in shell and the shipped JS; match surrounding code
-- Comments explain constraints the code cannot show — not what the next line does
-- Documentation conventions, including rule ownership:
-  [contributing.md § Documentation](docs/developer/contributing.md#documentation)
+- Untrusted values (logs, hostnames, URL-hash, UCI) MUST reach the DOM as text nodes, never an HTML sink. [security-model.md](docs/developer/security-model.md)
+- `CLASSIFY_SPEC` MUST be edited in `core/` **and** the LuCI mirror, then `./scripts/gen-all.sh`. Do not hand-edit the shell classifier or `css.js`. `gen-luci-wrapper.js` is a gate: it reports drift and will not fix it.
+- Sessions MUST NOT get `ubus log.read`. Keep read/write ACL scopes separate.
+- `PKG_VERSION` MUST match `APP_VERSION`.
+- Renderer tests do not render — a green run is not XSS proof. [build-and-test.md](docs/developer/build-and-test.md)
+- rpcd / ACL / shell helpers / release pipeline: update [security-review.md](docs/developer/security-review.md) in the same PR; audit via `.cursor/skills/security-audit`.
+- Vulnerabilities go to a private advisory ([SECURITY.md](SECURITY.md)), not a public issue.
+- Tabs in shell and shipped JS. Workflow: [contributing.md](docs/developer/contributing.md). Commands: [build-and-test.md](docs/developer/build-and-test.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `AGENTS.md` compressed to a brownfield hazard list; rules stay in owner docs
+
 ## [v0.1.33] — 2026-08-12
 
 ### Security

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -84,7 +84,7 @@ file, that second copy is drift — consolidate it.
 | Allowed | Shape |
 |---------|-------|
 | Imperative at the point of action | One sentence where the work happens (e.g. the `log.read` warning beside the ACL grant list). No rationale, no mechanics, no examples |
-| Router entry | A rule named in one line plus a link — [`../../AGENTS.md`](../../AGENTS.md) and index tables |
+| Router entry | A rule named in one line plus a link — [`../../AGENTS.md`](../../AGENTS.md) |
 | Verification command | *How* to confirm a fact may sit with the procedure that needs it, even when the fact is owned elsewhere |
 
 Everything else stays single-sourced: rationale, code samples, upstream


### PR DESCRIPTION
## Summary
- Compress root `AGENTS.md` from a 71-line router/tables into a ~12-line brownfield hazard list (gist authoring skill): non-obvious invariants stay as one-line pointers to owner docs.
- Drop “index tables” from the contributing.md SSOT restatement row so it matches the bullet shape.
- Changelog Unreleased note; no version bump.

## Test plan
- [ ] Spot-check links in `AGENTS.md` resolve (`security-model.md`, `contributing.md`, `build-and-test.md`, `security-review.md`, `SECURITY.md`).
- [ ] Confirm `docs/developer/contributing.md` SSOT “Router entry” no longer mentions index tables.
- [ ] CI docs/link checks if present.