### PR TITLE
docs: document the release process in release.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ Shipped surface: `openwrt-feed/luci-app-fwlive/`. Rules live in the linked owner
 - Untrusted values (logs, hostnames, URL-hash, UCI) MUST reach the DOM as text nodes, never an HTML sink. [security-model.md](docs/developer/security-model.md)
 - `CLASSIFY_SPEC` MUST be edited in `core/` **and** the LuCI mirror, then `./scripts/gen-all.sh`. Do not hand-edit the shell classifier or `css.js`. `gen-luci-wrapper.js` is a gate: it reports drift and will not fix it.
 - Sessions MUST NOT get `ubus log.read`. Keep read/write ACL scopes separate.
-- `PKG_VERSION` MUST match `APP_VERSION`.
+- `PKG_VERSION` MUST match `APP_VERSION` (bump both in lockstep; see [release.md](docs/release.md)).
 - Renderer tests do not render — a green run is not XSS proof. [build-and-test.md](docs/developer/build-and-test.md)
 - rpcd / ACL / shell helpers / release pipeline: update [security-review.md](docs/developer/security-review.md) in the same PR; audit via `.cursor/skills/security-audit`.
+- Releases: bump `PKG_VERSION`/`APP_VERSION`, fold CHANGELOG, tag `v0.1.N` — CI builds the signed feed + release assets. [release.md](docs/release.md)
 - Vulnerabilities go to a private advisory ([SECURITY.md](SECURITY.md)), not a public issue.
 - Tabs in shell and shipped JS. Workflow: [contributing.md](docs/developer/contributing.md). Commands: [build-and-test.md](docs/developer/build-and-test.md).

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -99,7 +99,7 @@ Then, to open the upstream PR:
 
 ## After publish
 
-1. Follow [release.md](release.md): publish GitHub Release → CI builds feed + attaches assets
+1. Follow [release.md](release.md): push the `v*` tag → CI builds the feed, deploys to Pages, and creates the GitHub Release with assets attached
 2. Confirm [binary feed](binary-feed.md) URLs respond
 3. Confirm README install section points at feed + Releases + `src-link`
 4. Optional: submit to third-party OpenWrt feed index (outside this checklist)

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,7 +29,7 @@ Before cutting a `v*` tag, re-verify the `peaceiris/actions-gh-pages` SHA in
 
 1. **Bump the third octet** of `PKG_VERSION` (keep `PKG_RELEASE:=1`) in
    [`openwrt-feed/luci-app-fwlive/Makefile`](../openwrt-feed/luci-app-fwlive/Makefile):
-   `0.1.33` → `0.1.34`.
+   `0.1.(N-1)` → `0.1.N` (e.g. `0.1.33` → `0.1.34`).
 2. **Mirror `APP_VERSION`** in
    [`openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js`](../openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js)
    — it MUST equal `PKG_VERSION` (AGENTS.md lock).

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,24 +27,34 @@ Before cutting a `v*` tag, re-verify the `peaceiris/actions-gh-pages` SHA in
 
 ## Release steps (automated CI)
 
-1. Bump `PKG_VERSION` / `PKG_RELEASE` in [`openwrt-feed/luci-app-fwlive/Makefile`](../openwrt-feed/luci-app-fwlive/Makefile).
-2. Update [`scripts/feeds.lock/`](../scripts/feeds.lock/) if the OpenWrt point release changed — see [binary-feed.md](binary-feed.md).
-3. Merge to main.
-4. Tag and push — **do not** create or publish a GitHub Release first; CI creates it with assets attached:
+1. **Bump the third octet** of `PKG_VERSION` (keep `PKG_RELEASE:=1`) in
+   [`openwrt-feed/luci-app-fwlive/Makefile`](../openwrt-feed/luci-app-fwlive/Makefile):
+   `0.1.33` → `0.1.34`.
+2. **Mirror `APP_VERSION`** in
+   [`openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js`](../openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js)
+   — it MUST equal `PKG_VERSION` (AGENTS.md lock).
+3. **Fold the changelog**: move the `## [Unreleased]` entries into a new
+   `## [v0.1.N] — YYYY-MM-DD` section at the top of [`CHANGELOG.md`](../CHANGELOG.md),
+   grouped under `### Security` / `### Changed` / `### Added` / `### Fixed` with
+   issue/PR references appended, and add the compare link at the bottom:
+   `[v0.1.N]: https://github.com/lucas-albers-lz4/fwlive/compare/v0.1.N-1...v0.1.N`.
+4. Update [`scripts/feeds.lock/`](../scripts/feeds.lock/) if the OpenWrt point release changed — see [binary-feed.md](binary-feed.md).
+5. Commit as a **direct `chore: release v0.1.N` commit on `master`** (release commits are not PRs) and push.
+6. Create an annotated tag and push it — **do not** create or publish a GitHub Release first; CI creates it with assets attached:
 
    ```sh
-   git tag -a v0.1.0 -m "Firewall Live View — 22.03 / 23.05 / 24.10 / 25.12"
-   git push origin v0.1.0
+   git tag -a v0.1.N -m "fwlive v0.1.N"
+   git push origin v0.1.N
    ```
 
    Pushing the tag triggers [`.github/workflows/publish-packages.yml`](../.github/workflows/publish-packages.yml), which:
    - Builds packages for **21.02**, **22.03**, **23.05**, **24.10**, **25.12**
    - Verifies reproducible builds ([`verify-reproducible-build.sh`](../scripts/verify-reproducible-build.sh))
    - Signs and deploys the feed to **`lucas-albers-lz4/fwlive-packages`** (GitHub Pages)
-   - Uploads release assets (one `.ipk` per opkg line, `.apk` for 25.12 — filenames include the OpenWrt line, e.g. `luci-app-fwlive_0.1.16_21.02_all.ipk`)
-   - Runs QEMU smoke tests installing from the live feed URL
+   - Uploads release assets (one `.ipk` per opkg line, `.apk` for 25.12 — filenames include the OpenWrt line, e.g. `luci-app-fwlive_0.1.34_21.02_all.ipk`)
+   - Runs a QEMU feed smoke (`smoke-from-feed` job) installing from the live feed URL — always on tag pushes (default cell **24.10**; `workflow_dispatch` can override via `feed_smoke` / `smoke_version` inputs)
 
-   GitHub **immutable releases** cannot receive assets after publish. If you already published an empty release, delete it on GitHub (keep the tag) and re-run the workflow from Actions → **Run workflow**.
+   GitHub **immutable releases** cannot receive assets after publish. If you already published an empty release, delete it on GitHub (keep the tag) and re-run the workflow from Actions → **Run workflow**, entering the tag name.
 
 Ensure GitHub Actions secrets are configured — see [binary-feed.md](binary-feed.md).
 
@@ -54,6 +64,7 @@ Ensure GitHub Actions secrets are configured — see [binary-feed.md](binary-fee
 
 ```sh
 export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+./scripts/docker-sdk.sh build --target x86-64 --version 21.02
 ./scripts/docker-sdk.sh build --target x86-64 --version 22.03
 ./scripts/docker-sdk.sh build --target x86-64 --version 23.05
 ./scripts/docker-sdk.sh build --target x86-64 --version 24.10


### PR DESCRIPTION
## What

- `docs/release.md`: full v0.1.34 release workflow — pre-flight gates, PKG_VERSION/APP_VERSION lockstep bump, CHANGELOG fold, direct `chore: release` commit on master, annotated tag, what the tag-triggered `publish-packages` CI does (5-version matrix, reproducible build, signed feed deploy, release assets, QEMU feed smoke), manual-build fallback, notes template, after-publish checks.
- `AGENTS.md`: point at `docs/release.md`; tie the `PKG_VERSION`↔`APP_VERSION` lock to it.

## Verified

- `./scripts/fwlive-linkcheck.sh`: 377 internal / 35 external links — 0 broken.