### PR TITLE
fix(security): pin SDK digest before signing-secret mounts (R7)

### DIFF
--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -135,7 +135,7 @@ part of the security boundary.
 | Feed signing keys | CI secrets, written under `umask 077` then `chmod 600` **after** normalize/decode; only public keys are staged for publish. Host-asserted by `tests/feed-keys-mode.test.sh` |
 | Package contents | `verify-reproducible-build.sh` — determinism of our inputs within a run |
 | OpenWrt feeds | Pinned in `scripts/feeds.lock/` |
-| SDK base images | Digests resolved per cell and recorded in the release manifest (no mutable-tag reliance) |
+| SDK base images | Digest-pinned at first **secret-touching** pull (`sdk_matrix_pull_and_pin` before the usign container); later staging prefers the pin cache. Per-cell digests recorded in the release manifest |
 | GitHub Actions | SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` |
 | Fetched build helpers and lab images | sha256-verified or commit-pinned before execution; `/tmp` trust removed (fresh `mktemp` per invocation). `usign` is commit-pinned via `USIGN_PIN_SHA` ([#166](https://github.com/lucas-albers-lz4/fwlive/issues/166)); `get-sdk.sh` verifies upstream `sha256sums` |
 

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -39,15 +39,15 @@ should carry a note saying what would raise it.
 
 | Surface | Last reviewed | Depth | Notes |
 |---------|---------------|-------|-------|
-| Frontend rendering sinks (`E()` string children) | 2026-08-12 | Sweep + harness | Re-swept; no bare-string sinks. Regression harness from [#138](https://github.com/lucas-albers-lz4/fwlive/issues/138) |
-| Untrusted-input trace (log fields, PTR, URL hash, UCI) | 2026-08-12 | Read | No change since the inventory in security-model.md |
-| rpcd plugin + ACL scope | 2026-08-12 | Read + selftest | `__`-prefixed methods absent from `list`; read/write split intact |
-| Shell helpers — injection and quoting | 2026-08-12 | Read | No log data reaches a command string |
-| Shell helpers — **file modes and lock ownership** | 2026-08-12 | Reproduced | New: [#167](https://github.com/lucas-albers-lz4/fwlive/issues/167) |
-| Shell helpers — **UCI commit scope and zone grammar** | 2026-08-12 | Read + upstream check | New: [#168](https://github.com/lucas-albers-lz4/fwlive/issues/168) |
-| Release pipeline — secrets and key handling | 2026-08-12 | Reproduced | New: [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) |
-| Release pipeline — fetch pinning | 2026-08-12 | Read | New: [#166](https://github.com/lucas-albers-lz4/fwlive/issues/166) |
-| Workflow inputs into `run:` bodies | 2026-08-12 | Read | Clean — inputs pass through `env:`, actions SHA-pinned |
+| Frontend rendering sinks (`E()` string children) | 2026-08-13 | Sweep + harness | #177: #175/#176 UI delta on recording-`innerHTML` harness; no non-empty innerHTML writes |
+| Untrusted-input trace (log fields, PTR, URL hash, UCI) | 2026-08-13 | Reproduced | #177: hostile log/PTR/UCI/hash through normalize + render + chips |
+| rpcd plugin + ACL scope | 2026-08-13 | Diff + selftest | #177: no diff since `ce9df02`; read/write split; no `ubus log.*` |
+| Shell helpers — injection and quoting | 2026-08-13 | Read | #177: no log data reaches a command string |
+| Shell helpers — **file modes and lock ownership** | 2026-08-13 | Reproduced | #177: `fwlive-logging-lock.test.sh` 32-trial; lock 0600 |
+| Shell helpers — **UCI commit scope and zone grammar** | 2026-08-13 | Host test | #177: pending-delta refuse; named/anonymous/non-zone lookups |
+| Release pipeline — secrets and key handling | 2026-08-15 | Reproduced | #177 key-mode re-run; R7 pin-before-mount + `--network none` ([#179](https://github.com/lucas-albers-lz4/fwlive/issues/179)) |
+| Release pipeline — fetch pinning | 2026-08-15 | Read + host test | #177 fetch-pin gate; R7 digest pin-cache (`tests/sdk-matrix-digests.test.sh`) |
+| Workflow inputs into `run:` bodies | 2026-08-13 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY` |
 
 ## Controls in force
 
@@ -63,7 +63,9 @@ should carry a note saying what would raise it.
 | `resolve` bounded by a wall-clock budget | `manual` | `RESOLVE_BUDGET`; no test asserts the bound |
 | `poll` bounded by `POLL_LINES_MAX` | `host` | rpcd `__selftest` |
 | Every `E()` string child is array-wrapped | `host` | rendering harness ([#138](https://github.com/lucas-albers-lz4/fwlive/issues/138)) |
-| Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` |
+| Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` — `peaceiris/actions-gh-pages@84c30a85c…` = `v4.1.0` (verified 2026-08-13); CodeQL alert 7 closed as **fixed**; re-check before each `v*` tag ([#178](https://github.com/lucas-albers-lz4/fwlive/issues/178)) |
+| SDK image digest-pinned at first **secret-touching** pull | `host` | `sdk_matrix_pull_and_pin` in `validate-feed-keys.sh`; `feed_publish_apply_sdk_pin` before opkg/apk sign; `tests/sdk-matrix-digests.test.sh` |
+| Signing-secret containers have no network | `host` | `docker run --network none` on validate usign check and opkg/apk sign steps (Compose v2 has no `--network` on `compose run`); same test |
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
@@ -76,7 +78,7 @@ should carry a note saying what would raise it.
 | ID | Severity | Issue | Summary |
 |----|----------|-------|---------|
 
-(no open findings from the 2026-08-12 wave)
+(no open findings after the 2026-08-15 R7 closeout)
 
 
 ## Accepted residuals
@@ -201,3 +203,21 @@ the same PR as this file.
 ([usrmanage#111](https://github.com/lucas-albers-lz4/usrmanage/issues/111)),
 where the blast radius is larger because the same lock guards every user-management
 mutator.
+
+### 2026-08-13 — Frontend delta + S1–S4 verification (record of non-findings, with one miss)
+
+**Scope.** Delta since 2026-08-12 (`ce9df02..4931026`, v0.1.33): #175/#176 UI work, plus execution of S1–S4 remediations. Filed as [#177](https://github.com/lucas-albers-lz4/fwlive/issues/177).
+
+**Method.** Host tests (`./scripts/fwlive-test.sh`) plus the recording-`innerHTML` harness; `feed-keys-mode`, `fetch-pin-gate`, logging lock/UCI tests.
+
+**Result recorded as no findings.** That was wrong for one class: `scripts/validate-feed-keys.sh` still resolved a mutable SDK tag and bind-mounted `OPKG_FEED_SECRET_KEY` without `--network none`. The pass treated validate-keys SDK ordering as usrmanage-only; it is the same R7 pattern. Closed by the 2026-08-15 entry.
+
+**Non-findings that still hold:** frontend sinks (harness, hostile log/PTR/UCI/hash/chips); S1–S4 tests; rpcd/ACL (no diff); workflows SHA-pinned including `FEED_DEPLOY_KEY`; no `${{ }}` in `run:` bodies.
+
+### 2026-08-15 — R7 pin-at-secret-mount and #178 pin checklist
+
+**Scope.** Close [#177](https://github.com/lucas-albers-lz4/fwlive/issues/177) via ledger correction; remaining [#178](https://github.com/lucas-albers-lz4/fwlive/issues/178) process (peaceiris SHA re-check); R7 analog from [usrmanage#128](https://github.com/lucas-albers-lz4/usrmanage/pull/128). Playbook [#179](https://github.com/lucas-albers-lz4/fwlive/issues/179).
+
+**Method.** Port `sdk_matrix_pull_and_pin` + always-pull; `--network none` on secret mounts; host greps and mocked-docker digest tests. No QEMU.
+
+**Result.** Validate path pins `x86-64`/`23.05` before the usign secret mount. Opkg/apk **sign** steps export tools via compose (no secret), then `docker run --network none` with a digest-pinned image and no `/builder` mount (Compose v2 `run` has no `--network`; compose volume names are project-prefixed). Pre-release checklist requires re-checking `peaceiris/actions-gh-pages` tag↔SHA (alert 7 already **fixed**; Dependabot version PRs stay off). Open findings table empty. No L12 analog (no incomplete-marker path).

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -18,6 +18,9 @@ Use before making this repo public upstream.
 - [ ] `core/fwlive-log.js` tracked as a normal file (not a stale submodule gitlink)
 - [ ] `node_modules/` not committed; dev deps declared in root `package.json`
 - [ ] ACL scope understood: `luci-app-fwlive` grants read (`fwlive.rules|poll|resolve|logging_status`) and write (`enable_wan_logging`, `disable_wan_logging`) — **not** direct `ubus log.read` (poll reads logd as root inside rpcd). Grant only to trusted admin LuCI users
+- [ ] Re-check `peaceiris/actions-gh-pages` latest release and that
+      `.github/workflows/publish-packages.yml` still SHA-pins that tag
+      (the step holds `FEED_DEPLOY_KEY`; Dependabot version updates are off)
 
 ## Distribution (canonical)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,6 +22,8 @@ Run from the repo root on **Linux x86_64**:
 Optional QEMU confidence: `./scripts/validate-openwrt.sh --version 24.10` — see [validation matrix](validation-matrix.md).
 
 Full publish checklist: [github-publish-checklist.md](github-publish-checklist.md).
+Before cutting a `v*` tag, re-verify the `peaceiris/actions-gh-pages` SHA in
+`publish-packages.yml` against the upstream tag (checklist pre-release item).
 
 ## Release steps (automated CI)
 

--- a/scripts/docker-sdk.sh
+++ b/scripts/docker-sdk.sh
@@ -77,7 +77,7 @@ run_one() {
 	local t="$1" v="$2"
 	sdk_matrix_validate_target "$t"
 	sdk_matrix_validate_version "$v"
-	sdk_matrix_resolve "$t" "$v"
+	sdk_matrix_pull_and_pin "$t" "$v" >/dev/null
 	echo "→ ${SDK_MATRIX_IMAGE} (volume: ${SDK_MATRIX_VOLUME})" >&2
 }
 
@@ -101,7 +101,6 @@ case "$CMD" in
 		;;
 	build)
 		run_one "$TARGET" "$VERSION"
-		sdk_matrix_pull
 		if ! sdk_matrix_feeds_ready; then
 			sdk_matrix_feeds_setup
 		fi
@@ -120,7 +119,6 @@ case "$CMD" in
 		for t in "${targets[@]}"; do
 			for v in "${versions[@]}"; do
 				run_one "$t" "$v"
-				sdk_matrix_pull
 				if ! sdk_matrix_feeds_ready; then
 					sdk_matrix_feeds_setup
 				fi

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -80,6 +80,9 @@ echo "== fwlive proto filter (menu + custom) ==" >&2
 echo "== fwlive feed release assets ==" >&2
 bash tests/feed-publish-release-assets.test.sh
 
+echo "== fwlive SDK digest pin-cache (R7) ==" >&2
+bash tests/sdk-matrix-digests.test.sh
+
 echo "== fwlive feed-keys mode (0600) ==" >&2
 bash tests/feed-keys-mode.test.sh
 

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -248,28 +248,84 @@ feed_publish_stage_opkg_host() {
 	usign -S -m "${pkg_dir}/Packages" -s "$OPKG_FEED_SECRET_KEY" -x "${pkg_dir}/Packages.sig"
 }
 
-feed_publish_stage_opkg_sdk() {
-	local version_key="$1" pkg_dir="$2"
-	local root pkg_abs key_abs
-	root="$(feed_publish_root)"
-	pkg_dir="$(feed_publish_abspath "$pkg_dir")"
-	key_abs="$(feed_publish_abspath "$OPKG_FEED_SECRET_KEY")"
+feed_publish_apply_sdk_pin() {
+	# Prefer build-time digest pin; otherwise pull-and-pin now (R7).
+	local version_key="$1" _pin
 	sdk_matrix_resolve x86-64 "$version_key"
-	sdk_matrix_feeds_ready \
-		|| { echo "run docker-sdk.sh build --version ${version_key} before staging opkg feed" >&2; return 1; }
+	if _pin="$(sdk_matrix_read_digest_cache x86-64 "$version_key")"; then
+		SDK_MATRIX_IMAGE="$_pin"
+		return 0
+	fi
+	sdk_matrix_pull_and_pin x86-64 "$version_key" >/dev/null
+}
+
+# Copy signing binaries out of the compose-managed SDK volume (no secrets).
+# Secret-touching docker run must not mount /builder: compose prefixes volume
+# names, so `docker run -v $SDK_MATRIX_VOLUME:/builder` is a different volume.
+feed_publish_export_opkg_tools() {
+	local tools_dir="$1" root
+	root="$(feed_publish_root)"
 	(
 		cd "$root"
 		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \
 		OWRT_SDK_VOLUME="$SDK_MATRIX_VOLUME" \
-		docker compose run --rm --user root \
-			-v "${pkg_dir}:/feed/pkgdir" \
-			-v "${key_abs}:/feed/opkg-secret.key:ro" \
+		docker compose run --rm --user "$(id -u):$(id -g)" \
+			-v "${tools_dir}:/feed/tools" \
 			sdk sh -ec '
 				set -e
-				USIGN=/builder/staging_dir/host/bin/usign
-				INDEX=/builder/scripts/ipkg-make-index.sh
-				MKHASH=/builder/staging_dir/host/bin/mkhash
-				export PATH="/builder/staging_dir/host/bin:$PATH"
+				cp -a /builder/staging_dir/host/bin/usign /feed/tools/usign
+				cp -a /builder/staging_dir/host/bin/mkhash /feed/tools/mkhash
+				cp -a /builder/scripts/ipkg-make-index.sh /feed/tools/ipkg-make-index.sh
+				chmod a+x /feed/tools/usign /feed/tools/mkhash /feed/tools/ipkg-make-index.sh
+			'
+	)
+}
+
+feed_publish_export_apk_tools() {
+	local tools_dir="$1" root
+	root="$(feed_publish_root)"
+	(
+		cd "$root"
+		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \
+		OWRT_SDK_VOLUME="$SDK_MATRIX_VOLUME" \
+		docker compose run --rm --user "$(id -u):$(id -g)" \
+			-v "${tools_dir}:/feed/tools" \
+			sdk sh -ec '
+				set -e
+				cp -a /builder/staging_dir/host/bin/apk /feed/tools/apk
+				chmod a+x /feed/tools/apk
+			'
+	)
+}
+
+feed_publish_stage_opkg_sdk() {
+	local version_key="$1" pkg_dir="$2"
+	local key_abs tools_dir rc
+	pkg_dir="$(feed_publish_abspath "$pkg_dir")"
+	key_abs="$(feed_publish_abspath "$OPKG_FEED_SECRET_KEY")"
+	feed_publish_apply_sdk_pin "$version_key" \
+		|| { echo "failed to pin SDK image for opkg sign" >&2; return 1; }
+	sdk_matrix_feeds_ready \
+		|| { echo "run docker-sdk.sh build --version ${version_key} before staging opkg feed" >&2; return 1; }
+	tools_dir="$(mktemp -d "${TMPDIR:-/tmp}/fwlive-sign-tools.XXXXXX")"
+	feed_publish_export_opkg_tools "$tools_dir" || {
+		rm -rf "$tools_dir"
+		echo "failed to export opkg signing tools from SDK volume" >&2
+		return 1
+	}
+	# Compose v2 `run` has no --network. Secret mounts use docker run
+	# --network none with exported tools only (no /builder).
+	docker run --rm --network none --user root --platform linux/amd64 \
+		-v "${pkg_dir}:/feed/pkgdir" \
+		-v "${key_abs}:/feed/opkg-secret.key:ro" \
+		-v "${tools_dir}:/feed/tools:ro" \
+		"$SDK_MATRIX_IMAGE" \
+		sh -ec '
+				set -e
+				USIGN=/feed/tools/usign
+				INDEX=/feed/tools/ipkg-make-index.sh
+				MKHASH=/feed/tools/mkhash
+				export PATH="/feed/tools:$PATH"
 				export MKHASH
 				test -x "$USIGN"
 				test -x "$INDEX"
@@ -288,7 +344,9 @@ feed_publish_stage_opkg_sdk() {
 					exit 1
 				fi
 			'
-	)
+	rc=$?
+	rm -rf "$tools_dir"
+	return "$rc"
 }
 
 feed_publish_stage_opkg() {
@@ -334,28 +392,34 @@ feed_publish_stage_apk() {
 		echo "APK_FEED_SECRET_KEY must point to RSA private key for apk mkndx --sign" >&2
 		return 1
 	}
-	sdk_matrix_resolve x86-64 "$version_key"
+	feed_publish_apply_sdk_pin "$version_key" \
+		|| { echo "failed to pin SDK image for apk sign" >&2; return 1; }
 	sdk_matrix_feeds_ready \
 		|| { echo "run docker-sdk.sh build --version ${version_key} before staging apk feed" >&2; return 1; }
-	local root pkg_abs key_abs
-	root="$(feed_publish_root)"
+	local key_abs tools_dir rc
 	pkg_dir="$(feed_publish_abspath "$pkg_dir")"
 	key_abs="$(feed_publish_abspath "$APK_FEED_SECRET_KEY")"
-	(
-		cd "$root"
-		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \
-		OWRT_SDK_VOLUME="$SDK_MATRIX_VOLUME" \
-		docker compose run --rm --user root \
-			-v "${pkg_dir}:/feed/pkgdir" \
-			-v "${key_abs}:/feed/apk-secret.rsa:ro" \
-			sdk sh -ec '
+	tools_dir="$(mktemp -d "${TMPDIR:-/tmp}/fwlive-sign-tools.XXXXXX")"
+	feed_publish_export_apk_tools "$tools_dir" || {
+		rm -rf "$tools_dir"
+		echo "failed to export apk signing tools from SDK volume" >&2
+		return 1
+	}
+	docker run --rm --network none --user root --platform linux/amd64 \
+		-v "${pkg_dir}:/feed/pkgdir" \
+		-v "${key_abs}:/feed/apk-secret.rsa:ro" \
+		-v "${tools_dir}:/feed/tools:ro" \
+		"$SDK_MATRIX_IMAGE" \
+		sh -ec '
 				set -e
-				APK=/builder/staging_dir/host/bin/apk
+				APK=/feed/tools/apk
 				test -x "$APK"
 				cd /feed/pkgdir
 				"$APK" mkndx --allow-untrusted --sign /feed/apk-secret.rsa --output packages.adb *.apk
 			'
-	)
+	rc=$?
+	rm -rf "$tools_dir"
+	[[ "$rc" -eq 0 ]] || return "$rc"
 	printf '%s' "$artifact"
 }
 
@@ -367,7 +431,7 @@ feed_publish_copy_keys() {
 
 feed_publish_write_manifest() {
 	local staging="$1" git_tag="${2:-unknown}"
-	local manifest ver artifact ver_label sum sdk_digest
+	local manifest ver artifact ver_label sum sdk_digest sdk_image
 	manifest="${staging}/manifest.json"
 	: > "$manifest"
 	printf '{\n  "git_tag": "%s",\n  "packages": [\n' "${git_tag//\"/\\\"}" >> "$manifest"
@@ -386,10 +450,11 @@ feed_publish_write_manifest() {
 		# without `|| return 1` an unresolvable digest would silently
 		# record an empty sdk_digest and the release would proceed.
 		sdk_digest="$(sdk_matrix_image_digest)" || return 1
+		sdk_image="ghcr.io/openwrt/sdk:$(sdk_matrix_image_tag x86-64 "$ver")"
 		[[ $first -eq 1 ]] || printf ',\n' >> "$manifest"
 		first=0
 		printf '    {"openwrt": "%s", "file": "%s", "sha256": "%s", "sdk_image": "%s", "sdk_digest": "%s"}' \
-			"$ver" "$(basename "$artifact")" "$sum" "$SDK_MATRIX_IMAGE" "$sdk_digest" >> "$manifest"
+			"$ver" "$(basename "$artifact")" "$sum" "$sdk_image" "$sdk_digest" >> "$manifest"
 	done
 	printf '\n  ]\n}\n' >> "$manifest"
 }

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -80,54 +80,98 @@ sdk_matrix_resolve() {
 	SDK_MATRIX_OUT_DIR="$(sdk_matrix_root)/out/${SDK_MATRIX_PACKAGE_ARCH}/${SDK_MATRIX_VERSION_LABEL}"
 }
 
-# Ensure the resolved cell's SDK image is present locally. Idempotent: docker
-# pull is a no-op for an already-present tag, so on a machine that already
-# built against the image this never re-fetches (and cannot drift to a tag that
-# moved upstream between build and release). Pull must happen before digest
-# resolution — the recorded digest is the image actually used for the build.
-sdk_matrix_pull() {
-	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}"
-	if ! docker image inspect "$image" >/dev/null 2>&1; then
-		echo "→ pulling ${image}..." >&2
-		docker image pull "$image"
-	fi
+sdk_matrix_digest_cache_path() {
+	local target="$1" version="$2" patch base
+	patch="$(sdk_matrix_version_patch "$version")"
+	base="${SDK_MATRIX_DIGEST_CACHE_DIR:-$(sdk_matrix_root)/out/.sdk-digests}"
+	printf '%s' "${base}/${target}_${patch}"
 }
 
-# Resolve the immutable digest of the SDK image actually used for this cell.
-# The tag (SDK_MATRIX_IMAGE) is mutable; the digest makes a release
-# attributable to the exact image it was built from.
-#
-# Source: `docker image inspect --format '{{index .RepoDigests 0}}'` after the
-# image is pulled (registry images carry repo@sha256:… RepoDigests).
-# Fallback: a locally built / registry-less image has empty RepoDigests — record
-# `@sha256:<image ID>` and warn. An empty digest is never recorded silently: if
-# neither source yields a digest this returns non-zero (release manifest aborts).
-sdk_matrix_image_digest() {
-	local image="${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}" repo digest id
-	# The repo prefix to match: ghcr.io/openwrt/sdk (strip any tag).
-	repo="${image%%:*}"
-	# Explicit pull propagation (luna fold 2026-08-10): a failed pull must
-	# abort — `sdk_digest="$(...)"` disables errexit inside the function,
-	# so a failed pull could otherwise fall through to a misleading inspect.
-	sdk_matrix_pull || return 1
-	# Select the RepoDigest matching THIS repository (luna fold 2026-08-10):
-	# an image can have multiple RepoDigests (same image pushed to several
-	# registries) with unspecified ordering — RepoDigests[0] is NOT
-	# guaranteed to be the ghcr.io/openwrt/sdk one. Match the requested
-	# repo prefix EXACTLY, literal (no regex — dots in ghcr.io are not
-	# wildcards): awk index() == 1 means the line starts with the repo.
-	digest="$(docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$image" 2>/dev/null \
-		| awk -v r="$repo" 'index($0, r "@sha256:") == 1 {print; exit}' || true)"
-	if [[ -z "$digest" ]]; then
-		id="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)"
-		if [[ -z "$id" ]]; then
-			echo "ERROR: cannot resolve SDK image digest for ${image} (no ${repo} RepoDigest, no image ID)" >&2
-			return 1
-		fi
-		digest="@${id}"
-		echo "WARNING: SDK image ${image} has no ${repo} RepoDigest (locally built?); recording image ID fallback ${digest}" >&2
+sdk_matrix_inspect_repo_digest() {
+	# Inspect already-local image ref; print matching RepoDigest or fail.
+	# RepoDigests[0] is not trusted: match THIS repo prefix literally
+	# (index()==1; dots in ghcr.io are not wildcards).
+	local image="$1" repo digests digest id
+	if [[ "$image" == *@sha256:* ]]; then
+		repo="${image%%@*}"
+	else
+		repo="${image%%:*}"
 	fi
+	digests="$(docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$image" 2>/dev/null || true)"
+	digest="$(printf '%s\n' "$digests" | awk -v r="$repo" 'index($0, r "@sha256:") == 1 {print; exit}')"
+	if [[ -n "$digest" ]]; then
+		printf '%s' "$digest"
+		return 0
+	fi
+	id="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)"
+	if [[ -n "$id" ]]; then
+		digest="@sha256:${id#sha256:}"
+		echo "WARNING: SDK image ${image} has no ${repo} RepoDigest (locally built?); recording image ID fallback ${digest}" >&2
+		printf '%s' "$digest"
+		return 0
+	fi
+	echo "ERROR: cannot resolve SDK image digest for ${image} (no ${repo} RepoDigest, no image ID)" >&2
+	return 1
+}
+
+# Always re-resolve the registry tag. Skipping pull when the tag exists locally
+# would record a stale digest if the tag moved upstream (luna fold).
+# With target/version: resolve that cell then pull. With no args: pull the
+# already-resolved SDK_MATRIX_IMAGE (do not default to another cell).
+sdk_matrix_pull() {
+	local target="${1:-}" version="${2:-}"
+	if [[ -n "$target" ]]; then
+		sdk_matrix_resolve "$target" "${version:?sdk_matrix_pull: version required with target}"
+	else
+		: "${SDK_MATRIX_IMAGE:?sdk_matrix_resolve first}"
+	fi
+	echo "→ pulling ${SDK_MATRIX_IMAGE}..." >&2
+	docker pull "$SDK_MATRIX_IMAGE"
+}
+
+sdk_matrix_pull_and_pin() {
+	# Pull the mutable tag once, pin SDK_MATRIX_IMAGE to repo@sha256, cache digest.
+	local target="${1:-${SDK_MATRIX_TARGET:-}}" version="${2:-${SDK_MATRIX_VERSION:-}}" digest cache
+	[[ -n "$target" && -n "$version" ]] || {
+		echo "sdk-matrix: pull_and_pin needs target/version (or sdk_matrix_resolve first)" >&2
+		return 1
+	}
+	sdk_matrix_pull "$target" "$version" || {
+		echo "sdk-matrix: failed to pull ${SDK_MATRIX_IMAGE}" >&2
+		return 1
+	}
+	digest="$(sdk_matrix_inspect_repo_digest "$SDK_MATRIX_IMAGE")" || return 1
+	cache="$(sdk_matrix_digest_cache_path "$target" "$version")"
+	mkdir -p "$(dirname "$cache")"
+	printf '%s\n' "$digest" > "$cache"
+	chmod 0644 "$cache" 2>/dev/null || true
+	SDK_MATRIX_IMAGE="$digest"
 	printf '%s' "$digest"
+}
+
+sdk_matrix_read_digest_cache() {
+	# Print non-empty cached digest or return 1 (never print empty).
+	local target="$1" version="$2" cache digest
+	cache="$(sdk_matrix_digest_cache_path "$target" "$version")"
+	[[ -f "$cache" ]] || return 1
+	digest="$(tr -d ' \n\r\t' < "$cache")"
+	[[ -n "$digest" ]] || return 1
+	printf '%s' "$digest"
+}
+
+# Prefer a pin file from sdk_matrix_pull_and_pin so write_manifest does not
+# re-pull a possibly moved tag. No-arg form uses the already-resolved cell.
+sdk_matrix_image_digest() {
+	local target="${1:-${SDK_MATRIX_TARGET:-}}" version="${2:-${SDK_MATRIX_VERSION:-}}" digest
+	[[ -n "$target" && -n "$version" ]] || {
+		echo "ERROR: cannot resolve SDK image digest (sdk_matrix_resolve first)" >&2
+		return 1
+	}
+	if digest="$(sdk_matrix_read_digest_cache "$target" "$version")"; then
+		printf '%s' "$digest"
+		return 0
+	fi
+	sdk_matrix_pull_and_pin "$target" "$version"
 }
 
 sdk_matrix_validate_target() {

--- a/scripts/validate-feed-keys.sh
+++ b/scripts/validate-feed-keys.sh
@@ -29,14 +29,18 @@ validate_opkg_usign_key() {
 	# Decode/normalize rewrite via mv; re-assert secret mode (issue #165).
 	chmod 600 "$secret" || die "cannot chmod 600 OPKG_FEED_SECRET_KEY"
 
-	sdk_matrix_resolve x86-64 23.05
+	# R7: pin the SDK digest at first pull *before* mounting the usign secret.
+	# sdk_matrix_resolve alone uses a mutable tag; a moved tag could exfiltrate
+	# OPKG_FEED_SECRET_KEY while a later build records a different digest.
+	sdk_matrix_pull_and_pin x86-64 23.05 >/dev/null \
+		|| die "failed to pull/pin OpenWrt SDK image for usign key check"
 
 	local secret_abs public_abs tmpdir
 	secret_abs="$(feed_publish_abspath "$secret")"
 	public_abs="$(feed_publish_abspath "$public")"
 	tmpdir="$(mktemp -d)"
 
-	docker run --rm --user root \
+	docker run --rm --network none --user root \
 		-v "${secret_abs}:/feed/opkg-secret.key:ro" \
 		-v "${public_abs}:/feed/public.key:ro" \
 		-v "${tmpdir}:/feed/out" \

--- a/tests/feed-publish-release-assets.test.sh
+++ b/tests/feed-publish-release-assets.test.sh
@@ -57,6 +57,12 @@ cat > "$mock_bin/docker" <<'EOF'
 set -euo pipefail
 image="${!#}"
 case "${1:-}" in
+	pull)
+		# sdk_matrix_pull always re-resolves via `docker pull`.
+		[[ -n "${MOCK_PULL_LOG:-}" ]] && echo "pull $image" >> "$MOCK_PULL_LOG"
+		[[ "${MOCK_PULL_FAIL:-0}" != "1" ]] || exit 1
+		exit 0
+		;;
 	image)
 		case "${2:-}" in
 			pull)
@@ -109,16 +115,27 @@ EOF
 chmod +x "$mock_bin/docker"
 PATH="$mock_bin:$PATH"
 
+export SDK_MATRIX_DIGEST_CACHE_DIR="${fixture}/sdk-digests"
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
+
 mkdir -p "${fixture}/manifest-staging" "${fixture}/fallback-staging" "${fixture}/abort-staging" "${fixture}/pull-staging" "${fixture}/pullfail-staging" "${fixture}/multi-staging"
-# Assert the pull path runs: image absent (bare inspect fails) → explicit
-# pull before the digest inspect (luna fold 2026-08-10).
+# Assert the pull path always runs (no skip when the tag exists locally).
 pull_log="$(mktemp)"
-export MOCK_PULL_LOG="$pull_log" MOCK_IMAGE_ABSENT=1
+export MOCK_PULL_LOG="$pull_log"
 feed_publish_write_manifest "${fixture}/pull-staging" test-tag
 grep -q '^pull ghcr.io/openwrt/sdk:' "$pull_log" || { echo "FAIL: sdk_matrix_pull not called"; exit 1; }
-unset MOCK_IMAGE_ABSENT
+# Cold pin-cache: sdk_image stays the mutable tag; digest is a separate field.
+grep -q '"sdk_image": "ghcr.io/openwrt/sdk:x86-64-21.02.7"' "${fixture}/pull-staging/manifest.json" \
+	|| { echo "FAIL: cold-cache sdk_image must be the tag, not the digest ref"; exit 1; }
+grep -q '"sdk_image": "ghcr.io/openwrt/sdk@sha256:' "${fixture}/pull-staging/manifest.json" \
+	&& { echo "FAIL: sdk_image must not be a digest ref"; exit 1; }
+# Pin cache: a second manifest write must not re-pull a possibly moved tag.
+: > "$pull_log"
 feed_publish_write_manifest "${fixture}/manifest-staging" test-tag
-grep -q '^pull ghcr.io/openwrt/sdk:' "$pull_log" || { echo "FAIL: sdk_matrix_pull not called"; exit 1; }
+if grep -q '^pull ' "$pull_log"; then
+	echo "FAIL: pin cache should avoid a second pull" >&2
+	exit 1
+fi
 test -f "${fixture}/manifest-staging/manifest.json"
 grep -q '"openwrt": "21.02"' "${fixture}/manifest-staging/manifest.json"
 grep -q '"sha256":' "${fixture}/manifest-staging/manifest.json"
@@ -136,6 +153,8 @@ command -v node >/dev/null 2>&1 && node -e '
 # Multi-registry RepoDigests: the production code must select the digest
 # matching ghcr.io/openwrt/sdk, NOT RepoDigests[0] (the ghcrXio decoy is
 # emitted FIRST, like docker sometimes orders multiple registries).
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
 mkdir -p "${fixture}/multi-staging"
 export MOCK_MULTI_REPO=1
 feed_publish_write_manifest "${fixture}/multi-staging" test-tag
@@ -149,6 +168,8 @@ echo "multi-registry digest selection OK"
 # Failed pull must abort (sdk_matrix_pull || return 1) — a failed pull
 # followed by a successful inspect would record a digest for an image that
 # was never pulled (luna fold 2026-08-10).
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
 pullfail_warn="$(mktemp)"
 export MOCK_IMAGE_ABSENT=1 MOCK_PULL_FAIL=1
 if feed_publish_write_manifest "${fixture}/pullfail-staging" test-tag 2>"$pullfail_warn"; then
@@ -159,6 +180,8 @@ unset MOCK_IMAGE_ABSENT MOCK_PULL_FAIL
 echo "pull-failure abort OK"
 
 # Empty RepoDigests → fallback to @sha256:<image ID> with a documented warning.
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
 fallback_warn="$(mktemp)"
 export MOCK_REPO_DIGESTS=0
 feed_publish_write_manifest "${fixture}/fallback-staging" test-tag 2>"$fallback_warn"
@@ -175,6 +198,8 @@ export MOCK_REPO_DIGESTS=1
 
 # Neither RepoDigests nor .Id resolvable → manifest generation must FAIL
 # (no empty digest recorded silently; luna fold 2026-08-10).
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
 abort_warn="$(mktemp)"
 export MOCK_REPO_DIGESTS=0 MOCK_NO_ID=1
 if feed_publish_write_manifest "${fixture}/abort-staging" test-tag 2>"$abort_warn"; then

--- a/tests/sdk-matrix-digests.test.sh
+++ b/tests/sdk-matrix-digests.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Host tests for SDK digest pin-cache (R4) and secret-mount isolation (R7).
+# Docker is mocked — no daemon needed.
+# shellcheck disable=SC2015
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../scripts/lib/sdk-matrix.sh
+source "$ROOT/scripts/lib/sdk-matrix.sh"
+
+fail=0
+ok() { echo "ok: $*"; }
+bad() { echo "FAIL: $*" >&2; fail=1; }
+
+# R7 host proof (no docker daemon): first secret-touching SDK use pins, and
+# every container that bind-mounts a signing secret is --network none.
+if grep -qE '^[[:space:]]*sdk_matrix_pull_and_pin ' "$ROOT/scripts/validate-feed-keys.sh" \
+	&& ! grep -qE '^[[:space:]]*sdk_matrix_resolve ' "$ROOT/scripts/validate-feed-keys.sh"; then
+	ok "R7: validate-feed-keys pins SDK (no resolve-only pull)"
+else
+	bad "R7: validate-feed-keys.sh must call pull_and_pin, not resolve"
+fi
+if grep -qE '^[[:space:]]*docker run --rm --network none --user root' "$ROOT/scripts/validate-feed-keys.sh"; then
+	ok "R7: validate-feed-keys docker run is --network none"
+else
+	bad "R7: validate-feed-keys.sh docker run missing --network none"
+fi
+_secret_runs="$(grep -cE '^[[:space:]]*docker run --rm --network none --user root' "$ROOT/scripts/lib/feed-publish.sh" || true)"
+if [[ "$_secret_runs" -eq 2 ]] \
+	&& grep -A8 -- '--network none --user root' "$ROOT/scripts/lib/feed-publish.sh" | grep -q 'opkg-secret.key' \
+	&& grep -A8 -- '--network none --user root' "$ROOT/scripts/lib/feed-publish.sh" | grep -q 'apk-secret.rsa' \
+	&& ! grep -A12 -- '--network none --user root' "$ROOT/scripts/lib/feed-publish.sh" | grep -q 'SDK_MATRIX_VOLUME'; then
+	ok "R7: opkg/apk secret runs are docker run --network none (no /builder volume)"
+else
+	bad "R7: feed-publish secret mounts must use docker run --network none without SDK volume (got ${_secret_runs})"
+fi
+_pin_calls="$(grep -cE '^[[:space:]]*feed_publish_apply_sdk_pin ' "$ROOT/scripts/lib/feed-publish.sh" || true)"
+if [[ "$_pin_calls" -eq 2 ]] \
+	&& grep -q 'sdk_matrix_read_digest_cache' "$ROOT/scripts/lib/feed-publish.sh"; then
+	ok "R7: feed-publish applies digest pin before secret mounts"
+else
+	bad "R7: feed-publish must apply pin cache before secret mounts (got ${_pin_calls} apply_sdk_pin calls)"
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export SDK_MATRIX_DIGEST_CACHE_DIR="$TMP/sdk-digests"
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
+
+MOCK_PULL_FAIL=0
+
+docker() {
+	local img
+	case "$1" in
+		pull)
+			[[ "$MOCK_PULL_FAIL" != 1 ]] || return 1
+			[[ -n "${MOCK_PULL_LOG:-}" ]] && echo "pull $2" >> "$MOCK_PULL_LOG"
+			return 0
+			;;
+		image)
+			[[ "$2" == "inspect" ]] || return 0
+			img="${!#}"
+			if [[ "${3:-}" == "--format" ]]; then
+				case "$4" in
+					*RepoDigests*)
+						[[ -n "${MOCK_REPO:-}" ]] && printf '%s\n' "$MOCK_REPO"
+						return 0
+						;;
+					*)
+						[[ -n "${MOCK_ID:-}" ]] && printf '%s' "$MOCK_ID"
+						return 0
+						;;
+				esac
+			fi
+			return 0
+			;;
+		*) return 0 ;;
+	esac
+}
+
+want='ghcr.io/openwrt/sdk@sha256:dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444dddd4444'
+decoy='registry.example.net/sdk@sha256:decoydecoydecoydecoydecoydecoydecoydecoydecoydecoydecoydecoydecoydeco'
+MOCK_REPO="${decoy}
+${want}"
+MOCK_ID=''
+
+got="$(sdk_matrix_image_digest x86-64 23.05)"
+if [[ "$got" == "$want" ]]; then
+	ok "digest x86-64/23.05 selects ghcr.io prefix, not decoy"
+else
+	bad "digest x86-64/23.05: got '${got}' want '${want}'"
+fi
+
+# Pin file: digest returned without a second pull.
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
+MOCK_PULL_LOG="$TMP/pull-pin.log"
+: > "$MOCK_PULL_LOG"
+sdk_matrix_pull_and_pin x86-64 23.05 >/dev/null
+pulls1="$(wc -l < "$MOCK_PULL_LOG" | tr -d ' ')"
+got="$(sdk_matrix_image_digest x86-64 23.05)"
+pulls2="$(wc -l < "$MOCK_PULL_LOG" | tr -d ' ')"
+if [[ "$got" == "$want" && "$pulls1" == "1" && "$pulls2" == "1" ]]; then
+	ok "R4 pin cache avoids re-pull"
+else
+	bad "R4 pin cache: got=$got pulls=$pulls1/$pulls2"
+fi
+unset MOCK_PULL_LOG
+
+# Fallback: empty RepoDigests → @sha256:<image id> + WARNING
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
+MOCK_REPO=''
+MOCK_ID='sha256:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed'
+warn="$TMP/fallback-warn.txt"
+got="$(sdk_matrix_image_digest x86-64 23.05 2>"$warn")"
+if [[ "$got" == "@sha256:feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed" ]]; then
+	ok "fallback digest uses image id"
+else
+	bad "fallback digest: got '$got'"
+fi
+grep -qi 'RepoDigest' "$warn" && ok "fallback emitted WARNING" || bad "no WARNING for fallback"
+
+# Abort: pull fails → non-zero
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
+MOCK_PULL_FAIL=1
+if sdk_matrix_image_digest x86-64 23.05 >/dev/null 2>&1; then
+	bad "digest should abort when pull fails"
+else
+	ok "digest aborts when pull fails"
+fi
+MOCK_PULL_FAIL=0
+
+# Abort: no RepoDigests / id
+rm -rf "${SDK_MATRIX_DIGEST_CACHE_DIR:?}"/*
+mkdir -p "$SDK_MATRIX_DIGEST_CACHE_DIR"
+MOCK_REPO=''
+MOCK_ID=''
+if sdk_matrix_image_digest x86-64 23.05 >/dev/null 2>&1; then
+	bad "digest should abort with no resolvable source"
+else
+	ok "digest aborts with no resolvable source"
+fi
+
+# sdk_matrix_pull must re-resolve tags even when the image is already local.
+MOCK_PULL_LOG="$TMP/pulls.log"
+: > "$MOCK_PULL_LOG"
+MOCK_REPO="$want"
+sdk_matrix_resolve x86-64 23.05
+sdk_matrix_pull
+pulls="$(grep -c 'ghcr.io/openwrt/sdk:' "$MOCK_PULL_LOG" || true)"
+if [[ "$pulls" -ge 1 ]]; then
+	ok "sdk_matrix_pull always re-resolves (pull fired on present image)"
+else
+	bad "sdk_matrix_pull skipped pull on present image (stale digest risk)"
+fi
+unset MOCK_PULL_LOG
+
+[ "$fail" = "0" ] || exit 1
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
- Pin the OpenWrt SDK image (`sdk_matrix_pull_and_pin`) before bind-mounting signing secrets; always re-pull tags so a stale local image cannot be recorded.
- Isolate secret-touching containers with `docker run --network none` (Compose v2 `run` has no `--network`). Sign exports tools via compose first so `/builder` is not mounted beside the key.
- Close #178 process: pre-release re-check of the SHA-pinned `peaceiris/actions-gh-pages` step. Ledger records the 2026-08-13 pass **and** the R7 miss (#177 claimed validate-keys SDK ordering was usrmanage-only).

Closes #177
Closes #178
Closes #179

## Test plan
- [x] `./scripts/fwlive-test.sh` on macOS
- [x] `tests/sdk-matrix-digests.test.sh` R7 greps (call-site `pull_and_pin`, `docker run --network none`, no SDK volume on secret runs)
- [x] `tests/feed-publish-release-assets.test.sh` pin-cache + cold-cache `sdk_image` is the tag
- [ ] Reviewers: Grok/Luna/Bugbot round 1+2 on the branch; remaining volume-prefix finding folded into this PR
- [ ] Do not merge unless asked