### PR TITLE
ci: release-consistency assert + Cursor reviewer/Bugbot merge gate

### DIFF
--- a/.cursor/rules/pr-bugbot-before-merge.mdc
+++ b/.cursor/rules/pr-bugbot-before-merge.mdc
@@ -1,0 +1,54 @@
+---
+description: Before merging a PR in an agent-driven Cursor cycle, default to a luna-or-grok review + Bugbot, and triage external review comments
+alwaysApply: true
+---
+
+# PR cycle: reviewer (luna/grok) + Bugbot before merge (Cursor, plan-mode aware)
+
+In agent-driven PR cycles run from **Cursor**, do **not** merge on CI-green alone.
+Even though cursor work normally runs under **plan mode**, plan-mode execution does
+**not** satisfy the merge gate — the reviewer + Bugbot pass still applies before merging.
+Default to **two independent gates** before merge:
+
+1. A **review** by **luna** (preferred) — or **grok** as the alternative reviewer.
+2. **Bugbot** on branch changes.
+
+## When this applies
+
+- You are creating or merging a PR in an agent-driven cycle (create → CI → gate → merge) from Cursor.
+- Applies whether or not the cycle ran under plan mode.
+- The change is **non-trivial** (below).
+
+## Non-trivial vs trivial
+
+**Trivial** (may merge after CI green + a light self-review):
+
+- Docs-only typos, badge/link/metadata, single-line comment, pure formatting with no logic change
+- Housekeeping like license badge, topics, changelog date bumps
+
+**Non-trivial** (reviewer + Bugbot **required** before merge):
+
+- Any new/changed logic, scripts, tests, CI workflows, schemas, OpenWrt feed/package files, or config
+- Multi-file features or refactors
+
+If unsure, treat as non-trivial.
+
+## Required sequence (non-trivial)
+
+1. Open or update the PR; wait for **CI** to go green (required checks present AND passing — a rollup missing expected jobs is not green).
+2. Ensure the PR head branch is checked out locally.
+3. Run a **review** with **luna** (preferred) or **grok** (alternative) on **branch changes** (merge-base vs the default base).
+4. Run **Bugbot** via the `review-bugbot` skill / `bugbot` subagent on **branch changes**.
+5. If the reviewer or Bugbot reports findings: **fix them** (or explicitly document why each is a false positive), push, re-run once after substantive fixes.
+6. Triage external review comments on the PR before merge:
+   - Pull the thread (`gh api repos/{owner}/{repo}/pulls/<n>/comments --paginate`, `<n>/reviews`, issue comments) and classify each: `CONFIRMED` (fix it), `DISMISS` (document why it's a false positive), or `FOLD` (already addressed / duplicate).
+   - Do **not** auto-apply a CodeRabbit-suggested fix without ground-truthing it against the code / real API — a suggested fix can be wrong.
+   - Human `REQUEST_CHANGES` / substantive inline comments **outrank** bot comments. A bare bot comment doesn't block merge by itself, but unresolved `CONFIRMED` bot findings do not merge clean.
+7. Only then merge (`gh pr merge` with the repo's usual strategy).
+
+## Do not
+
+- Merge a non-trivial PR on CI-green alone — default to the luna-or-grok review + Bugbot regardless of plan mode.
+- Treat plan-mode execution as a substitute for the reviewer + Bugbot gates.
+- Merge with unresolved `CONFIRMED` bot/CodeRabbit findings or an un-triaged review-comment thread.
+- Rely on AGENTS.md alone for this gate — this Cursor rule is the merge-cycle source of truth.

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -80,6 +80,21 @@ jobs:
       - name: Set SOURCE_DATE_EPOCH from release tag
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
 
+      - name: Assert feed PKG_VERSION == release tag (release-consistency)
+        run: |
+          src="openwrt-feed/luci-app-fwlive/Makefile"
+          pkg="$(sed -n 's/^PKG_VERSION:=\(.*\)/\1/p' "$src")"
+          want="${FWLIVE_RELEASE_TAG#v}"
+          if [ -z "$pkg" ]; then
+            echo "PKG_VERSION not found in $src" >&2
+            exit 1
+          fi
+          if [ "$pkg" != "$want" ]; then
+            echo "feed PKG_VERSION '$pkg' != release tag version '$want'" >&2
+            exit 1
+          fi
+          echo "feed PKG_VERSION $pkg matches tag $FWLIVE_RELEASE_TAG" >&2
+
       - name: Validate baseline
         run: ./scripts/validate-baseline.sh
 


### PR DESCRIPTION
## What
Two changes:
1. **W4 — release-consistency assert** in `.github/workflows/publish-packages.yml`: before publishing, assert the feed Makefile `PKG_VERSION` (`openwrt-feed/luci-app-fwlive/Makefile`) equals the release tag (e.g. `v0.1.34` → `0.1.34`). Prevents a release going out with a stale feed version.
2. **W7 — Cursor merge gate** `.cursor/rules/pr-bugbot-before-merge.mdc` (new): agent-driven Cursor cycles now **default to a luna (or grok) review + Bugbot before merge**, regardless of plan mode, plus CodeRabbit/external comment triage.

## Why
- AGENTS.md already requires `PKG_VERSION`/`APP_VERSION` lockstep and tag-tracked versioning — CI now enforces the release half of that rule.
- fwlive previously had no Bugbot-before-merge gate in Cursor; this makes the reviewer + Bugbot default explicit and plan-mode-aware.

## Verification
- `publish-packages.yml` YAML-valid; assert step confirmed present.
- Assert logic ground-truthed against the real Makefile: matching tag (`v0.1.34` → `0.1.34`) passes (rc=0); mismatched tag errors (rc=1).
- `.mdc` frontmatter parses.

## Gate
Left open for review/approval before merge.
