### PR TITLE
ci: CodeRabbit config + shellcheck discovery gate

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,57 @@
+# fwlive — .coderabbit.yaml
+# Grounded in the actual repo invariants (NOT AI-failure stereotypes):
+#   - OpenWrt LuCI feed package + shipped busybox-sh rpcd shell
+#   - LuCI/JS view that must mirror the core/ parser
+# Profile "chill": comments only, never blocks the merge. CI is the gate;
+# this bot is a cheap second opinion that flags real regressions.
+language: "en"
+early_access: false
+reviews:
+  profile: "chill"            # classic notes, no hard request-changes
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: true              # review draft PRs too (this repo's workflow is PR-based)
+    base: auto
+  tools:
+    ast_grep: true            # the tool name is ast_grep (NOT "ast_grex" — see discussion)
+    bullseye: true            # security add-on: good for the rpcd/frontend boundary
+  path_instructions:
+    - path: "**/*.sh"
+      instructions: |
+        These scripts run under busybox ash on OpenWrt targets, NOT bash.
+        Flag any bashism: `[[ ]]`, `${var,,}`/case-modifiers, arrays,
+        `declare`/`local`, `source`, process substitution `<(...)`.
+        Every variable expansion on a shared/runtime path must be quoted
+        (CI enforces SC2086 — keep it that way).
+        Flag hardcoded absolute paths: lookup paths must come from the
+        runtime $FILTER_DIR / $LOGGING_SH-style resolution.
+    - path: "openwrt-feed/luci-app-fwlive/root/usr/libexec/**"
+      instructions: |
+        This is the shipped rpcd/libexec shell. It is exposed over LuCI RPC.
+        Flag any path where a value originating from the LuCI frontend is
+        interpolated into `nft`/`iptables`/`awk`/`grep` without escaping
+        (command/argument injection). Also enforce POSIX sh + quoted vars
+        (see **/*.sh).
+    - path: "**/Makefile"
+      instructions: |
+        OpenWrt feed package Makefiles. On release, PKG_VERSION must track
+        the release tag/package.json version. Flag a PKG_VERSION/PKG_RELEASE
+        that was bumped without the matching frontend/version change, or a
+        source pin/hash that is stale relative to the declared version.
+    - path: "openwrt-feed/luci-app-fwlive/htdocs/**/*.js"
+      instructions: |
+        This LuCI view must stay semantically in sync with the core/ parser
+        (there is an explicit core-vs-LuCI sync gate). Flag new/renamed
+        filter tokens, log fields, or nft table/chain names added on one
+        side but not the other.
+  system_instructions: |
+    This is fwlive, a LuCI app for live firewall log viewing over
+    nftables/fw4 and iptables. The shipped shell in root/usr/libexec runs
+    in a minimal OpenWrt (busybox ash) environment, so POSIX-only shell
+    and quoted variables are hard invariants. Prefer a precise, grounded
+    comment over a generic nitpick — if you cannot tie a concern to one of
+    the path invariants above, skip it.

--- a/scripts/fwlive-shellcheck.sh
+++ b/scripts/fwlive-shellcheck.sh
@@ -10,11 +10,12 @@ if ! command -v shellcheck >/dev/null 2>&1; then
 	exit 1
 fi
 
-# Do not use -x: sourced paths are runtime-resolved ($FILTER_DIR / $LOGGING_SH).
-shellcheck -s sh \
-	"$LIBEXEC/fwlive-log-filter.sh" \
-	"$LIBEXEC/fwlive-logging.sh" \
-	"$LIBEXEC/fwlive-is-firewall-event.sh" \
-	"$LIBEXEC/rpcd/fwlive"
+# Enumerate by discovery, not a fixed list, so a newly added script cannot
+# silently escape this gate (it previously named 4 files explicitly). The
+# shipped rpcd entrypoint `rpcd/fwlive` has no extension, so match *.sh OR
+# that exact name. Do not use -x: sourced paths are runtime-resolved
+# ($FILTER_DIR / $LOGGING_SH).
+find "$LIBEXEC" -type f \( -name '*.sh' -o -name 'fwlive' \) -print0 \
+	| xargs -0 -r shellcheck -s sh
 
 echo "fwlive shellcheck OK" >&2


### PR DESCRIPTION
## What
Two low-risk changes:
1. **`.coderabbit.yaml`** — grounded CodeRabbit config for fwlive (JS + OpenWrt busybox-ash invariants). `profile: chill` (comments only, never blocks merge — CI + luna/bugbot stay the authoritative gate). Flag real invariants: POSIX-ash/quoting for shipped `root/usr/libexec` shell, LuCI-view/core parser sync, Makefile `PKG_VERSION` consistency, rpcd/frontend injection boundary.
2. **`scripts/fwlive-shellcheck.sh`** — switch from a fixed 4-file list to `find`-based discovery so a newly added shipped shell script cannot silently escape the gate.

## Why
Enables the CodeRabbit second-opinion reviewer and closes the "new .sh escapes the shellcheck gate" gap.

## Verification
- `.coderabbit.yaml` parses (PyYAML OK).
- `scripts/fwlive-shellcheck.sh` runs clean locally (`fwlive shellcheck OK`, exit 0) — same 4 files covered, plus any future additions.

## Gate
Left open for the usual review/approval before merge.
