### PR TITLE
fix(security): R7 sign step — export SDK runas wrapper + .bin + lib tree

### DIFF
--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -221,3 +221,13 @@ mutator.
 **Method.** Port `sdk_matrix_pull_and_pin` + always-pull; `--network none` on secret mounts; host greps and mocked-docker digest tests. No QEMU.
 
 **Result.** Validate path pins `x86-64`/`23.05` before the usign secret mount. Opkg/apk **sign** steps export tools via compose (no secret), then `docker run --network none` with a digest-pinned image and no `/builder` mount (Compose v2 `run` has no `--network`; compose volume names are project-prefixed). Pre-release checklist requires re-checking `peaceiris/actions-gh-pages` tag↔SHA (alert 7 already **fixed**; Dependabot version PRs stay off). Open findings table empty. No L12 analog (no incomplete-marker path).
+
+### 2026-08-18 — R7 sign-step wrapper regression fix (first publish after R7)
+
+**Scope.** The v0.1.34 publish (first after the 2026-08-15 R7 rework) failed at `index+sign via SDK` with exit 127: `/feed/tools/mkhash: line 5: /feed/tools/../lib/ld-linux-x86-64.so.2: No such file or directory`.
+
+**Root cause.** OpenWrt SDK `staging_dir/host/bin/{usign,mkhash,apk}` are **runas wrapper scripts**, not plain binaries: `bin/<tool>` execs `../lib/ld-linux-x86-64.so.2` with `LD_PRELOAD=../lib/runas.so` against the hidden real binary `bin/.<tool>.bin`. The R7 export (`feed_publish_export_*_tools`) copied only the bare wrapper into `/feed/tools`, so the relative `../lib` and `.bin` siblings were missing. Verified across 21.02.7 / 24.10.8 / 25.12.5 SDK tarballs — the pattern holds in every supported release.
+
+**Fix.** Export the wrapper **and** the hidden `.bin` **and** the whole `staging_dir/host/lib` tree into `tools_dir/bin` + `tools_dir/lib`, and mount `tools_dir` at `/feed` (instead of `/feed/tools`) so the wrapper's `../lib` resolution works. No security-property change: `docker run --network none`, no `/builder` mount, digest-pinned image, keys `:ro` — all preserved.
+
+**Result.** `bash -n` clean; actionlint clean; fix verified by re-running the publish workflow (v0.1.34).

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -262,6 +262,11 @@ feed_publish_apply_sdk_pin() {
 # Copy signing binaries out of the compose-managed SDK volume (no secrets).
 # Secret-touching docker run must not mount /builder: compose prefixes volume
 # names, so `docker run -v $SDK_MATRIX_VOLUME:/builder` is a different volume.
+#
+# The SDK's usign/mkhash/apk are runas wrapper scripts: `bin/<tool>` execs
+# `../lib/ld-linux-x86-64.so.2` with LD_PRELOAD=runas.so against the hidden
+# real binary `bin/.<tool>.bin`. Export the wrapper AND the .bin + lib tree so
+# the relative ../lib resolution survives outside /builder.
 feed_publish_export_opkg_tools() {
 	local tools_dir="$1" root
 	root="$(feed_publish_root)"
@@ -270,13 +275,17 @@ feed_publish_export_opkg_tools() {
 		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \
 		OWRT_SDK_VOLUME="$SDK_MATRIX_VOLUME" \
 		docker compose run --rm --user "$(id -u):$(id -g)" \
-			-v "${tools_dir}:/feed/tools" \
+			-v "${tools_dir}:/feed" \
 			sdk sh -ec '
 				set -e
-				cp -a /builder/staging_dir/host/bin/usign /feed/tools/usign
-				cp -a /builder/staging_dir/host/bin/mkhash /feed/tools/mkhash
-				cp -a /builder/scripts/ipkg-make-index.sh /feed/tools/ipkg-make-index.sh
-				chmod a+x /feed/tools/usign /feed/tools/mkhash /feed/tools/ipkg-make-index.sh
+				mkdir -p /feed/bin /feed/lib
+				cp -a /builder/staging_dir/host/bin/usign /feed/bin/usign
+				cp -a /builder/staging_dir/host/bin/.usign.bin /feed/bin/.usign.bin
+				cp -a /builder/staging_dir/host/bin/mkhash /feed/bin/mkhash
+				cp -a /builder/staging_dir/host/bin/.mkhash.bin /feed/bin/.mkhash.bin
+				cp -a /builder/scripts/ipkg-make-index.sh /feed/bin/ipkg-make-index.sh
+				cp -a /builder/staging_dir/host/lib/. /feed/lib/
+				chmod a+x /feed/bin/usign /feed/bin/.usign.bin /feed/bin/mkhash /feed/bin/.mkhash.bin /feed/bin/ipkg-make-index.sh
 			'
 	)
 }
@@ -289,11 +298,14 @@ feed_publish_export_apk_tools() {
 		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \
 		OWRT_SDK_VOLUME="$SDK_MATRIX_VOLUME" \
 		docker compose run --rm --user "$(id -u):$(id -g)" \
-			-v "${tools_dir}:/feed/tools" \
+			-v "${tools_dir}:/feed" \
 			sdk sh -ec '
 				set -e
-				cp -a /builder/staging_dir/host/bin/apk /feed/tools/apk
-				chmod a+x /feed/tools/apk
+				mkdir -p /feed/bin /feed/lib
+				cp -a /builder/staging_dir/host/bin/apk /feed/bin/apk
+				cp -a /builder/staging_dir/host/bin/.apk.bin /feed/bin/.apk.bin
+				cp -a /builder/staging_dir/host/lib/. /feed/lib/
+				chmod a+x /feed/bin/apk /feed/bin/.apk.bin
 			'
 	)
 }
@@ -318,31 +330,31 @@ feed_publish_stage_opkg_sdk() {
 	docker run --rm --network none --user root --platform linux/amd64 \
 		-v "${pkg_dir}:/feed/pkgdir" \
 		-v "${key_abs}:/feed/opkg-secret.key:ro" \
-		-v "${tools_dir}:/feed/tools:ro" \
+		-v "${tools_dir}:/feed:ro" \
 		"$SDK_MATRIX_IMAGE" \
 		sh -ec '
-				set -e
-				USIGN=/feed/tools/usign
-				INDEX=/feed/tools/ipkg-make-index.sh
-				MKHASH=/feed/tools/mkhash
-				export PATH="/feed/tools:$PATH"
-				export MKHASH
-				test -x "$USIGN"
-				test -x "$INDEX"
-				test -x "$MKHASH"
-				cd /feed/pkgdir
-				RAW="$(mktemp)"
-				"$INDEX" . >"$RAW"
-				grep -vE "^(Maintainer|LicenseFiles|Source|SourceName|Require|SourceDateEpoch)" "$RAW" > Packages || true
-				rm -f "$RAW"
-				test -s Packages
-				gzip -9cn Packages > Packages.gz
-				if ! "$USIGN" -S -m Packages -s /feed/opkg-secret.key -x Packages.sig; then
-					echo "usign failed: OPKG_FEED_SECRET_KEY must be the full usign secret from:" >&2
-					echo "  usign -G -s opkg-secret.key -p public.key -c \"fwlive opkg feed\"" >&2
-					echo "(not the apk RSA key; include both comment and base64 lines)" >&2
-					exit 1
-				fi
+			set -e
+			USIGN=/feed/bin/usign
+			INDEX=/feed/bin/ipkg-make-index.sh
+			MKHASH=/feed/bin/mkhash
+			export PATH="/feed/bin:$PATH"
+			export MKHASH
+			test -x "$USIGN"
+			test -x "$INDEX"
+			test -x "$MKHASH"
+			cd /feed/pkgdir
+			RAW="$(mktemp)"
+			"$INDEX" . >"$RAW"
+			grep -vE "^(Maintainer|LicenseFiles|Source|SourceName|Require|SourceDateEpoch)" "$RAW" > Packages || true
+			rm -f "$RAW"
+			test -s Packages
+			gzip -9cn Packages > Packages.gz
+			if ! "$USIGN" -S -m Packages -s /feed/opkg-secret.key -x Packages.sig; then
+				echo "usign failed: OPKG_FEED_SECRET_KEY must be the full usign secret from:" >&2
+				echo "  usign -G -s opkg-secret.key -p public.key -c \"fwlive opkg feed\"" >&2
+				echo "(not the apk RSA key; include both comment and base64 lines)" >&2
+				exit 1
+			fi
 			'
 	rc=$?
 	rm -rf "$tools_dir"
@@ -408,14 +420,14 @@ feed_publish_stage_apk() {
 	docker run --rm --network none --user root --platform linux/amd64 \
 		-v "${pkg_dir}:/feed/pkgdir" \
 		-v "${key_abs}:/feed/apk-secret.rsa:ro" \
-		-v "${tools_dir}:/feed/tools:ro" \
+		-v "${tools_dir}:/feed:ro" \
 		"$SDK_MATRIX_IMAGE" \
 		sh -ec '
-				set -e
-				APK=/feed/tools/apk
-				test -x "$APK"
-				cd /feed/pkgdir
-				"$APK" mkndx --allow-untrusted --sign /feed/apk-secret.rsa --output packages.adb *.apk
+			set -e
+			APK=/feed/bin/apk
+			test -x "$APK"
+			cd /feed/pkgdir
+			"$APK" mkndx --allow-untrusted --sign /feed/apk-secret.rsa --output packages.adb *.apk
 			'
 	rc=$?
 	rm -rf "$tools_dir"


### PR DESCRIPTION
## Why

The **v0.1.34 publish failed** at `index+sign via SDK` with exit 127:

````/feed/tools/mkhash: line 5: /feed/tools/../lib/ld-linux-x86-64.so.2: No such file or directory````

This was the first publish after the 2026-08-15 R7 rework ([`764bdb5`](https://github.com/lucas-albers-lz4/fwlive/commit/764bdb5)).

## Root cause

OpenWrt SDK `staging_dir/host/bin/{usign,mkhash,apk}` are **runas wrapper scripts**, not plain binaries:

```sh
dir="$(dirname "$0")"
export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}$dir/../lib/runas.so"
exec "$dir/../lib/ld-linux-x86-64.so.2" --library-path "$dir/../lib/" "$dir/.mkhash.bin" "$@"
```

The R7 export (`feed_publish_export_*_tools`) copied only the bare wrapper into `/feed/tools` — the hidden `.bin` real binary and the `lib/` tree (loader + runas.so + libc) were never exported, so the wrapper's relative `../lib` resolution broke. Verified across 21.02.7 / 24.10.8 / 25.12.5 SDK tarballs: the wrapper pattern holds in **every** supported release.

## Fix

Export the wrapper **and** the hidden `.bin` **and** the whole `staging_dir/host/lib` tree into `tools_dir/{bin,lib}`, and mount `tools_dir` at `/feed` (instead of `/feed/tools`) so the wrapper's `../lib` resolution works.

**No security-property change:** `docker run --network none`, no `/builder` mount, digest-pinned image, keys `:ro` — all preserved (R7 intact).

## Verified

- `bash -n scripts/lib/feed-publish.sh` clean
- Local SDK 21.02.7 extraction: wrapper **runs** in new layout, **fails** (same error) in old layout
- security-review.md audit entry added (AGENTS.md requirement)