### PR TITLE
Security audit remediations (#204, #205, #206)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,17 +1,3 @@
 {
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@playwright/mcp@latest",
-        "--browser=chromium",
-        "--headless",
-        "--isolated",
-        "--viewport-size=1440x900",
-        "--caps=vision",
-        "--output-dir=.cursor/browser-output"
-      ]
-    }
-  }
+  "mcpServers": {}
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,6 @@ address on the GitHub profile.
 
 We aim to acknowledge reports within a few business days and will coordinate
 a fix and disclosure timeline with you.
+
+For security review state (surface coverage, proof classes, open findings),
+see [docs/developer/security-review.md](docs/developer/security-review.md).

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -12,6 +12,14 @@ open. This document is the **record**; it owns no rules.
 Start here before a pass. Do not re-derive the trust boundaries, and do not
 reopen an accepted residual without new evidence.
 
+## Review goals
+
+| Goal | Examples in this repo |
+|------|------------------------|
+| Exploit | Injection, ACL bypass, XSS from log data, privilege escalation |
+| Data corruption / availability | Log pipeline failure, lock issues, UCI sweep |
+| Supply chain | Unpinned tooling, signing keys, feed trust |
+
 ## Why a ledger and not just a model
 
 `security-model.md` states what must be true. It cannot tell you whether anyone
@@ -43,12 +51,16 @@ should carry a note saying what would raise it.
 | Untrusted-input trace (log fields, PTR, URL hash, UCI) | 2026-08-13 | Reproduced | #177: hostile log/PTR/UCI/hash through normalize + render + chips |
 | rpcd plugin + ACL scope | 2026-08-13 | Diff + selftest | #177: no diff since `ce9df02`; read/write split; no `ubus log.*` |
 | Shell helpers — injection and quoting | 2026-08-13 | Read | #177: no log data reaches a command string |
-| Shell helpers — **file modes and lock ownership** | 2026-08-13 | Reproduced | #177: `fwlive-logging-lock.test.sh` 32-trial; lock 0600 |
+| Shell helpers — **file modes and lock ownership** | 2026-08-23 | Reproduced | #204 fix: symlink at lock path rejected; Part E in `fwlive-logging-lock.test.sh`; lock 0600 (Part D) |
 | Shell helpers — **uninstall baseline restore (`prerm`)** | 2026-08-22 | Read + host test | `/etc/fwlive/wan-log-baseline`; restore only on `remove` |
 | Shell helpers — **UCI commit scope and zone grammar** | 2026-08-13 | Host test | #177: pending-delta refuse; named/anonymous/non-zone lookups |
 | Release pipeline — secrets and key handling | 2026-08-18 | Reproduced | #177 key-mode re-run; R7 pin-before-mount + `--network none` ([#179](https://github.com/lucas-albers-lz4/fwlive/issues/179)); 2026-08-18 hardening parity + R7 wrapper fix |
 | Release pipeline — fetch pinning | 2026-08-18 | Read + host test | #177 fetch-pin gate; R7 digest pin-cache (`tests/sdk-matrix-digests.test.sh`); 2026-08-18 wrapper-export + exact-cache-key |
-| Workflow inputs into `run:` bodies | 2026-08-18 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY`; 2026-08-18: dispatch tag validated (control chars, shape, real-tag + HEAD identity) before repo scripts |
+| Workflow inputs into `run:` bodies | 2026-08-23 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY`; 2026-08-18: dispatch tag validated (control chars, shape, real-tag + HEAD identity) before repo scripts |
+| LuCI view (templates / shipped JS) | 2026-08-23 | Read | No new sinks; untrusted values remain text nodes |
+| Package/install surface (Makefiles, prerm, feed layout) | 2026-08-23 | Read | No ACL or path regressions |
+| Build inputs (`feeds.lock`, `package-lock.json`) | 2026-08-23 | Read | Pins intact |
+| Dev tooling (`.cursor/mcp.json`) | 2026-08-23 | Read + fix | #205: unpinned `@playwright/mcp@latest` removed; UI tests use pinned `playwright` devDep |
 
 ## Controls in force
 
@@ -78,13 +90,21 @@ should carry a note saying what would raise it.
 | WAN toggle changes only the zone `log` bit | `host` | `tests/fwlive-logging.test.sh` — pending-delta refuse; named + anonymous zone lookup |
 | Uninstall restores WAN `log` from pre-first-enable baseline | `host` | `tests/fwlive-logging.test.sh` — baseline snapshot/restore; `scripts/qemu-logging-uninstall-smoke.sh` (`lab`) |
 | The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` Part D — create+tighten to 0600 |
+| Lock path rejects symlinks before truncate/chmod/chown | `host` | `tests/fwlive-logging-lock.test.sh` Part E — #204 |
 
 ## Open findings
 
 | ID | Severity | Issue | Summary |
 |----|----------|-------|---------|
-| — | Low | [#190](https://github.com/lucas-albers-lz4/fwlive/issues/190) | `is_resolvable_address` admitted hostname-shaped tokens (dotted-hex) → read-ACL `resolve` sessions could trigger arbitrary upstream DNS via `getent`; strict IPv4/IPv6 validation + selftest cases landed in the fix PR — open until merge |
-| — | Low | [#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) | Global `uci commit firewall` could sweep unrelated staged deltas from non-lock-cooperating writers; mitigated with pre-stage + post-stage foreign gates and post-commit verification — residual window (stage between post-stage check and commit, or same-option races) documented; lab confirmation still pending |
+
+## Verified findings (closed in this ledger)
+
+| ID | Severity | Issue | Summary | Verified |
+|----|----------|-------|---------|----------|
+| Low | [#204](https://github.com/lucas-albers-lz4/fwlive/issues/204) | Predictable lock path opened O_TRUNC without symlink check | `acquire_wan_log_lock` rejects `-L` before create/tighten/open; Part E asserts decoy not truncated | 2026-08-23 — security-audit PR |
+| Low | [#205](https://github.com/lucas-albers-lz4/fwlive/issues/205) | Unpinned `@playwright/mcp@latest` in `.cursor/mcp.json` | MCP entry removed; tests use pinned `playwright@1.60.0` | 2026-08-23 — security-audit PR |
+| Low | [#190](https://github.com/lucas-albers-lz4/fwlive/issues/190) | `is_resolvable_address` hostname-shaped tokens | Strict IPv4/IPv6 validation + selftest cases | merged 2026-08-21 |
+| Low | [#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) | `uci commit firewall` foreign-delta sweep | Pre/post-stage gates + post-commit verification; residual window documented | merged 2026-08-23 |
 
 
 ## Accepted residuals
@@ -245,3 +265,33 @@ mutator.
 **Fix.** Export the wrapper **and** the hidden `.bin` into `tools_dir` and the shared-lib tree (`*.so*` only) into a separate `lib_dir`, mounted as siblings at `/feed/tools` + `/feed/lib` so the wrapper's `../lib` resolution works while `/feed/pkgdir` stays a plain mount. Export runs in the dedicated `sdk-export` compose service (SDK volume only, **no workspace mount**) as the invoking uid — the workspace holds the signing keys, so the export container must never see them; only world-readable `.so*` libs are copied (the 0600 buildbot-owned `meson/` templates are not needed), so root is not required. Sign runs remain `docker run --network none`, no `/builder` mount, digest-pinned image, keys `:ro` — all preserved.
 
 **Result.** `bash -n` clean; actionlint clean; fix verified by re-running the publish workflow (v0.1.34).
+
+### 2026-08-23 — Read-only audit + remediations (#204, #205, #206)
+
+**Scope.** Full-surface read-only pass (log parsing/logging script, rpcd plugin + ACL,
+LuCI view, package/install surface, CI workflows, release + signing, build inputs,
+dev tooling). Filed [#204](https://github.com/lucas-albers-lz4/fwlive/issues/204),
+[#205](https://github.com/lucas-albers-lz4/fwlive/issues/205), [#206](https://github.com/lucas-albers-lz4/fwlive/issues/206).
+
+**Method.** Read-only inspection against `master`; upstream source checks where
+relevant. Two findings remediated in the same PR: symlink guard on the WAN logging
+lock (#204), removal of unpinned `@playwright/mcp@latest` (#205). Ledger refresh
+(#206) records verified state.
+
+**Findings fixed in PR.**
+
+- **#204** — `acquire_wan_log_lock` failed closed on `-L` before create, chmod/chown,
+  and `exec 9>`; Part E in `fwlive-logging-lock.test.sh`.
+- **#205** — `.cursor/mcp.json` playwright MCP removed; UI smoke tests use pinned
+  `playwright@1.60.0` from `package.json`.
+
+**Non-findings** (surfaces examined, clean):
+
+- rpcd plugin + ACL: read/write split; no `ubus log.*`; selftests intact.
+- LuCI view: no new HTML sinks; untrusted values remain text nodes.
+- CI workflows: no `${{ }}` in `run:` bodies; actions SHA-pinned.
+- Release + signing: R7 controls unchanged; no new unpinned fetches.
+- Build inputs: `feeds.lock` / `package-lock.json` pins intact.
+
+**Result.** Open findings table empty. #204/#205 in Verified findings. `SECURITY.md`
+links to this ledger for review state.

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -101,10 +101,10 @@ should carry a note saying what would raise it.
 
 | ID | Severity | Issue | Summary | Verified |
 |----|----------|-------|---------|----------|
-| Low | [#204](https://github.com/lucas-albers-lz4/fwlive/issues/204) | Predictable lock path opened O_TRUNC without symlink check | `acquire_wan_log_lock` rejects `-L` before create/tighten/open; Part E asserts decoy not truncated | 2026-08-23 — security-audit PR |
-| Low | [#205](https://github.com/lucas-albers-lz4/fwlive/issues/205) | Unpinned `@playwright/mcp@latest` in `.cursor/mcp.json` | MCP entry removed; tests use pinned `playwright@1.60.0` | 2026-08-23 — security-audit PR |
-| Low | [#190](https://github.com/lucas-albers-lz4/fwlive/issues/190) | `is_resolvable_address` hostname-shaped tokens | Strict IPv4/IPv6 validation + selftest cases | merged 2026-08-21 |
-| Low | [#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) | `uci commit firewall` foreign-delta sweep | Pre/post-stage gates + post-commit verification; residual window documented | merged 2026-08-23 |
+| [#204](https://github.com/lucas-albers-lz4/fwlive/issues/204) | Low | Predictable lock path opened O_TRUNC without symlink check | Lock under `/etc/fwlive/`; `acquire_wan_log_lock` rejects `-L` before create/tighten/open; Part E | 2026-08-23 — security-audit PR |
+| [#205](https://github.com/lucas-albers-lz4/fwlive/issues/205) | Low | Unpinned `@playwright/mcp@latest` in `.cursor/mcp.json` | MCP entry removed; tests use pinned `playwright@1.60.0` | 2026-08-23 — security-audit PR |
+| [#190](https://github.com/lucas-albers-lz4/fwlive/issues/190) | Low | `is_resolvable_address` hostname-shaped tokens | Strict IPv4/IPv6 validation + selftest cases | merged 2026-08-21 |
+| [#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) | Low | `uci commit firewall` foreign-delta sweep | Pre/post-stage gates + post-commit verification; residual window documented | merged 2026-08-23 |
 
 
 ## Accepted residuals
@@ -280,8 +280,9 @@ lock (#204), removal of unpinned `@playwright/mcp@latest` (#205). Ledger refresh
 
 **Findings fixed in PR.**
 
-- **#204** — `acquire_wan_log_lock` failed closed on `-L` before create, chmod/chown,
-  and `exec 9>`; Part E in `fwlive-logging-lock.test.sh`.
+- **#204** — WAN logging lock moved to `/etc/fwlive/logging.lock` (root-only dir);
+  `acquire_wan_log_lock` fails closed on `-L` before create, chmod/chown, and
+  `exec 9>`; Part E in `fwlive-logging-lock.test.sh`.
 - **#205** — `.cursor/mcp.json` playwright MCP removed; UI smoke tests use pinned
   `playwright@1.60.0` from `package.json`.
 

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -27,9 +27,14 @@ WAN_LOG_BASELINE_FILE="${FWLIVE_WAN_LOG_BASELINE_FILE:-/etc/fwlive/wan-log-basel
 # Create/tighten the lock to 0600 so unprivileged UIDs cannot take LOCK_EX on
 # a world-readable fd (issue #167 / flock(2) allows exclusive locks on O_RDONLY).
 acquire_wan_log_lock() {
+	# Fail closed on a pre-planted symlink: chmod/chown/exec O_TRUNC follow the
+	# target and run as root (#204). Re-check after create/tighten (TOCTOU).
+	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
 	( umask 077; : >> "$WAN_LOG_LOCK_FILE" ) 2>/dev/null || return 1
+	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
 	chmod 0600 "$WAN_LOG_LOCK_FILE" 2>/dev/null || true
 	chown 0:0 "$WAN_LOG_LOCK_FILE" 2>/dev/null || true
+	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
 	exec 9>"$WAN_LOG_LOCK_FILE" 2>/dev/null || return 1
 	flock 9 2>/dev/null || {
 		exec 9>&-

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -18,8 +18,8 @@ NF_LOG_IPV6='/proc/sys/net/netfilter/nf_log/10'
 # the /etc/init.d/firewall reload (can take seconds); the lock is released
 # before reload, and reload-failure rollback is a best-effort UCI write
 # outside the lock.
-# Overridable for tests/containers (default is the production path).
-WAN_LOG_LOCK_FILE="${FWLIVE_WAN_LOG_LOCK_FILE:-/var/lock/fwlive-logging.lock}"
+# Overridable for tests/containers (default is root-only /etc/fwlive).
+WAN_LOG_LOCK_FILE="${FWLIVE_WAN_LOG_LOCK_FILE:-/etc/fwlive/logging.lock}"
 WAN_LOG_BASELINE_FILE="${FWLIVE_WAN_LOG_BASELINE_FILE:-/etc/fwlive/wan-log-baseline}"
 
 # Acquire the exclusive logging lock on fd 9. Blocks until free; fails closed
@@ -27,9 +27,14 @@ WAN_LOG_BASELINE_FILE="${FWLIVE_WAN_LOG_BASELINE_FILE:-/etc/fwlive/wan-log-basel
 # Create/tighten the lock to 0600 so unprivileged UIDs cannot take LOCK_EX on
 # a world-readable fd (issue #167 / flock(2) allows exclusive locks on O_RDONLY).
 acquire_wan_log_lock() {
-	# Fail closed on a pre-planted symlink: chmod/chown/exec O_TRUNC follow the
-	# target and run as root (#204). Re-check after create/tighten (TOCTOU).
+	# Fail closed on symlinks: chmod/chown/exec O_TRUNC follow the target as root
+	# (#204). Default lock lives under /etc/fwlive (root-only), not world-writable
+	# /var/lock. Re-check after create/tighten (TOCTOU).
+	lock_dir="$(dirname "$WAN_LOG_LOCK_FILE")"
+	[ -L "$lock_dir" ] && return 1
 	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
+	( umask 077; mkdir -p "$lock_dir" ) 2>/dev/null || return 1
+	[ -L "$lock_dir" ] && return 1
 	( umask 077; : >> "$WAN_LOG_LOCK_FILE" ) 2>/dev/null || return 1
 	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
 	chmod 0600 "$WAN_LOG_LOCK_FILE" 2>/dev/null || true

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -22,6 +22,20 @@ NF_LOG_IPV6='/proc/sys/net/netfilter/nf_log/10'
 WAN_LOG_LOCK_FILE="${FWLIVE_WAN_LOG_LOCK_FILE:-/etc/fwlive/logging.lock}"
 WAN_LOG_BASELINE_FILE="${FWLIVE_WAN_LOG_BASELINE_FILE:-/etc/fwlive/wan-log-baseline}"
 
+# Production lock dir must be root-owned with no group/other write (#204).
+wan_log_lock_dir_safe() {
+	dir="$1"
+	[ -n "$dir" ] || return 1
+	[ -L "$dir" ] && return 1
+	[ -d "$dir" ] || return 1
+	u=$(stat -c '%u' "$dir" 2>/dev/null) || return 1
+	[ "$u" = "0" ] || return 1
+	m=$(stat -c '%a' "$dir" 2>/dev/null) || return 1
+	o=$((m % 10))
+	g=$(( (m / 10) % 10 ))
+	[ $((o & 2)) -eq 0 ] && [ $((g & 2)) -eq 0 ]
+}
+
 # Acquire the exclusive logging lock on fd 9. Blocks until free; fails closed
 # (return 1) only if the lock file cannot be opened or flock is unavailable.
 # Create/tighten the lock to 0600 so unprivileged UIDs cannot take LOCK_EX on
@@ -35,6 +49,9 @@ acquire_wan_log_lock() {
 	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
 	( umask 077; mkdir -p "$lock_dir" ) 2>/dev/null || return 1
 	[ -L "$lock_dir" ] && return 1
+	if [ -z "${FWLIVE_WAN_LOG_LOCK_FILE:-}" ]; then
+		wan_log_lock_dir_safe "$lock_dir" || return 1
+	fi
 	( umask 077; : >> "$WAN_LOG_LOCK_FILE" ) 2>/dev/null || return 1
 	[ -L "$WAN_LOG_LOCK_FILE" ] && return 1
 	chmod 0600 "$WAN_LOG_LOCK_FILE" 2>/dev/null || true

--- a/tests/fwlive-logging-lock.test.sh
+++ b/tests/fwlive-logging-lock.test.sh
@@ -292,4 +292,16 @@ release_wan_log_lock
 	|| die "pre-existing 0644 lock not tightened (got $(stat_mode "$FWLIVE_WAN_LOG_LOCK_FILE"))"
 ok "pre-existing 0644 lock tightened to 0600"
 
+# --- Part E: symlink at lock path rejected (#204) ----------------------------
+rm -f "$FWLIVE_WAN_LOG_LOCK_FILE"
+decoy="$WORK/decoy-lock-target"
+printf 'precious-content' > "$decoy"
+ln -s "$decoy" "$FWLIVE_WAN_LOG_LOCK_FILE"
+if acquire_wan_log_lock; then
+	die "acquire_wan_log_lock succeeded on symlink lock path"
+fi
+[ "$(cat "$decoy")" = "precious-content" ] \
+	|| die "symlink target truncated (got '$(cat "$decoy")')"
+ok "symlink at lock path rejected; decoy content preserved"
+
 echo "fwlive-logging-lock tests passed"

--- a/tests/fwlive-logging-lock.test.sh
+++ b/tests/fwlive-logging-lock.test.sh
@@ -15,7 +15,7 @@
 # BusyBox note: the production flock helper has no -w timeout, so the
 # critical section stays short (read->compute->set->commit); the firewall
 # reload runs outside the lock. Tests run hermetically by pointing
-# FWLIVE_WAN_LOG_LOCK_FILE at a temp path (default is /var/lock/...).
+# FWLIVE_WAN_LOG_LOCK_FILE at a temp path (default is /etc/fwlive/logging.lock).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

- **#204** — `acquire_wan_log_lock` rejects symlinks (`-L`) before create, chmod/chown, and `exec 9>`; Part E in `fwlive-logging-lock.test.sh` asserts decoy content is not truncated.
- **#205** — Remove unpinned `@playwright/mcp@latest` from `.cursor/mcp.json`; UI smoke tests use pinned `playwright@1.60.0` from `package.json`. Interactive browser debugging can use one-off `npx @playwright/mcp@<pinned>` when needed.
- **#206** — Refresh `docs/developer/security-review.md` with 2026-08-23 audit pass, verified findings for #204/#205, cleared stale #190/#191 open rows; link ledger from `SECURITY.md`.

## Test plan

- [x] `./scripts/fwlive-test.sh`
- [x] `tests/fwlive-logging-lock.test.sh` (Part E symlink rejection)

## Review gates (before marking Ready)

- [ ] CI green
- [ ] Luna review
- [ ] Bugbot
- [ ] Security review
- [ ] CodeRabbit (after `gh pr ready`)

Closes #204, #205, #206


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened WAN logging lock handling by rejecting symlinked directories and lock files.
  * Moved the default logging lock location to `/etc/fwlive/logging.lock`.
  * Added verification that unsafe lock paths fail without modifying their targets.

* **Documentation**
  * Expanded security review coverage, goals, audit history, and verified findings.
  * Updated vulnerability reporting guidance to link to the security review documentation.

* **Chores**
  * Removed the Playwright MCP server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->