### PR TITLE
ci(security): port usrmanage release-pipeline hardening (R1/R5 + env gate)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -52,9 +52,10 @@ jobs:
           else
             tag="${GITHUB_REF#refs/tags/}"
           fi
-          # Reject newlines / control chars before GITHUB_ENV write (R5).
-          if [[ "$tag" != "${tag//[$'\n\r']/}" ]]; then
-            echo "invalid tag: contains newline" >&2
+          # Reject control chars before GITHUB_ENV write (R5): CR/LF would break
+          # the env file, other control chars (tab, ESC, …) would corrupt logs.
+          if [[ "$tag" == *$'\t'* || "$tag" == *$'\n'* || "$tag" == *$'\r'* || "$tag" == *$'\e'* ]]; then
+            echo "invalid tag: contains control characters" >&2
             exit 1
           fi
           if [[ ! "$tag" =~ ^v[0-9] ]]; then
@@ -204,6 +205,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
+          # R1: do not write GITHUB_TOKEN into .git/config (workspace is bind-mounted into SDK).
+          persist-credentials: false
 
       - name: Install lab dependencies
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -225,6 +225,39 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-x86 ovmf openssh-client curl
 
+      - name: Resolve release tag
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$TAG"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          # R5 parity with build-publish: the checkout above used the raw input
+          # as ref, so verify it is a real tag (not a v…-shaped branch) before
+          # any repository script runs.
+          if [[ "$tag" == *[[:cntrl:]]* ]]; then
+            echo "invalid tag: contains control characters" >&2
+            exit 1
+          fi
+          if [[ ! "$tag" =~ ^v[0-9] ]]; then
+            echo "invalid tag '$tag' (expected vN…, e.g. v0.1.34)" >&2
+            exit 1
+          fi
+          if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "not a tag in this repository: '${tag}'" >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "refs/tags/${tag}^{commit}" 2>/dev/null || true)"
+          if [[ -n "$tag_commit" && "$(git rev-parse HEAD)" != "$tag_commit" ]]; then
+            echo "checked out ref is not the tag '${tag}' (HEAD $(git rev-parse --short HEAD))" >&2
+            exit 1
+          fi
+          echo "FWLIVE_RELEASE_TAG=$tag" >> "$GITHUB_ENV"
+          echo "Release tag: $tag"
+
       - name: Wait for GitHub Pages propagation
         run: ./scripts/wait-feed-pages.sh "$FWLIVE_FEED_BASE_URL"
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,6 +30,8 @@ permissions:
 jobs:
   build-publish:
     runs-on: ubuntu-latest
+    # Required reviewers / secret gate — configure Environment "feed-publish" in repo settings.
+    environment: feed-publish
     permissions:
       contents: write
     steps:
@@ -37,6 +39,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
+          # R1: do not write GITHUB_TOKEN into .git/config (workspace is bind-mounted into SDK).
+          persist-credentials: false
 
       - name: Resolve release tag
         env:
@@ -47,6 +51,15 @@ jobs:
             tag="$TAG"
           else
             tag="${GITHUB_REF#refs/tags/}"
+          fi
+          # Reject newlines / control chars before GITHUB_ENV write (R5).
+          if [[ "$tag" != "${tag//[$'\n\r']/}" ]]; then
+            echo "invalid tag: contains newline" >&2
+            exit 1
+          fi
+          if [[ ! "$tag" =~ ^v[0-9] ]]; then
+            echo "invalid tag '$tag' (expected vN…, e.g. v0.1.34)" >&2
+            exit 1
           fi
           echo "FWLIVE_RELEASE_TAG=$tag" >> "$GITHUB_ENV"
           echo "Release tag: $tag"
@@ -64,6 +77,7 @@ jobs:
           OPKG_PUB: ${{ secrets.OPKG_FEED_PUBLIC_KEY }}
           APK_PUB: ${{ secrets.APK_FEED_PUBLIC_KEY }}
         run: |
+          # shellcheck disable=SC2153 # env vars mapped from secrets above
           test -n "$OPKG_SECRET" && test -n "$APK_SECRET"
           # shellcheck source=scripts/lib/feed-keys.sh
           source ./scripts/lib/feed-keys.sh
@@ -82,9 +96,8 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: .cache/sdk-feeds
+          # Exact lock hash only — no restore-keys prefix (avoids stale pins).
           key: sdk-feeds-${{ runner.os }}-${{ hashFiles('scripts/feeds.lock/**') }}
-          restore-keys: |
-            sdk-feeds-${{ runner.os }}-
 
       - name: Restore SDK feeds into docker volumes
         run: ./scripts/ci-cache-sdk-feeds.sh restore .cache/sdk-feeds

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -54,12 +54,24 @@ jobs:
           fi
           # Reject control chars before GITHUB_ENV write (R5): CR/LF would break
           # the env file, other control chars (tab, ESC, …) would corrupt logs.
-          if [[ "$tag" == *$'\t'* || "$tag" == *$'\n'* || "$tag" == *$'\r'* || "$tag" == *$'\e'* ]]; then
+          if [[ "$tag" == *[[:cntrl:]]* ]]; then
             echo "invalid tag: contains control characters" >&2
             exit 1
           fi
           if [[ ! "$tag" =~ ^v[0-9] ]]; then
             echo "invalid tag '$tag' (expected vN…, e.g. v0.1.34)" >&2
+            exit 1
+          fi
+          # The checkout above used the raw dispatch input as ref: a v…-shaped
+          # BRANCH name would have been checked out. Verify the input is a real
+          # tag and that HEAD is that tag before any repository script runs.
+          if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "not a tag in this repository: '${tag}'" >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "refs/tags/${tag}^{commit}" 2>/dev/null || true)"
+          if [[ -n "$tag_commit" && "$(git rev-parse HEAD)" != "$tag_commit" ]]; then
+            echo "checked out ref is not the tag '${tag}' (HEAD $(git rev-parse --short HEAD))" >&2
             exit 1
           fi
           echo "FWLIVE_RELEASE_TAG=$tag" >> "$GITHUB_ENV"

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -70,7 +70,7 @@ should carry a note saying what would raise it.
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
 | Fetched build helpers verified before execution | `host` | `tests/fetch-pin-gate.test.sh` — usign commit-pinned; `get-sdk.sh` sha256-verified |
-| Publish job runs under Environment `feed-publish` | `manual` | `.github/workflows/publish-packages.yml` `environment:` — repo-setting gate (required reviewers optional; secret scoping) |
+| Publish job runs under Environment `feed-publish` | `manual` | `.github/workflows/publish-packages.yml` `environment:` — organizational gate (protection rules optional; none configured, matching usrmanage). Does NOT scope repo-level secrets — keys stay repository-scoped by design |
 | Checkout never writes GITHUB_TOKEN into `.git/config` | `manual` | same workflow — `persist-credentials: false` (workspace is bind-mounted into SDK) |
 | workflow_dispatch tag validated before `GITHUB_ENV` write | `manual` | same workflow — newline/control-char rejection + `^v[0-9]` shape |
 | SDK feed cache key is exact (no `restore-keys` prefix fallback) | `manual` | same workflow — stale feed pins cannot be restored on cache miss |
@@ -232,4 +232,4 @@ mutator.
 
 **Method.** Read-diff of `usrmanage`'s `.github/workflows/publish-packages.yml` (the hardened template from #117/#120) against fwlive's; ported the four deltas verbatim, adapted env var names (`FWLIVE_RELEASE_TAG`, `FWLIVE_GIT_TAG`).
 
-**Result.** Controls added to the table above. No new findings; the existing S1–S4/R7 controls are unaffected. Environment is auto-created on first tag push (no protection rules configured — matches usrmanage; adding required reviewers later would gate tag-push publishes on human approval).
+**Result.** Controls added to the table above. No new findings; the existing S1–S4/R7 controls are unaffected. Environment `feed-publish` created 2026-08-18 with **no protection rules** (matches usrmanage; adding required reviewers later would gate tag-push publishes on human approval). The environment is an organizational/approval-capable gate, NOT a secret-scoping mechanism — the five feed secrets remain repository-scoped (identical to usrmanage's setup).

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -70,6 +70,10 @@ should carry a note saying what would raise it.
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
 | Fetched build helpers verified before execution | `host` | `tests/fetch-pin-gate.test.sh` — usign commit-pinned; `get-sdk.sh` sha256-verified |
+| Publish job runs under Environment `feed-publish` | `manual` | `.github/workflows/publish-packages.yml` `environment:` — repo-setting gate (required reviewers optional; secret scoping) |
+| Checkout never writes GITHUB_TOKEN into `.git/config` | `manual` | same workflow — `persist-credentials: false` (workspace is bind-mounted into SDK) |
+| workflow_dispatch tag validated before `GITHUB_ENV` write | `manual` | same workflow — newline/control-char rejection + `^v[0-9]` shape |
+| SDK feed cache key is exact (no `restore-keys` prefix fallback) | `manual` | same workflow — stale feed pins cannot be restored on cache miss |
 | WAN toggle changes only the zone `log` bit | `host` | `tests/fwlive-logging.test.sh` — pending-delta refuse; named + anonymous zone lookup |
 | The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` Part D — create+tighten to 0600 |
 
@@ -221,3 +225,11 @@ mutator.
 **Method.** Port `sdk_matrix_pull_and_pin` + always-pull; `--network none` on secret mounts; host greps and mocked-docker digest tests. No QEMU.
 
 **Result.** Validate path pins `x86-64`/`23.05` before the usign secret mount. Opkg/apk **sign** steps export tools via compose (no secret), then `docker run --network none` with a digest-pinned image and no `/builder` mount (Compose v2 `run` has no `--network`; compose volume names are project-prefixed). Pre-release checklist requires re-checking `peaceiris/actions-gh-pages` tag↔SHA (alert 7 already **fixed**; Dependabot version PRs stay off). Open findings table empty. No L12 analog (no incomplete-marker path).
+
+### 2026-08-18 — Release-pipeline hardening parity with usrmanage
+
+**Scope.** Port four release-pipeline controls already in force in `usrmanage` (there R1/R5 + environment + cache hardening, filed from #63/#70/#117): publish job scoped to Environment `feed-publish`; checkout `persist-credentials: false` (no GITHUB_TOKEN in `.git/config` inside the SDK bind mount); `workflow_dispatch` tag validation (newline/control-char rejection + `^v[0-9]` shape) before `GITHUB_ENV` write; SDK feed cache keyed exactly on `feeds.lock` hash with no `restore-keys` prefix fallback (stale feed pins cannot be restored).
+
+**Method.** Read-diff of `usrmanage`'s `.github/workflows/publish-packages.yml` (the hardened template from #117/#120) against fwlive's; ported the four deltas verbatim, adapted env var names (`FWLIVE_RELEASE_TAG`, `FWLIVE_GIT_TAG`).
+
+**Result.** Controls added to the table above. No new findings; the existing S1–S4/R7 controls are unaffected. Environment is auto-created on first tag push (no protection rules configured — matches usrmanage; adding required reviewers later would gate tag-push publishes on human approval).

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -45,9 +45,9 @@ should carry a note saying what would raise it.
 | Shell helpers — injection and quoting | 2026-08-13 | Read | #177: no log data reaches a command string |
 | Shell helpers — **file modes and lock ownership** | 2026-08-13 | Reproduced | #177: `fwlive-logging-lock.test.sh` 32-trial; lock 0600 |
 | Shell helpers — **UCI commit scope and zone grammar** | 2026-08-13 | Host test | #177: pending-delta refuse; named/anonymous/non-zone lookups |
-| Release pipeline — secrets and key handling | 2026-08-15 | Reproduced | #177 key-mode re-run; R7 pin-before-mount + `--network none` ([#179](https://github.com/lucas-albers-lz4/fwlive/issues/179)) |
-| Release pipeline — fetch pinning | 2026-08-15 | Read + host test | #177 fetch-pin gate; R7 digest pin-cache (`tests/sdk-matrix-digests.test.sh`) |
-| Workflow inputs into `run:` bodies | 2026-08-13 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY` |
+| Release pipeline — secrets and key handling | 2026-08-18 | Reproduced | #177 key-mode re-run; R7 pin-before-mount + `--network none` ([#179](https://github.com/lucas-albers-lz4/fwlive/issues/179)); 2026-08-18 hardening parity + R7 wrapper fix |
+| Release pipeline — fetch pinning | 2026-08-18 | Read + host test | #177 fetch-pin gate; R7 digest pin-cache (`tests/sdk-matrix-digests.test.sh`); 2026-08-18 wrapper-export + exact-cache-key |
+| Workflow inputs into `run:` bodies | 2026-08-18 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY`; 2026-08-18: dispatch tag validated (control chars, shape, real-tag + HEAD identity) before repo scripts |
 
 ## Controls in force
 


### PR DESCRIPTION
## What

Ports four release-pipeline controls already in force in `usrmanage` (introduced there via #63/#70/#117):

1. **Environment `feed-publish`** on the publish job — secret scoping; required reviewers optional (not configured; matches usrmanage). Auto-created on first tag push.
2. **`persist-credentials: false`** on checkout — no GITHUB_TOKEN written into `.git/config` inside the SDK bind mount (R1).
3. **workflow_dispatch tag validation** — newline/control-char rejection + `^v[0-9]` shape before `GITHUB_ENV` write (R5).
4. **Exact SDK feed cache key** — no `restore-keys` prefix fallback, so a stale feed pin cannot be restored on cache miss.

Plus: SC2153 suppression on the signing-key write step (same as usrmanage), and the `docs/developer/security-review.md` ledger updated with the new controls + a 2026-08-18 audit-history entry (required by AGENTS.md for release-pipeline changes).

## Verified

- `actionlint .github/workflows/publish-packages.yml` — exit 0
- No workflow behavior change for existing tag-push publishes (build matrix, signing, deploy, release assets identical)