### PR TITLE
feat: F1 Z3 address proofs + #121 deploy wiring (#197/#121)

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -54,3 +54,18 @@ jobs:
             -w /repo \
             "$ZIZMOR_IMAGE" \
             --offline --persona=regular --min-severity=high .
+
+  # #121: authoritative Z3 suite (F1+; F2–F4 land in later PRs).
+  z3-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+      - name: Install z3-solver (pinned)
+        run: pip install --disable-pip-version-check "z3-solver==5.0.0"
+      - name: Z3 verify --full
+        run: python3 scripts/z3-verify.py --full

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,12 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
+
+  # #121: Z3 fast subset — skip when z3-solver is not installed (CI is authoritative).
+  - repo: local
+    hooks:
+      - id: z3-verify-fast
+        name: Z3 regex verification (fast subset)
+        entry: bash -c 'python3 -c "import z3" 2>/dev/null || { echo "z3-solver not installed — skipping (CI is authoritative)"; exit 0; }; python3 scripts/z3-verify.py --fast'
+        language: system
+        pass_filenames: false

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -38,6 +38,7 @@ Documentation for **building, testing, and extending** `luci-app-fwlive` and the
 | Publish checklist | [`../github-publish-checklist.md`](../github-publish-checklist.md) |
 | Feed layout (no submodule split) | [architecture.md § Feed layout decision](architecture.md#feed-layout-decision) |
 | Trust boundaries & security invariants | [security-model.md](security-model.md) |
+| Z3 verification (host/CI; #120/#121) | [z3-verification.md](z3-verification.md) |
 | Security review state (coverage, proofs, open findings) | [security-review.md](security-review.md) |
 | Agent orientation (invariants, commands) | [`../../AGENTS.md`](../../AGENTS.md) |
 

--- a/docs/developer/z3-verification.md
+++ b/docs/developer/z3-verification.md
@@ -37,8 +37,8 @@ python3 scripts/z3-verify.py --full
 ## F1 scope note
 
 `is_resolvable_address` first rejects anything outside `[0-9a-fA-F:.]`, then
-validates IPv4/IPv6 shape in awk. F1 proves the **alphabet gate** with Z3
-(length-independent char-class reasoning). Dotted-hex hostnames that use only
-hex letters (e.g. `ab.cd.ef.01`) are alphabet-admissible and are rejected by
-awk — the full suite documents that split so we do not over-claim the alphabet
-layer.
+validates IPv4/IPv6 shape in awk. F1 models the **alphabet gate** in Z3 with a
+quantifier-free char-at encoding **bounded to length ≤ 64** (declared domain —
+not a claim of all-length coverage). Dotted-hex hostnames that use only hex
+letters (e.g. `ab.cd.ef.01`) are alphabet-admissible and are rejected by awk —
+the full suite documents that split so we do not over-claim the alphabet layer.

--- a/docs/developer/z3-verification.md
+++ b/docs/developer/z3-verification.md
@@ -1,0 +1,44 @@
+# Z3 verification (host / CI)
+
+Umbrella: [#120](https://github.com/lucas-albers-lz4/fwlive/issues/120).  
+Deployment: [#121](https://github.com/lucas-albers-lz4/fwlive/issues/121).
+
+Verification is **host and CI only** — never on the OpenWrt device. The epic
+*verifies* regex / address gates; it does not change runtime classifier or
+rpcd behavior (file separate issues for behavior fixes).
+
+## Children
+
+| Child | Issue | Status in harness |
+| ----- | ----- | ----------------- |
+| F1 `is_resolvable_address` alphabet | [#197](https://github.com/lucas-albers-lz4/fwlive/issues/197) | `scripts/z3-verify.py` |
+| F2 CLASSIFY_SPEC | [#198](https://github.com/lucas-albers-lz4/fwlive/issues/198) | planned |
+| F3 adversarial parity | [#199](https://github.com/lucas-albers-lz4/fwlive/issues/199) | planned |
+| F4 parser robustness | [#200](https://github.com/lucas-albers-lz4/fwlive/issues/200) | planned |
+
+## Commands
+
+```sh
+# Pre-commit subset (skip if z3 not installed — CI is authoritative)
+python3 scripts/z3-verify.py --fast
+
+# Full suite (CI)
+pip install 'z3-solver==5.0.0'
+python3 scripts/z3-verify.py --full
+```
+
+## Tiers (#121)
+
+| Tier | Flag | Where |
+| ---- | ---- | ----- |
+| Convenience | `--fast` | `.pre-commit-config.yaml` local hook (skip if no z3) |
+| Enforcement | `--full` | `fwlive-test` workflow job `z3-verify` |
+
+## F1 scope note
+
+`is_resolvable_address` first rejects anything outside `[0-9a-fA-F:.]`, then
+validates IPv4/IPv6 shape in awk. F1 proves the **alphabet gate** with Z3
+(length-independent char-class reasoning). Dotted-hex hostnames that use only
+hex letters (e.g. `ab.cd.ef.01`) are alphabet-admissible and are rejected by
+awk — the full suite documents that split so we do not over-claim the alphabet
+layer.

--- a/docs/developer/z3-verification.md
+++ b/docs/developer/z3-verification.md
@@ -19,10 +19,12 @@ rpcd behavior (file separate issues for behavior fixes).
 ## Commands
 
 ```sh
-# Pre-commit subset (skip if z3 not installed — CI is authoritative)
+# Pre-commit subset (hook skips if z3 not installed — CI is authoritative)
+pre-commit run z3-verify-fast
+# Or, with z3 installed:
 python3 scripts/z3-verify.py --fast
 
-# Full suite (CI)
+# Full suite (CI; requires z3)
 pip install 'z3-solver==5.0.0'
 python3 scripts/z3-verify.py --full
 ```

--- a/scripts/z3-verify.py
+++ b/scripts/z3-verify.py
@@ -161,7 +161,7 @@ def run_f1_full() -> int:
 
 def run_fast() -> int:
 	"""Pre-commit subset (#121); return failure count."""
-	# F2–F4 stubs land in later PRs; F1 only for now.
+	# F2-F4 stubs land in later PRs; F1 only for now.
 	return run_f1_fast()
 
 

--- a/scripts/z3-verify.py
+++ b/scripts/z3-verify.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Host-side Z3 checks for fwlive regex / address sanitation (#120 / #121).
+
+F1: alphabet gate for `is_resolvable_address` in rpcd/fwlive (pre-awk
+`case *[ !0-9a-fA-F:.]*`). Not a full re-encoding of the awk IPv6 grammar.
+
+Usage:
+  ./scripts/z3-verify.py --fast
+  ./scripts/z3-verify.py --full
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+try:
+	from z3 import And, If, Or, Solver, String, StringVal, sat, unsat
+	from z3 import Length, SubString
+except ImportError:  # pragma: no cover
+	print(
+		"error: z3 python module missing (pip install 'z3-solver==5.0.0')",
+		file=sys.stderr,
+	)
+	sys.exit(2)
+
+# Matches the pre-awk case alphabet in is_resolvable_address (#190/#192).
+ADDR_ALPHABET = "0123456789abcdefABCDEF:."
+# Bound for quantifier-free char-at encoding (addresses are short in practice).
+ADDR_MAX_LEN = 64
+
+
+def _char_in(s, i, alphabet: str):
+	"""Z3 OR: character at position i of s is one of alphabet."""
+	return Or(*[SubString(s, i, 1) == StringVal(c) for c in alphabet])
+
+
+def alphabet_ok(s):
+	"""Z3 predicate: non-empty, length ≤ ADDR_MAX_LEN, only ADDR_ALPHABET chars."""
+	n = Length(s)
+	conds = [n >= 1, n <= ADDR_MAX_LEN]
+	for i in range(ADDR_MAX_LEN):
+		conds.append(If(n > i, _char_in(s, i, ADDR_ALPHABET), True))
+	return And(*conds)
+
+
+def check_unsat(name: str, formula) -> bool:
+	"""Assert formula is unsatisfiable; print ok/FAIL and return success."""
+	sol = Solver()
+	sol.add(formula)
+	r = sol.check()
+	if r == unsat:
+		print(f"ok: {name}")
+		return True
+	if r == sat:
+		print(f"FAIL: {name} — unexpected model: {sol.model()}", file=sys.stderr)
+		return False
+	print(f"FAIL: {name} — solver {r}", file=sys.stderr)
+	return False
+
+
+def check_sat(name: str, formula) -> bool:
+	"""Assert formula is satisfiable; print ok/FAIL and return success."""
+	sol = Solver()
+	sol.add(formula)
+	r = sol.check()
+	if r == sat:
+		print(f"ok: {name}")
+		return True
+	print(f"FAIL: {name} — expected sat got {r}", file=sys.stderr)
+	return False
+
+
+def run_f1_fast() -> int:
+	"""F1 --fast: alphabet-level rejection/acceptance; return failure count."""
+	fail = 0
+	a = String("a")
+
+	# Empty rejected
+	if not check_unsat("F1 empty rejected", And(a == StringVal(""), alphabet_ok(a))):
+		fail += 1
+
+	# Shell / whitespace metachars rejected at alphabet gate
+	for label, bad in (
+		("space", "not an ip"),
+		("dollar-paren", "$(reboot)"),
+		("backtick", "`id`"),
+		("slash", "1.2.3.4/24"),
+		("percent", "%s"),
+		("newline-embed", "192.0.2.1\nevil"),
+	):
+		if not check_unsat(
+			f"F1 reject {label}",
+			And(a == StringVal(bad), alphabet_ok(a)),
+		):
+			fail += 1
+
+	# Hostname with non-hex letters rejected (x,m,p,l not in hex alphabet)
+	if not check_unsat(
+		"F1 reject hostname example.com",
+		And(a == StringVal("example.com"), alphabet_ok(a)),
+	):
+		fail += 1
+
+	# Good literals are alphabet-admissible
+	for label, good in (
+		("ipv4", "192.0.2.1"),
+		("ipv6", "2001:db8::1"),
+		("ipv6-loopback", "::1"),
+	):
+		if not check_sat(
+			f"F1 accept alphabet {label}",
+			And(a == StringVal(good), alphabet_ok(a)),
+		):
+			fail += 1
+
+	return fail
+
+
+def run_f1_full() -> int:
+	"""F1 --full: fast suite + dotted-hex / extra metachar corpus."""
+	fail = run_f1_fast()
+	a = String("a")
+
+	# Dotted-hex hostname shapes: may still be alphabet-ok (only hex+dots).
+	# Document domain: alphabet gate alone does NOT reject these; awk does.
+	# Prove they are alphabet-admissible so we do not falsely claim alphabet rejects them.
+	for label, hexish in (
+		("dotted-hex-short", "ab.cd.ef.01"),
+		("dotted-hex-long", "dead.beef.cafe.baad"),
+	):
+		if not check_sat(
+			f"F1 alphabet admits {label} (awk rejects; not alphabet)",
+			And(a == StringVal(hexish), alphabet_ok(a)),
+		):
+			fail += 1
+
+	# Additional metachar corpus
+	for label, bad in (
+		("semicolon", "1;2"),
+		("pipe", "1|2"),
+		("ampersand", "1&2"),
+		("quote", "1'2"),
+		("dquote", '1"2'),
+	):
+		if not check_unsat(
+			f"F1 reject {label}",
+			And(a == StringVal(bad), alphabet_ok(a)),
+		):
+			fail += 1
+
+	return fail
+
+
+def run_fast() -> int:
+	"""Pre-commit subset (#121); return failure count."""
+	# F2–F4 stubs land in later PRs; F1 only for now.
+	return run_f1_fast()
+
+
+def run_full() -> int:
+	"""CI / full suite (#121); return failure count."""
+	return run_f1_full()
+
+
+def main() -> int:
+	"""Parse args and run the fast or full Z3 suite; return process exit code."""
+	ap = argparse.ArgumentParser(description=__doc__)
+	g = ap.add_mutually_exclusive_group()
+	g.add_argument("--fast", action="store_true", help="pre-commit subset")
+	g.add_argument("--full", action="store_true", help="CI / full suite (default)")
+	args = ap.parse_args()
+	mode_full = not args.fast
+	fail = run_full() if mode_full else run_fast()
+	if fail:
+		print(f"z3-verify: {fail} failure(s)", file=sys.stderr)
+		return 1
+	print(f"z3-verify: all ok ({'full' if mode_full else 'fast'})")
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/z3-verify.py
+++ b/scripts/z3-verify.py
@@ -27,7 +27,8 @@ except ImportError:  # pragma: no cover
 
 # Matches the pre-awk case alphabet in is_resolvable_address (#190/#192).
 ADDR_ALPHABET = "0123456789abcdefABCDEF:."
-# Bound for quantifier-free char-at encoding (addresses are short in practice).
+# Bound for quantifier-free char-at encoding. Proofs are valid up to this
+# length (not length-independent). Real addresses are far shorter.
 ADDR_MAX_LEN = 64
 
 
@@ -37,7 +38,12 @@ def _char_in(s, i, alphabet: str):
 
 
 def alphabet_ok(s):
-	"""Z3 predicate: non-empty, length ≤ ADDR_MAX_LEN, only ADDR_ALPHABET chars."""
+	"""Z3 predicate: non-empty, length ≤ ADDR_MAX_LEN, only ADDR_ALPHABET chars.
+
+	Domain: proven for Length(s) in [1, ADDR_MAX_LEN]. Strings longer than
+	ADDR_MAX_LEN are outside this model (shell has no length cap on the case
+	alphabet alone).
+	"""
 	n = Length(s)
 	conds = [n >= 1, n <= ADDR_MAX_LEN]
 	for i in range(ADDR_MAX_LEN):


### PR DESCRIPTION
## Summary
- F1 (#197): host Z3 proofs for `is_resolvable_address` pre-awk alphabet gate
- #121: `--fast` pre-commit hook (skip if no z3) + CI `z3-verify` job (`z3-solver==5.0.0`, `--full`)
- Docs: `docs/developer/z3-verification.md`

Zero runtime/rpcd changes. F2–F4 remain stubs for later PRs (#198–#200).

Closes #197. Partially addresses #121 (F1 wired; F2–F4 hooks TBD).

## Test plan
- [ ] `python3 scripts/z3-verify.py --fast` / `--full` green in CI `z3-verify` job
- [ ] Existing `test` / `zizmor` jobs still green
- [ ] Pre-commit hook skips cleanly without z3 installed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added formal verification for address validation, covering accepted literals and rejected malformed or injection-like inputs.
  - Added fast and full verification modes with clear success or failure reporting.

- **Documentation**
  - Added developer guidance covering verification scope, execution options, validation tiers, and known address-format behavior.

- **Chores**
  - Added continuous integration checks for the full verification suite.
  - Added an optional pre-commit check for fast verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->