### PR TITLE
fix(ci): sdk cache chown must skip buildbot-owned dirs on non-root runners

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -134,6 +134,13 @@ jobs:
 
       - name: Prepare SDK cache dirs
         run: |
+          set -euo pipefail
+          # #208: refuse to mkdir/chown through a symlinked cache path — sudo
+          # chmod -R on a symlinked root would modify the target (luna r10).
+          source ./scripts/lib/sdk-matrix.sh
+          sdk_matrix_reject_symlink_path "$PWD/.ci-sdk-cache" || { echo "cache path must not traverse symlinks" >&2; exit 1; }
+          sdk_matrix_reject_symlink_path "$PWD/.ci-sdk-cache/dl" || { echo "cache path must not traverse symlinks" >&2; exit 1; }
+          sdk_matrix_reject_symlink_path "$PWD/.ci-sdk-cache/feeds" || { echo "cache path must not traverse symlinks" >&2; exit 1; }
           mkdir -p .ci-sdk-cache/dl
           for v in 21.02.7 22.03.7 23.05.5 24.10.8 25.12.5; do
             mkdir -p ".ci-sdk-cache/feeds/$v"
@@ -153,6 +160,12 @@ jobs:
       - name: Fix SDK cache permissions
         if: always()
         run: |
+          set -euo pipefail
+          # #208: never chmod/chown through a symlinked cache path (luna r10).
+          source ./scripts/lib/sdk-matrix.sh
+          sdk_matrix_reject_symlink_path "$PWD/.ci-sdk-cache" || { echo "cache path must not traverse symlinks" >&2; exit 1; }
+          sdk_matrix_reject_symlink_path "$PWD/.ci-sdk-cache/dl" || { echo "cache path must not traverse symlinks" >&2; exit 1; }
+          sdk_matrix_reject_symlink_path "$PWD/.ci-sdk-cache/feeds" || { echo "cache path must not traverse symlinks" >&2; exit 1; }
           # Re-assert ownership after buildbot writes (same least-privilege policy).
           sudo chown -R 1000:1000 .ci-sdk-cache
           sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -87,6 +87,7 @@ should carry a note saying what would raise it.
 | Checkout never writes GITHUB_TOKEN into `.git/config` | `manual` | same workflow — `persist-credentials: false` (workspace is bind-mounted into SDK) |
 | workflow_dispatch tag validated before `GITHUB_ENV` write | `manual` | same workflow — newline/control-char rejection + `^v[0-9]` shape |
 | SDK feed cache key is exact (no `restore-keys` prefix fallback) | `manual` | same workflow — stale feed pins cannot be restored on cache miss |
+| SDK cache dirs owned by buildbot (1000:1000), owner-write + group/other read-traverse; enforced fail-closed pre-build (skipped only when CI pre-chowned both trees, roots AND nested entries; scan errors fail closed) | `host` | `tests/sdk-matrix-cache-owner.test.sh` — #208 (v0.1.36 chown regression) |
 | WAN toggle changes only the zone `log` bit | `host` | `tests/fwlive-logging.test.sh` — pending-delta refuse; named + anonymous zone lookup |
 | Uninstall restores WAN `log` from pre-first-enable baseline | `host` | `tests/fwlive-logging.test.sh` — baseline snapshot/restore; `scripts/qemu-logging-uninstall-smoke.sh` (`lab`) |
 | The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` Part D — create+tighten to 0600 |

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -83,6 +83,9 @@ bash tests/feed-publish-release-assets.test.sh
 echo "== fwlive SDK digest pin-cache (R7) ==" >&2
 bash tests/sdk-matrix-digests.test.sh
 
+echo "== fwlive SDK cache ownership (runner chown regression) ==" >&2
+bash tests/sdk-matrix-cache-owner.test.sh
+
 echo "== fwlive feed-keys mode (0600) ==" >&2
 bash tests/feed-keys-mode.test.sh
 

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -233,27 +233,34 @@ sdk_matrix_cache_dirs() {
 	fi
 	# Nested entries must match too, for root AND non-root callers (a root
 	# caller would otherwise chmod a stray wrong-owned file into a state uid
-	# 1000 cannot write). Scan errors (unreadable subtree) fail closed — a
-	# hidden error must never read as a clean tree.
+	# 1000 cannot write). The scan also validates MODES — buildbot (owner)
+	# must be able to write and the runner (group/other) to read/traverse
+	# (cache save + probe); a correct-owner-but-unwritable cache must not
+	# pass. Scan errors (unreadable subtree) fail closed — a hidden error
+	# must never read as a clean tree.
 	scan_rc=0
-	scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \
-		\( ! -user 1000 -o ! -group 1000 \) -print -quit 2>&1)" || scan_rc=$?
+	scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
+			\( ! -user 1000 -o ! -group 1000 \) -o \
+			\( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) -o \
+			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
+		\) -print -quit 2>&1)" || scan_rc=$?
 	if [[ "$scan_rc" -ne 0 ]]; then
-		echo "sdk-matrix: cannot verify .ci-sdk-cache ownership (scan failed)" >&2
+		echo "sdk-matrix: cannot verify .ci-sdk-cache ownership/modes (scan failed)" >&2
 		echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
 		return 1
 	fi
 	if [[ -n "$scan_out" ]]; then
-		# Wrong-owned entries found: root repairs recursively (tree becomes
-		# uniform); a non-root caller cannot fix them — fail closed.
+		# Wrong ownership or modes found: root repairs recursively (tree
+		# becomes uniform); a non-root caller cannot fix them — fail closed.
 		if [[ "$(id -u)" -eq 0 ]]; then
-			if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
-				echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+			if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null \
+				|| ! chmod -R u=rwX,g=rX,o=rX "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"; then
+				echo "sdk-matrix: cannot fix .ci-sdk-cache ownership/modes (uid 1000 buildbot)" >&2
 				echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
 				return 1
 			fi
 		else
-			echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+			echo "sdk-matrix: cannot fix .ci-sdk-cache ownership/modes (uid 1000 buildbot)" >&2
 			echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
 			return 1
 		fi

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -249,8 +249,14 @@ sdk_matrix_link_ok() {
 		"${feeds_root}"/*) ;;
 		*) return 1 ;;
 	esac
-	[[ "$link" == "${feeds_root}/fwlive" \
-		&& "$(readlink "$link")" == "/work/fwlive/openwrt-feed" ]] && return 0
+	# Exact src-link exception. Raw-byte comparison via readlink -n + cmp:
+	# command substitution strips trailing newlines, which would let a target
+	# '/work/fwlive/openwrt-feed\n' masquerade as the allowed one (luna r16).
+	if [[ "$link" == "${feeds_root}/fwlive" ]] \
+		&& readlink -n "$link" 2>/dev/null \
+			| cmp -s - <(printf '%s' "/work/fwlive/openwrt-feed"); then
+		return 0
+	fi
 	resolved="$(readlink -f "$link" 2>/dev/null)" || return 1
 	case "$resolved" in
 		"${feeds_root}"/*) return 0 ;;
@@ -270,7 +276,7 @@ sdk_matrix_cache_scan() {
 	done
 	out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
 			\( ! -user 1000 -o ! -group 1000 \) -o \
-			\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
+			\( ! -type l \( ! -perm -u+r -o ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
 			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
 			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
 		\) -print -quit 2>&1)" || return 1

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -213,6 +213,11 @@ sdk_matrix_validate_version() {
 # never legitimately behind a symlink or a '..' component.
 sdk_matrix_reject_symlink_path() {
 	local p="$1" head="" comp
+	# read splits on IFS=/ but stops at a newline — reject control characters
+	# so a newline-bearing component cannot truncate the walk (luna r13).
+	case "$p" in
+		*$'\n'* | *$'	'* | *$'\r'*) return 1 ;;
+	esac
 	[[ "$p" == /* ]] && head="/" || head="."
 	IFS=/ read -ra comps <<< "$p"
 	for comp in "${comps[@]}"; do
@@ -246,6 +251,7 @@ sdk_matrix_cache_scan() {
 			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
 			\( -type l ! \( \
 				\( -lname "/work/fwlive/openwrt-feed" -name "fwlive" \) -o \
+				\( -path "${feeds_root}/base" -lname "base_root/package" \) -o \
 				\( -path "${feeds_root}/*" \( -name "*.index" -o -name "*.targetindex" \) \
 					! -lname "/*" ! -lname "*..*" \) \
 			\) \) -o \

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -208,7 +208,7 @@ sdk_matrix_validate_version() {
 }
 
 sdk_matrix_cache_dirs() {
-	local root="$1" version_label="$2" dl_uid dl_gid
+	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
 	SDK_MATRIX_FEEDS_CACHE="${OWRT_SDK_FEEDS_CACHE:-${root}/.ci-sdk-cache/feeds/${version_label}}"
 	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"
@@ -216,21 +216,32 @@ sdk_matrix_cache_dirs() {
 	# Least privilege: own as buildbot; owner rwx only for write; group/other read+traverse.
 	# Fail closed (no world-writable, no ACL mask footguns). CI pre-chowns via
 	# sudo in the workflow "Prepare SDK cache dirs" step, so by the time we run
-	# the dirs are already buildbot-owned — and a non-root runner CANNOT chown
-	# uid-1000-owned files (EPERM, v0.1.36 publish regression). Skip the
-	# mutation when ownership is already correct; enforce only when we can.
-	dl_uid="$(stat -c %u "$SDK_MATRIX_DL_CACHE")"
-	dl_gid="$(stat -c %g "$SDK_MATRIX_DL_CACHE")"
-	if [[ "$dl_uid" != "1000" || "$dl_gid" != "1000" ]]; then
+	# the dirs are usually already buildbot-owned — and a non-root runner CANNOT
+	# chown uid-1000-owned files (EPERM, v0.1.36 publish regression). Skip the
+	# mutation only when BOTH cache trees are fully buildbot-owned; enforce when
+	# we can (root); otherwise fail closed.
+	dl_uid="$(stat -c %u "$SDK_MATRIX_DL_CACHE" 2>/dev/null)" || return 1
+	dl_gid="$(stat -c %g "$SDK_MATRIX_DL_CACHE" 2>/dev/null)" || return 1
+	feeds_uid="$(stat -c %u "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
+	feeds_gid="$(stat -c %g "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
+	if [[ "$dl_uid" != "1000" || "$dl_gid" != "1000" || "$feeds_uid" != "1000" || "$feeds_gid" != "1000" ]]; then
 		if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
 			echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
 			echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
 			return 1
 		fi
 	fi
+	# Nested entries must match too — a non-root runner cannot fix a stray
+	# wrong-owned file inside an otherwise buildbot-owned tree (fail closed).
+	if [[ "$(id -u)" -ne 0 ]] && find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \
+		! -user 1000 -o ! -group 1000 2>/dev/null | grep -q .; then
+		echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+		echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
+		return 1
+	fi
 	# chmod only as root or the owner — the workflow's sudo chown already set
 	# modes in CI, and a non-owner runner cannot chmod either.
-	if [[ "$(id -u)" -eq 0 || "$dl_uid" == "$(id -u)" ]]; then
+	if [[ "$(id -u)" -eq 0 || "$(stat -c %u "$SDK_MATRIX_DL_CACHE" 2>/dev/null)" == "$(id -u)" ]]; then
 		if ! chmod -R u=rwX,g=rX,o=rX "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"; then
 			echo "sdk-matrix: chmod failed on .ci-sdk-cache" >&2
 			return 1

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -220,7 +220,7 @@ sdk_matrix_reject_symlink_path() {
 		*[[:cntrl:]]*) return 1 ;;
 	esac
 	[[ "$p" == /* ]] && head="/" || head="."
-	IFS=/ read -ra comps <<< "$p"
+	IFS=/ read -r -a comps <<< "$p"
 	for comp in "${comps[@]}"; do
 		[[ -z "$comp" || "$comp" == "." ]] && continue
 		[[ "$comp" == ".." ]] && return 1

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -228,17 +228,27 @@ sdk_matrix_reject_symlink_path() {
 # are meaningless (links are always 0777) so mode checks skip them; instead
 # the ALLOWED links are exactly the ones OpenWrt feed setup legitimately
 # creates in the cached feeds tree: the absolute src-link package feed
-# (`/work/fwlive/openwrt-feed`, from feeds.lock src-link fwlive) and the
-# relative `*.index` / `*.targetindex` links `scripts/feeds update` writes
-# (luna r11). Any other symlink is flagged. Print the first violation
-# (-quit); a nonzero status means the scan itself failed (fail closed).
+# (`/work/fwlive/openwrt-feed`, from feeds.lock src-link fwlive, link name
+# `fwlive`) and the relative `*.index` / `*.targetindex` links `scripts/feeds
+# update` writes (luna r11). The index allowlist constrains the TARGET too:
+# relative only (not `/*`) and no `..` components — an absolute or escaping
+# target is a bypass (luna r12). Any other symlink is flagged. Print the
+# first violation (-quit); a nonzero status means the scan failed (fail
+# closed).
 sdk_matrix_cache_scan() {
+	local feeds_root="${SDK_MATRIX_FEEDS_CACHE}"
+	while [[ "$feeds_root" == */ && "$feeds_root" != "/" ]]; do
+		feeds_root="${feeds_root%/}"
+	done
 	find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
 			\( ! -user 1000 -o ! -group 1000 \) -o \
 			\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
 			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
-			\( -type l ! \( -lname "/work/fwlive/openwrt-feed" -o \
-				\( -path "${SDK_MATRIX_FEEDS_CACHE}/*" \( -name "*.index" -o -name "*.targetindex" \) \) \) \) -o \
+			\( -type l ! \( \
+				\( -lname "/work/fwlive/openwrt-feed" -name "fwlive" \) -o \
+				\( -path "${feeds_root}/*" \( -name "*.index" -o -name "*.targetindex" \) \
+					! -lname "/*" ! -lname "*..*" \) \
+			\) \) -o \
 			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
 		\) -print -quit 2>&1
 }
@@ -247,6 +257,14 @@ sdk_matrix_cache_dirs() {
 	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid scan_out scan_rc
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
 	SDK_MATRIX_FEEDS_CACHE="${OWRT_SDK_FEEDS_CACHE:-${root}/.ci-sdk-cache/feeds/${version_label}}"
+	# Normalize trailing slashes on env overrides so -path patterns and
+	# symlink walks see consistent paths (luna r12 Minor).
+	while [[ "$SDK_MATRIX_DL_CACHE" == */ && "$SDK_MATRIX_DL_CACHE" != "/" ]]; do
+		SDK_MATRIX_DL_CACHE="${SDK_MATRIX_DL_CACHE%/}"
+	done
+	while [[ "$SDK_MATRIX_FEEDS_CACHE" == */ && "$SDK_MATRIX_FEEDS_CACHE" != "/" ]]; do
+		SDK_MATRIX_FEEDS_CACHE="${SDK_MATRIX_FEEDS_CACHE%/}"
+	done
 	# Cache roots must be real directories. Validate the path BEFORE any
 	# mutation: mkdir -p through a symlink would create dirs outside the
 	# intended cache tree (luna r9), a regular file in place of a root fails

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -230,18 +230,27 @@ sdk_matrix_reject_symlink_path() {
 	return 0
 }
 
-# A cached-feed symlink is acceptable iff it is the exact src-link exception
-# (fwlive -> /work/fwlive/openwrt-feed — a container path, unresolvable on
-# the host) or its fully-resolved target stays INSIDE the feeds cache tree.
-# The resolution rule covers every legitimate link class at once: the
-# top-level OpenWrt-generated links (base -> base_root/package, *.index /
-# *.targetindex) AND tracked symlinks inside the pinned OpenWrt/LuCI
-# checkouts (base-files os-release, netifd ifdown, LuCI Bootstrap links) —
-# while rejecting absolute-target, escaping (..), and CHAINED links (e.g.
-# evil.index -> fwlive) that resolve outside the cache (luna r14).
+# A cached-feed symlink is acceptable iff it originates INSIDE the feeds
+# cache tree and either is the exact src-link exception (feeds/<ver>/fwlive ->
+# /work/fwlive/openwrt-feed — a container path, unresolvable on the host) or
+# its fully-resolved target stays INSIDE the feeds cache tree. The origin
+# rule blocks location-blind exceptions (a link in dl/ cannot claim the
+# src-link target; luna r15); the resolution rule covers every legitimate
+# link class at once — top-level OpenWrt-generated links (base ->
+# base_root/package, *.index / *.targetindex) AND tracked symlinks inside the
+# pinned OpenWrt/LuCI checkouts (base-files os-release, netifd ifdown, LuCI
+# Bootstrap links) — while rejecting absolute-target, escaping (..), and
+# CHAINED links (e.g. evil.index -> fwlive) that resolve outside the cache
+# (luna r14).
 sdk_matrix_link_ok() {
-	local link="$1" feeds_root="$2" resolved
-	[[ "$(readlink "$link")" == "/work/fwlive/openwrt-feed" ]] && return 0
+	local link="$1" feeds_root="$2" ldir resolved
+	ldir="${link%/*}"
+	case "$ldir/" in
+		"${feeds_root}"/*) ;;
+		*) return 1 ;;
+	esac
+	[[ "$link" == "${feeds_root}/fwlive" \
+		&& "$(readlink "$link")" == "/work/fwlive/openwrt-feed" ]] && return 0
 	resolved="$(readlink -f "$link" 2>/dev/null)" || return 1
 	case "$resolved" in
 		"${feeds_root}"/*) return 0 ;;
@@ -255,7 +264,7 @@ sdk_matrix_link_ok() {
 # first violation; a nonzero status means the scan itself failed (fail
 # closed).
 sdk_matrix_cache_scan() {
-	local feeds_root="$SDK_MATRIX_FEEDS_CACHE" out l
+	local feeds_root="$SDK_MATRIX_FEEDS_CACHE" out l tmp links_rc=0
 	while [[ "$feeds_root" == */ && "$feeds_root" != "/" ]]; do
 		feeds_root="${feeds_root%/}"
 	done
@@ -266,13 +275,25 @@ sdk_matrix_cache_scan() {
 			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
 		\) -print -quit 2>&1)" || return 1
 	[[ -n "$out" ]] && { printf '%s\n' "$out"; return 0; }
-	while IFS= read -r l; do
+	# NUL-delimited enumeration via a temp file (command substitution would
+	# strip NULs and concatenate paths): a newline-bearing link NAME must not
+	# split the list (luna r15), and find's own status fails closed (luna r15
+	# Minor).
+	tmp="$(mktemp)" || return 1
+	find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" -type l -print0 > "$tmp" 2>/dev/null || links_rc=$?
+	if [[ "$links_rc" -ne 0 ]]; then
+		rm -f "$tmp"
+		return 1
+	fi
+	while IFS= read -r -d '' l; do
 		[[ -n "$l" ]] || continue
 		if ! sdk_matrix_link_ok "$l" "$feeds_root"; then
 			printf '%s\n' "$l"
+			rm -f "$tmp"
 			return 0
 		fi
-	done < <(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" -type l -print 2>/dev/null)
+	done < "$tmp"
+	rm -f "$tmp"
 	return 0
 }
 

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -224,6 +224,25 @@ sdk_matrix_reject_symlink_path() {
 	return 0
 }
 
+# Scan both cache trees for ownership/mode/symlink violations. Symlink modes
+# are meaningless (links are always 0777) so mode checks skip them; instead
+# the ALLOWED links are exactly the ones OpenWrt feed setup legitimately
+# creates in the cached feeds tree: the absolute src-link package feed
+# (`/work/fwlive/openwrt-feed`, from feeds.lock src-link fwlive) and the
+# relative `*.index` / `*.targetindex` links `scripts/feeds update` writes
+# (luna r11). Any other symlink is flagged. Print the first violation
+# (-quit); a nonzero status means the scan itself failed (fail closed).
+sdk_matrix_cache_scan() {
+	find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
+			\( ! -user 1000 -o ! -group 1000 \) -o \
+			\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
+			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
+			\( -type l ! \( -lname "/work/fwlive/openwrt-feed" -o \
+				\( -path "${SDK_MATRIX_FEEDS_CACHE}/*" \( -name "*.index" -o -name "*.targetindex" \) \) \) \) -o \
+			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
+		\) -print -quit 2>&1
+}
+
 sdk_matrix_cache_dirs() {
 	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid scan_out scan_rc
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
@@ -278,13 +297,7 @@ sdk_matrix_cache_dirs() {
 	# feed materializes. Scan errors (unreadable subtree) fail closed — a
 	# hidden error must never read as a clean tree.
 	scan_rc=0
-	scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
-			\( ! -user 1000 -o ! -group 1000 \) -o \
-			\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
-			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
-			\( -type l ! -lname "/work/fwlive/openwrt-feed" \) -o \
-			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
-		\) -print -quit 2>&1)" || scan_rc=$?
+	scan_out="$(sdk_matrix_cache_scan)" || scan_rc=$?
 	if [[ "$scan_rc" -ne 0 ]]; then
 		echo "sdk-matrix: cannot verify .ci-sdk-cache ownership/modes (scan failed)" >&2
 		echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
@@ -304,13 +317,7 @@ sdk_matrix_cache_dirs() {
 				return 1
 			fi
 			scan_rc=0
-			scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
-					\( ! -user 1000 -o ! -group 1000 \) -o \
-					\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
-					\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
-					\( -type l ! -lname "/work/fwlive/openwrt-feed" \) -o \
-					\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
-				\) -print -quit 2>&1)" || scan_rc=$?
+			scan_out="$(sdk_matrix_cache_scan)" || scan_rc=$?
 			if [[ "$scan_rc" -ne 0 || -n "$scan_out" ]]; then
 				echo "sdk-matrix: cannot repair .ci-sdk-cache (unresolvable ownership/mode/symlink state)" >&2
 				echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -208,21 +208,33 @@ sdk_matrix_validate_version() {
 }
 
 sdk_matrix_cache_dirs() {
-	local root="$1" version_label="$2"
+	local root="$1" version_label="$2" dl_uid dl_gid
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
 	SDK_MATRIX_FEEDS_CACHE="${OWRT_SDK_FEEDS_CACHE:-${root}/.ci-sdk-cache/feeds/${version_label}}"
 	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"
 	# buildbot (uid 1000) must write bind mounts; Actions runner is often 1001.
 	# Least privilege: own as buildbot; owner rwx only for write; group/other read+traverse.
-	# Fail closed (no world-writable, no ACL mask footguns). CI uses sudo chown first.
-	if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
-		echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
-		echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
-		return 1
+	# Fail closed (no world-writable, no ACL mask footguns). CI pre-chowns via
+	# sudo in the workflow "Prepare SDK cache dirs" step, so by the time we run
+	# the dirs are already buildbot-owned — and a non-root runner CANNOT chown
+	# uid-1000-owned files (EPERM, v0.1.36 publish regression). Skip the
+	# mutation when ownership is already correct; enforce only when we can.
+	dl_uid="$(stat -c %u "$SDK_MATRIX_DL_CACHE")"
+	dl_gid="$(stat -c %g "$SDK_MATRIX_DL_CACHE")"
+	if [[ "$dl_uid" != "1000" || "$dl_gid" != "1000" ]]; then
+		if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
+			echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+			echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
+			return 1
+		fi
 	fi
-	if ! chmod -R u=rwX,g=rX,o=rX "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"; then
-		echo "sdk-matrix: chmod failed on .ci-sdk-cache" >&2
-		return 1
+	# chmod only as root or the owner — the workflow's sudo chown already set
+	# modes in CI, and a non-owner runner cannot chmod either.
+	if [[ "$(id -u)" -eq 0 || "$dl_uid" == "$(id -u)" ]]; then
+		if ! chmod -R u=rwX,g=rX,o=rX "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"; then
+			echo "sdk-matrix: chmod failed on .ci-sdk-cache" >&2
+			return 1
+		fi
 	fi
 }
 

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -271,13 +271,18 @@ sdk_matrix_cache_dirs() {
 	# 1000 cannot write). The scan also validates MODES — buildbot (owner)
 	# must be able to write and the runner (group/other) to read/traverse
 	# (cache save + probe); a correct-owner-but-unwritable cache must not
-	# pass. Scan errors (unreadable subtree) fail closed — a hidden error
-	# must never read as a clean tree.
+	# pass, and group/other WRITE bits are rejected (least privilege). Symlink
+	# modes are meaningless (links are always 0777) so mode checks skip them;
+	# instead the ONLY symlink allowed anywhere in the trees is the feeds
+	# src-link (`/work/fwlive/openwrt-feed`), which is how the local package
+	# feed materializes. Scan errors (unreadable subtree) fail closed — a
+	# hidden error must never read as a clean tree.
 	scan_rc=0
 	scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
 			\( ! -user 1000 -o ! -group 1000 \) -o \
-			\( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) -o \
-			\( -perm -g+w -o -perm -o+w \) -o \
+			\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
+			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
+			\( -type l ! -lname "/work/fwlive/openwrt-feed" \) -o \
 			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
 		\) -print -quit 2>&1)" || scan_rc=$?
 	if [[ "$scan_rc" -ne 0 ]]; then
@@ -286,12 +291,28 @@ sdk_matrix_cache_dirs() {
 		return 1
 	fi
 	if [[ -n "$scan_out" ]]; then
-		# Wrong ownership or modes found: root repairs recursively (tree
-		# becomes uniform); a non-root caller cannot fix them — fail closed.
+		# Wrong ownership, modes, or disallowed symlinks found: root repairs
+		# recursively (tree becomes uniform); a non-root caller cannot fix
+		# them — fail closed. Root RESCANS after repair: chmod cannot change
+		# symlink modes, so a still-flagged tree (e.g. a disallowed symlink)
+		# fails closed (luna r10).
 		if [[ "$(id -u)" -eq 0 ]]; then
 			if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null \
 				|| ! chmod -R u=rwX,g=rX,o=rX "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"; then
 				echo "sdk-matrix: cannot fix .ci-sdk-cache ownership/modes (uid 1000 buildbot)" >&2
+				echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
+				return 1
+			fi
+			scan_rc=0
+			scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
+					\( ! -user 1000 -o ! -group 1000 \) -o \
+					\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
+					\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
+					\( -type l ! -lname "/work/fwlive/openwrt-feed" \) -o \
+					\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
+				\) -print -quit 2>&1)" || scan_rc=$?
+			if [[ "$scan_rc" -ne 0 || -n "$scan_out" ]]; then
+				echo "sdk-matrix: cannot repair .ci-sdk-cache (unresolvable ownership/mode/symlink state)" >&2
 				echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
 				return 1
 			fi

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -213,10 +213,11 @@ sdk_matrix_validate_version() {
 # never legitimately behind a symlink or a '..' component.
 sdk_matrix_reject_symlink_path() {
 	local p="$1" head="" comp
-	# read splits on IFS=/ but stops at a newline — reject control characters
-	# so a newline-bearing component cannot truncate the walk (luna r13).
+	# read splits on IFS=/ but stops at a newline — reject all control
+	# characters so a control-bearing component cannot truncate the walk
+	# (luna r13/r14).
 	case "$p" in
-		*$'\n'* | *$'	'* | *$'\r'*) return 1 ;;
+		*[[:cntrl:]]*) return 1 ;;
 	esac
 	[[ "$p" == /* ]] && head="/" || head="."
 	IFS=/ read -ra comps <<< "$p"
@@ -229,34 +230,50 @@ sdk_matrix_reject_symlink_path() {
 	return 0
 }
 
+# A cached-feed symlink is acceptable iff it is the exact src-link exception
+# (fwlive -> /work/fwlive/openwrt-feed — a container path, unresolvable on
+# the host) or its fully-resolved target stays INSIDE the feeds cache tree.
+# The resolution rule covers every legitimate link class at once: the
+# top-level OpenWrt-generated links (base -> base_root/package, *.index /
+# *.targetindex) AND tracked symlinks inside the pinned OpenWrt/LuCI
+# checkouts (base-files os-release, netifd ifdown, LuCI Bootstrap links) —
+# while rejecting absolute-target, escaping (..), and CHAINED links (e.g.
+# evil.index -> fwlive) that resolve outside the cache (luna r14).
+sdk_matrix_link_ok() {
+	local link="$1" feeds_root="$2" resolved
+	[[ "$(readlink "$link")" == "/work/fwlive/openwrt-feed" ]] && return 0
+	resolved="$(readlink -f "$link" 2>/dev/null)" || return 1
+	case "$resolved" in
+		"${feeds_root}"/*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
 # Scan both cache trees for ownership/mode/symlink violations. Symlink modes
-# are meaningless (links are always 0777) so mode checks skip them; instead
-# the ALLOWED links are exactly the ones OpenWrt feed setup legitimately
-# creates in the cached feeds tree: the absolute src-link package feed
-# (`/work/fwlive/openwrt-feed`, from feeds.lock src-link fwlive, link name
-# `fwlive`) and the relative `*.index` / `*.targetindex` links `scripts/feeds
-# update` writes (luna r11). The index allowlist constrains the TARGET too:
-# relative only (not `/*`) and no `..` components — an absolute or escaping
-# target is a bypass (luna r12). Any other symlink is flagged. Print the
-# first violation (-quit); a nonzero status means the scan failed (fail
+# are meaningless (links are always 0777) so mode checks skip them; symlinks
+# are validated by sdk_matrix_link_ok (resolution-based, luna r14). Print the
+# first violation; a nonzero status means the scan itself failed (fail
 # closed).
 sdk_matrix_cache_scan() {
-	local feeds_root="${SDK_MATRIX_FEEDS_CACHE}"
+	local feeds_root="$SDK_MATRIX_FEEDS_CACHE" out l
 	while [[ "$feeds_root" == */ && "$feeds_root" != "/" ]]; do
 		feeds_root="${feeds_root%/}"
 	done
-	find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
+	out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
 			\( ! -user 1000 -o ! -group 1000 \) -o \
 			\( ! -type l \( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) \) -o \
 			\( ! -type l \( -perm -g+w -o -perm -o+w \) \) -o \
-			\( -type l ! \( \
-				\( -lname "/work/fwlive/openwrt-feed" -name "fwlive" \) -o \
-				\( -path "${feeds_root}/base" -lname "base_root/package" \) -o \
-				\( -path "${feeds_root}/*" \( -name "*.index" -o -name "*.targetindex" \) \
-					! -lname "/*" ! -lname "*..*" \) \
-			\) \) -o \
 			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
-		\) -print -quit 2>&1
+		\) -print -quit 2>&1)" || return 1
+	[[ -n "$out" ]] && { printf '%s\n' "$out"; return 0; }
+	while IFS= read -r l; do
+		[[ -n "$l" ]] || continue
+		if ! sdk_matrix_link_ok "$l" "$feeds_root"; then
+			printf '%s\n' "$l"
+			return 0
+		fi
+	done < <(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" -type l -print 2>/dev/null)
+	return 0
 }
 
 sdk_matrix_cache_dirs() {

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -208,7 +208,7 @@ sdk_matrix_validate_version() {
 }
 
 sdk_matrix_cache_dirs() {
-	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid
+	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid scan_out scan_rc
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
 	SDK_MATRIX_FEEDS_CACHE="${OWRT_SDK_FEEDS_CACHE:-${root}/.ci-sdk-cache/feeds/${version_label}}"
 	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"
@@ -231,13 +231,32 @@ sdk_matrix_cache_dirs() {
 			return 1
 		fi
 	fi
-	# Nested entries must match too — a non-root runner cannot fix a stray
-	# wrong-owned file inside an otherwise buildbot-owned tree (fail closed).
-	if [[ "$(id -u)" -ne 0 ]] && find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \
-		! -user 1000 -o ! -group 1000 2>/dev/null | grep -q .; then
-		echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+	# Nested entries must match too, for root AND non-root callers (a root
+	# caller would otherwise chmod a stray wrong-owned file into a state uid
+	# 1000 cannot write). Scan errors (unreadable subtree) fail closed — a
+	# hidden error must never read as a clean tree.
+	scan_rc=0
+	scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \
+		\( ! -user 1000 -o ! -group 1000 \) -print -quit 2>&1)" || scan_rc=$?
+	if [[ "$scan_rc" -ne 0 ]]; then
+		echo "sdk-matrix: cannot verify .ci-sdk-cache ownership (scan failed)" >&2
 		echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
 		return 1
+	fi
+	if [[ -n "$scan_out" ]]; then
+		# Wrong-owned entries found: root repairs recursively (tree becomes
+		# uniform); a non-root caller cannot fix them — fail closed.
+		if [[ "$(id -u)" -eq 0 ]]; then
+			if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
+				echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+				echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
+				return 1
+			fi
+		else
+			echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2
+			echo "sdk-matrix: run once: sudo chown -R 1000:1000 .ci-sdk-cache && sudo chmod -R u=rwX,g=rX,o=rX .ci-sdk-cache" >&2
+			return 1
+		fi
 	fi
 	# chmod only as root or the owner — the workflow's sudo chown already set
 	# modes in CI, and a non-owner runner cannot chmod either.

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -225,9 +225,24 @@ sdk_matrix_cache_dirs() {
 	feeds_uid="$(stat -c %u "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
 	feeds_gid="$(stat -c %g "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
 	# Cache roots must be real directories — a symlinked root changes what the
-	# bind mount exposes (stat follows the link, find does not; chown -R
-	# repairs the target, not the link) and cannot be repaired safely (luna r5).
-	if [[ -L "$SDK_MATRIX_DL_CACHE" || -L "$SDK_MATRIX_FEEDS_CACHE" ]]; then
+	# bind mount exposes (lstat sees the link; the mount and recursive chown
+	# operate on the resolved target) and cannot be repaired safely (luna r5).
+	# Normalize trailing '/' and '/.' first: the shell resolves 'link/' to the
+	# target, which would bypass a bare -L test (luna r6).
+	local dl_root feeds_root
+	dl_root="${SDK_MATRIX_DL_CACHE}"
+	feeds_root="${SDK_MATRIX_FEEDS_CACHE}"
+	while [[ "$dl_root" == */ || "$dl_root" == */. ]]; do
+		dl_root="${dl_root%/}"
+		dl_root="${dl_root%/.}"
+	done
+	while [[ "$feeds_root" == */ || "$feeds_root" == */. ]]; do
+		feeds_root="${feeds_root%/}"
+		feeds_root="${feeds_root%/.}"
+	done
+	[[ -z "$dl_root" ]] && dl_root="/"
+	[[ -z "$feeds_root" ]] && feeds_root="/"
+	if [[ -L "$dl_root" || -L "$feeds_root" ]]; then
 		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
 		return 1
 	fi

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -207,11 +207,44 @@ sdk_matrix_validate_version() {
 	return 1
 }
 
+# Reject a cache-root path containing any symlink component or '..' (luna r8:
+# a final-component -L test is bypassed by 'dl/sub/..' / 'dl/./sub' spellings
+# that resolve through the link to a real final component). Cache roots are
+# never legitimately behind a symlink or a '..' component.
+sdk_matrix_reject_symlink_path() {
+	local p="$1" head="" comp
+	[[ "$p" == /* ]] && head="/"
+	IFS=/ read -ra comps <<< "$p"
+	for comp in "${comps[@]}"; do
+		[[ -z "$comp" || "$comp" == "." ]] && continue
+		[[ "$comp" == ".." ]] && return 1
+		head="${head%/}/$comp"
+		[[ -L "$head" ]] && return 1
+	done
+	return 0
+}
+
 sdk_matrix_cache_dirs() {
 	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid scan_out scan_rc
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
 	SDK_MATRIX_FEEDS_CACHE="${OWRT_SDK_FEEDS_CACHE:-${root}/.ci-sdk-cache/feeds/${version_label}}"
-	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE"
+	# Cache roots must be real directories. Fail closed BEFORE any mutation:
+	# mkdir failure, a regular file in place of a root, or a symlink ANYWHERE
+	# in the root path (component-wise lstat — a final-component -L test is
+	# bypassed by 'dl/sub/..' / 'dl/./sub' spellings; luna r8).
+	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" || return 1
+	if [[ ! -d "$SDK_MATRIX_DL_CACHE" || ! -d "$SDK_MATRIX_FEEDS_CACHE" ]]; then
+		echo "sdk-matrix: .ci-sdk-cache roots must be directories" >&2
+		return 1
+	fi
+	sdk_matrix_reject_symlink_path "$SDK_MATRIX_DL_CACHE" || {
+		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
+		return 1
+	}
+	sdk_matrix_reject_symlink_path "$SDK_MATRIX_FEEDS_CACHE" || {
+		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
+		return 1
+	}
 	# buildbot (uid 1000) must write bind mounts; Actions runner is often 1001.
 	# Least privilege: own as buildbot; owner rwx only for write; group/other read+traverse.
 	# Fail closed (no world-writable, no ACL mask footguns). CI pre-chowns via
@@ -224,28 +257,6 @@ sdk_matrix_cache_dirs() {
 	dl_gid="$(stat -c %g "$SDK_MATRIX_DL_CACHE" 2>/dev/null)" || return 1
 	feeds_uid="$(stat -c %u "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
 	feeds_gid="$(stat -c %g "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
-	# Cache roots must be real directories — a symlinked root changes what the
-	# bind mount exposes (lstat sees the link; the mount and recursive chown
-	# operate on the resolved target) and cannot be repaired safely (luna r5).
-	# Normalize trailing '/' and '/.' first: the shell resolves 'link/' to the
-	# target, which would bypass a bare -L test (luna r6).
-	local dl_root feeds_root
-	dl_root="${SDK_MATRIX_DL_CACHE}"
-	feeds_root="${SDK_MATRIX_FEEDS_CACHE}"
-	while [[ "$dl_root" == */ || "$dl_root" == */. ]]; do
-		dl_root="${dl_root%/}"
-		dl_root="${dl_root%/.}"
-	done
-	while [[ "$feeds_root" == */ || "$feeds_root" == */. ]]; do
-		feeds_root="${feeds_root%/}"
-		feeds_root="${feeds_root%/.}"
-	done
-	[[ -z "$dl_root" ]] && dl_root="/"
-	[[ -z "$feeds_root" ]] && feeds_root="/"
-	if [[ -L "$dl_root" || -L "$feeds_root" ]]; then
-		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
-		return 1
-	fi
 	if [[ "$dl_uid" != "1000" || "$dl_gid" != "1000" || "$feeds_uid" != "1000" || "$feeds_gid" != "1000" ]]; then
 		if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
 			echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -224,6 +224,13 @@ sdk_matrix_cache_dirs() {
 	dl_gid="$(stat -c %g "$SDK_MATRIX_DL_CACHE" 2>/dev/null)" || return 1
 	feeds_uid="$(stat -c %u "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
 	feeds_gid="$(stat -c %g "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null)" || return 1
+	# Cache roots must be real directories — a symlinked root changes what the
+	# bind mount exposes (stat follows the link, find does not; chown -R
+	# repairs the target, not the link) and cannot be repaired safely (luna r5).
+	if [[ -L "$SDK_MATRIX_DL_CACHE" || -L "$SDK_MATRIX_FEEDS_CACHE" ]]; then
+		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
+		return 1
+	fi
 	if [[ "$dl_uid" != "1000" || "$dl_gid" != "1000" || "$feeds_uid" != "1000" || "$feeds_gid" != "1000" ]]; then
 		if ! chown -R 1000:1000 "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" 2>/dev/null; then
 			echo "sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)" >&2

--- a/scripts/lib/sdk-matrix.sh
+++ b/scripts/lib/sdk-matrix.sh
@@ -213,7 +213,7 @@ sdk_matrix_validate_version() {
 # never legitimately behind a symlink or a '..' component.
 sdk_matrix_reject_symlink_path() {
 	local p="$1" head="" comp
-	[[ "$p" == /* ]] && head="/"
+	[[ "$p" == /* ]] && head="/" || head="."
 	IFS=/ read -ra comps <<< "$p"
 	for comp in "${comps[@]}"; do
 		[[ -z "$comp" || "$comp" == "." ]] && continue
@@ -228,15 +228,12 @@ sdk_matrix_cache_dirs() {
 	local root="$1" version_label="$2" dl_uid dl_gid feeds_uid feeds_gid scan_out scan_rc
 	SDK_MATRIX_DL_CACHE="${OWRT_SDK_DL_CACHE:-${root}/.ci-sdk-cache/dl}"
 	SDK_MATRIX_FEEDS_CACHE="${OWRT_SDK_FEEDS_CACHE:-${root}/.ci-sdk-cache/feeds/${version_label}}"
-	# Cache roots must be real directories. Fail closed BEFORE any mutation:
-	# mkdir failure, a regular file in place of a root, or a symlink ANYWHERE
-	# in the root path (component-wise lstat — a final-component -L test is
-	# bypassed by 'dl/sub/..' / 'dl/./sub' spellings; luna r8).
-	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" || return 1
-	if [[ ! -d "$SDK_MATRIX_DL_CACHE" || ! -d "$SDK_MATRIX_FEEDS_CACHE" ]]; then
-		echo "sdk-matrix: .ci-sdk-cache roots must be directories" >&2
-		return 1
-	fi
+	# Cache roots must be real directories. Validate the path BEFORE any
+	# mutation: mkdir -p through a symlink would create dirs outside the
+	# intended cache tree (luna r9), a regular file in place of a root fails
+	# closed, and a symlink ANYWHERE in the root path fails closed
+	# (component-wise lstat — a final-component -L test is bypassed by
+	# 'dl/sub/..' / 'dl/./sub' spellings; luna r8).
 	sdk_matrix_reject_symlink_path "$SDK_MATRIX_DL_CACHE" || {
 		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
 		return 1
@@ -245,6 +242,11 @@ sdk_matrix_cache_dirs() {
 		echo "sdk-matrix: .ci-sdk-cache roots must be real directories, not symlinks" >&2
 		return 1
 	}
+	mkdir -p "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" || return 1
+	if [[ ! -d "$SDK_MATRIX_DL_CACHE" || ! -d "$SDK_MATRIX_FEEDS_CACHE" ]]; then
+		echo "sdk-matrix: .ci-sdk-cache roots must be directories" >&2
+		return 1
+	fi
 	# buildbot (uid 1000) must write bind mounts; Actions runner is often 1001.
 	# Least privilege: own as buildbot; owner rwx only for write; group/other read+traverse.
 	# Fail closed (no world-writable, no ACL mask footguns). CI pre-chowns via
@@ -275,6 +277,7 @@ sdk_matrix_cache_dirs() {
 	scan_out="$(find "$SDK_MATRIX_DL_CACHE" "$SDK_MATRIX_FEEDS_CACHE" \( \
 			\( ! -user 1000 -o ! -group 1000 \) -o \
 			\( ! -perm -u+w -o ! -perm -g+r -o ! -perm -o+r \) -o \
+			\( -perm -g+w -o -perm -o+w \) -o \
 			\( -type d \( ! -perm -u+x -o ! -perm -g+x -o ! -perm -o+x \) \) \
 		\) -print -quit 2>&1)" || scan_rc=$?
 	if [[ "$scan_rc" -ne 0 ]]; then
@@ -311,7 +314,7 @@ sdk_matrix_cache_dirs() {
 sdk_matrix_compose_run() {
 	local root
 	root="$(sdk_matrix_root)"
-	sdk_matrix_cache_dirs "$root" "$SDK_MATRIX_VERSION_LABEL"
+	sdk_matrix_cache_dirs "$root" "$SDK_MATRIX_VERSION_LABEL" || return 1
 	(
 		cd "$root"
 		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \
@@ -492,7 +495,7 @@ sdk_matrix_copy_out() {
 	mkdir -p "$dest_host"
 	# SDK image runs as buildbot (uid 1000); GHA workspace is often uid 1001 — copy as root.
 	# Pass the same dl/feeds bind mounts as compose_run so defaults do not clobber /builder.
-	sdk_matrix_cache_dirs "$root" "$SDK_MATRIX_VERSION_LABEL"
+	sdk_matrix_cache_dirs "$root" "$SDK_MATRIX_VERSION_LABEL" || return 1
 	(
 		cd "$root"
 		OWRT_SDK_IMAGE="$SDK_MATRIX_IMAGE" \

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -100,6 +100,15 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "unreadable subtree fails closed for a non-root runner"
 	fi
+	# Case 7: fail-closed — correct ownership but unwritable modes (owner
+	# 1000, 0555): buildbot cannot write the cache, must not pass.
+	prep_workflow
+	$SUDO chmod -R 555 "$DL"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "unwritable modes must fail closed for a non-root runner"
+	else
+		ok "unwritable modes fail closed for a non-root runner"
+	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -10,9 +10,12 @@
 #
 # Correct behavior: skip chown only when BOTH cache trees are fully
 # buildbot-owned (roots AND nested entries, verified by a scan that fails
-# closed on errors) and only chmod as root/owner; wrong ownership is repaired
-# by root or fails closed for non-root. Non-root needs passwordless sudo to
-# set up buildbot-owned dirs (SKIPs otherwise); root runs without sudo.
+# closed on errors) with buildbot-writable modes; roots must be real
+# directories (no symlinks, no trailing-slash bypass); wrong ownership/modes
+# are repaired by root or fail closed for non-root. Non-root needs
+# passwordless sudo to set up buildbot-owned dirs (SKIPs otherwise); root
+# runs without sudo. Each case isolates ONE root as the fault so the other
+# cannot mask a regression (luna r7).
 # shellcheck disable=SC2317
 set -euo pipefail
 
@@ -48,6 +51,21 @@ export OWRT_SDK_DL_CACHE="$DL" OWRT_SDK_FEEDS_CACHE="$FEEDS"
 prep_workflow() {
 	$SUDO chown -R 1000:1000 "$WORK"
 	$SUDO chmod -R u=rwX,g=rX,o=rX "$WORK"
+}
+
+# Replace a root with a real, valid buildbot-owned directory (isolates the
+# other root as the single fault in each case).
+restore_root() {
+	$SUDO rm -rf "$1"
+	$SUDO mkdir -p "$1"
+	$SUDO chown 1000:1000 "$1"
+	$SUDO chmod u=rwX,g=rX,o=rX "$1"
+}
+
+symlink_root() {
+	$SUDO rm -rf "$1"
+	$SUDO ln -s "$2" "$1"
+	$SUDO mkdir -p "$2"
 }
 
 # Case 1 (the regression): CI state — both trees buildbot-owned. Must pass
@@ -108,39 +126,38 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "unwritable modes fail closed for a non-root runner"
 	fi
-	# Case 8: fail-closed — symlinked cache root: stat follows the link while
-	# find/chown do not; the mount would expose the target (luna r5).
+	# Case 8: fail-closed — symlinked DL root (FEEDS stays a real dir; luna r5).
 	prep_workflow
-	$SUDO rm -rf "$DL"
-	$SUDO ln -s "$WORK/dl-target" "$DL"
-	$SUDO mkdir -p "$WORK/dl-target"
+	symlink_root "$DL" "$WORK/dl-target"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "symlinked cache root must fail closed for a non-root runner"
 	else
 		ok "symlinked cache root fails closed for a non-root runner"
 	fi
-	# Case 10: fail-closed — symlinked FEEDS root (each root is checked).
+	# Case 10: fail-closed — symlinked FEEDS root (DL restored to a real dir,
+	# so the FEEDS symlink is the single fault; luna r7).
 	prep_workflow
-	$SUDO rm -rf "$FEEDS"
-	$SUDO ln -s "$WORK/feeds-target" "$FEEDS"
-	$SUDO mkdir -p "$WORK/feeds-target"
+	restore_root "$DL"
+	symlink_root "$FEEDS" "$WORK/feeds-target"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "symlinked feeds root must fail closed for a non-root runner"
 	else
 		ok "symlinked feeds root fails closed for a non-root runner"
 	fi
-	# Case 11: fail-closed — trailing-slash form of a symlinked root ('dl/'
-	# resolves to the target) must not bypass the symlink rejection (luna r6).
+	# Case 11: fail-closed — trailing forms of a symlinked DL root (FEEDS
+	# restored): 'dl/', 'dl//', 'dl/.' must not bypass the -L rejection
+	# (luna r6/r7).
 	prep_workflow
-	$SUDO rm -rf "$DL"
-	$SUDO ln -s "$WORK/dl-target" "$DL"
-	$SUDO mkdir -p "$WORK/dl-target"
-	export OWRT_SDK_DL_CACHE="$DL/"
-	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
-		bad "trailing-slash symlinked root must fail closed for a non-root runner"
-	else
-		ok "trailing-slash symlinked root fails closed for a non-root runner"
-	fi
+	restore_root "$FEEDS"
+	symlink_root "$DL" "$WORK/dl-target"
+	for _form in "$DL/" "$DL//" "$DL/."; do
+		export OWRT_SDK_DL_CACHE="$_form"
+		if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+			bad "trailing form '$_form' of symlinked root must fail closed for a non-root runner"
+		else
+			ok "trailing form '$_form' of symlinked root fails closed for a non-root runner"
+		fi
+	done
 	export OWRT_SDK_DL_CACHE="$DL"
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
@@ -158,22 +175,20 @@ else
 	else
 		bad "root caller must succeed by repairing nested wrong ownership"
 	fi
-	# Case 9 (root): symlinked cache root must fail closed too — no repair is
-	# possible (chown -R would fix the target, not the link).
+	# Case 9 (root): symlinked DL root fails closed — no repair is possible
+	# (chown -R would fix the target, not the link).
 	prep_workflow
-	rm -rf "$DL"
-	ln -s "$WORK/dl-target" "$DL"
-	mkdir -p "$WORK/dl-target"
+	symlink_root "$DL" "$WORK/dl-target"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "symlinked cache root must fail closed for root as well"
 	else
 		ok "symlinked cache root fails closed for root"
 	fi
-	# Case 12 (root): trailing-slash form must not bypass the symlink rejection.
+	# Case 12 (root): trailing-slash form must not bypass the symlink rejection
+	# (FEEDS restored to isolate DL).
 	prep_workflow
-	rm -rf "$DL"
-	ln -s "$WORK/dl-target" "$DL"
-	mkdir -p "$WORK/dl-target"
+	restore_root "$FEEDS"
+	symlink_root "$DL" "$WORK/dl-target"
 	export OWRT_SDK_DL_CACHE="$DL/"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "trailing-slash symlinked root must fail closed for root as well"
@@ -181,6 +196,15 @@ else
 		ok "trailing-slash symlinked root fails closed for root"
 	fi
 	export OWRT_SDK_DL_CACHE="$DL"
+	# Case 13 (root): symlinked FEEDS root fails closed (DL restored).
+	prep_workflow
+	restore_root "$DL"
+	symlink_root "$FEEDS" "$WORK/feeds-target"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "symlinked feeds root must fail closed for root as well"
+	else
+		ok "symlinked feeds root fails closed for root"
+	fi
 fi
 
 [ "$fail" = "0" ] || exit 1

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -246,8 +246,10 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	fi
 	# Case 25: OpenWrt `scripts/feeds update` creates relative *.index /
 	# *.targetindex symlinks in the cached feeds tree — they are legit and
-	# must PASS alongside the src-link (luna r11).
+	# must PASS alongside the src-link (luna r11). The fwlive link from case
+	# 20 must be reset first (set -e kills the branch at a duplicate ln).
 	prep_workflow
+	$SUDO rm -f "$FEEDS/fwlive" "$FEEDS/packages.index" "$FEEDS/packages.targetindex"
 	$SUDO ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
 	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
 	$SUDO ln -s base.index "$FEEDS/packages.index"
@@ -257,6 +259,27 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		ok "OpenWrt index symlinks in feeds cache pass"
 	else
 		bad "legit OpenWrt index symlinks must pass for a non-root runner"
+	fi
+	# Case 27: fail-closed — the index allowlist constrains the TARGET: an
+	# absolute-target link (evil.index -> /etc/passwd) must not pass (luna r12).
+	prep_workflow
+	$SUDO rm -f "$FEEDS/fwlive" "$FEEDS/packages.index" "$FEEDS/packages.targetindex"
+	$SUDO ln -s /etc/passwd "$FEEDS/evil.index"
+	$SUDO chown -h 1000:1000 "$FEEDS/evil.index"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "absolute-target index symlink must fail closed for a non-root runner"
+	else
+		ok "absolute-target index symlink fails closed for a non-root runner"
+	fi
+	# ... and an escaping relative target (.. components) must not pass either.
+	prep_workflow
+	$SUDO rm -f "$FEEDS/evil.index"
+	$SUDO ln -s ../../etc/passwd "$FEEDS/evil.targetindex"
+	$SUDO chown -h 1000:1000 "$FEEDS/evil.targetindex"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "escaping index symlink must fail closed for a non-root runner"
+	else
+		ok "escaping index symlink fails closed for a non-root runner"
 	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
@@ -369,6 +392,17 @@ else
 		ok "legit symlinks pass for root too"
 	else
 		bad "legit src-link + index symlinks must pass for root"
+	fi
+	# Case 28 (root): absolute-target index symlink fails closed for root too —
+	# chmod cannot repair link targets, the rescan still flags it (luna r12).
+	prep_workflow
+	rm -f "$FEEDS/fwlive" "$FEEDS/packages.index"
+	ln -s /etc/passwd "$FEEDS/evil.index"
+	chown -h 1000:1000 "$FEEDS/evil.index"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "absolute-target index symlink must fail closed for root as well"
+	else
+		ok "absolute-target index symlink fails closed for root"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -184,6 +184,32 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "regular file as cache root fails closed for a non-root runner"
 	fi
+	# Case 17: fail-closed — RELATIVE symlinked root ('rel/dl'): the walker
+	# must probe relative components from '.', not '/', so a relative symlink
+	# override is caught (luna r9).
+	prep_workflow
+	restore_root "$FEEDS"
+	$SUDO mkdir -p "$WORK/rel"
+	$SUDO ln -s "$WORK/dl-target" "$WORK/rel/dl"
+	$SUDO mkdir -p "$WORK/dl-target"
+	if ( cd "$WORK" \
+		&& export OWRT_SDK_DL_CACHE="rel/dl" \
+		&& sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null ); then
+		bad "relative symlinked root must fail closed for a non-root runner"
+	else
+		ok "relative symlinked root fails closed for a non-root runner"
+	fi
+	# Case 18: fail-closed — world-writable modes (g+w/o+w) violate the
+	# least-privilege policy even when owned by buildbot (luna r9).
+	prep_workflow
+	restore_root "$FEEDS"
+	restore_root "$DL"
+	$SUDO chmod -R 777 "$DL"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "world-writable cache must fail closed for a non-root runner"
+	else
+		ok "world-writable cache fails closed for a non-root runner"
+	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
@@ -241,6 +267,22 @@ else
 		bad "regular file as cache root must fail closed for root as well"
 	else
 		ok "regular file as cache root fails closed for root"
+	fi
+	# Case 19 (root): world-writable tree is REPAIRED (chmod strips g+w/o+w),
+	# not accepted as-is (luna r9).
+	prep_workflow
+	rm -rf "$DL"
+	mkdir -p "$DL"
+	chown 1000:1000 "$DL"
+	chmod -R 777 "$DL"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		if [[ "$(stat -c %a "$DL")" == "755" ]]; then
+			ok "root caller repairs world-writable cache (0755 after)"
+		else
+			bad "root caller must repair world-writable cache (got $(stat -c %a "$DL"))"
+		fi
+	else
+		bad "root caller must succeed by repairing world-writable modes"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -109,6 +109,17 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "unwritable modes fail closed for a non-root runner"
 	fi
+	# Case 8: fail-closed — symlinked cache root: stat follows the link while
+	# find/chown do not; the mount would expose the target (luna r5).
+	prep_workflow
+	$SUDO rm -rf "$DL"
+	$SUDO ln -s "$WORK/dl-target" "$DL"
+	$SUDO mkdir -p "$WORK/dl-target"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "symlinked cache root must fail closed for a non-root runner"
+	else
+		ok "symlinked cache root fails closed for a non-root runner"
+	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
@@ -124,6 +135,17 @@ else
 		fi
 	else
 		bad "root caller must succeed by repairing nested wrong ownership"
+	fi
+	# Case 9 (root): symlinked cache root must fail closed too — no repair is
+	# possible (chown -R would fix the target, not the link).
+	prep_workflow
+	rm -rf "$DL"
+	ln -s "$WORK/dl-target" "$DL"
+	mkdir -p "$WORK/dl-target"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "symlinked cache root must fail closed for root as well"
+	else
+		ok "symlinked cache root fails closed for root"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -246,10 +246,13 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	fi
 	# Case 25: OpenWrt `scripts/feeds update` creates relative *.index /
 	# *.targetindex symlinks in the cached feeds tree — they are legit and
-	# must PASS alongside the src-link (luna r11). The fwlive link from case
-	# 20 must be reset first (set -e kills the branch at a duplicate ln).
+	# must PASS alongside the src-link (luna r11). Resolution-based validation
+	# requires the index TARGETS to exist; the fwlive link from case 20 must
+	# be reset first (set -e kills the branch at a duplicate ln).
 	prep_workflow
 	$SUDO rm -f "$FEEDS/fwlive" "$FEEDS/packages.index" "$FEEDS/packages.targetindex"
+	$SUDO touch "$FEEDS/base.index" "$FEEDS/base.targetindex"
+	$SUDO chown 1000:1000 "$FEEDS/base.index" "$FEEDS/base.targetindex"
 	$SUDO ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
 	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
 	$SUDO ln -s base.index "$FEEDS/packages.index"
@@ -259,6 +262,33 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		ok "OpenWrt index symlinks in feeds cache pass"
 	else
 		bad "legit OpenWrt index symlinks must pass for a non-root runner"
+	fi
+	# Case 32: tracked symlinks INSIDE the pinned feed checkouts (base-files
+	# os-release, netifd ifdown, LuCI Bootstrap links) resolve inside the
+	# feeds tree and must pass (luna r14).
+	prep_workflow
+	$SUDO rm -f "$FEEDS/fwlive" "$FEEDS/packages.index" "$FEEDS/packages.targetindex" "$FEEDS/base.index" "$FEEDS/base.targetindex"
+	$SUDO mkdir -p "$FEEDS/base/package/base-files/files/etc" "$FEEDS/base/package/netifd"
+	$SUDO touch "$FEEDS/base/package/base-files/files/etc/os-release"
+	$SUDO ln -s ../base-files/files/etc/os-release "$FEEDS/base/package/netifd/os-release"
+	$SUDO chown -R 1000:1000 "$FEEDS/base"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		ok "tracked repo symlinks resolving inside the feeds tree pass"
+	else
+		bad "inside-resolving repo symlinks must pass for a non-root runner"
+	fi
+	# Case 33: fail-closed — a CHAINED link (evil.index -> fwlive) resolves
+	# through the src-link to the workspace, outside the cache (luna r14).
+	prep_workflow
+	$SUDO rm -rf "$FEEDS/base"
+	$SUDO ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
+	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
+	$SUDO ln -s fwlive "$FEEDS/evil.index"
+	$SUDO chown -h 1000:1000 "$FEEDS/evil.index"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "chained index symlink must fail closed for a non-root runner"
+	else
+		ok "chained index symlink fails closed for a non-root runner"
 	fi
 	# Case 27: fail-closed — the index allowlist constrains the TARGET: an
 	# absolute-target link (evil.index -> /etc/passwd) must not pass (luna r12).
@@ -282,9 +312,12 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		ok "escaping index symlink fails closed for a non-root runner"
 	fi
 	# Case 29: OpenWrt `src-git --root=package base` (25.12/snapshot cells)
-	# materializes feeds/base -> base_root/package — legit, must pass (luna r13).
+	# materializes feeds/base -> base_root/package — legit, must pass (luna r13;
+	# base_root/package must exist for resolution-based validation).
 	prep_workflow
 	$SUDO rm -f "$FEEDS/evil.targetindex"
+	$SUDO mkdir -p "$FEEDS/base_root/package"
+	$SUDO chown -R 1000:1000 "$FEEDS/base_root"
 	$SUDO ln -s base_root/package "$FEEDS/base"
 	$SUDO chown -h 1000:1000 "$FEEDS/base"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
@@ -405,6 +438,7 @@ else
 	# too — the clean-tree chmod path must tolerate the links (luna r11 Nit).
 	prep_workflow
 	rm -f "$DL/ww"
+	touch "$FEEDS/base.index"
 	ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
 	chown -h 1000:1000 "$FEEDS/fwlive"
 	ln -s base.index "$FEEDS/packages.index"
@@ -428,6 +462,7 @@ else
 	# Case 30 (root): feeds/base -> base_root/package passes for root too.
 	prep_workflow
 	rm -f "$FEEDS/evil.index"
+	mkdir -p "$FEEDS/base_root/package"
 	ln -s base_root/package "$FEEDS/base"
 	chown -h 1000:1000 "$FEEDS/base"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -159,6 +159,31 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		fi
 	done
 	export OWRT_SDK_DL_CACHE="$DL"
+	# Case 14: fail-closed — symlinked root via 'dl/sub/..' spelling (final
+	# component is real; the component-wise walk must catch the link; luna r8).
+	prep_workflow
+	restore_root "$FEEDS"
+	symlink_root "$DL" "$WORK/dl-target"
+	$SUDO mkdir -p "$WORK/dl-target/sub"
+	export OWRT_SDK_DL_CACHE="$DL/sub/.."
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "'dl/sub/..' spelling of a symlinked root must fail closed for a non-root runner"
+	else
+		ok "'dl/sub/..' spelling of a symlinked root fails closed for a non-root runner"
+	fi
+	export OWRT_SDK_DL_CACHE="$DL"
+	# Case 15: fail-closed — regular file in place of the DL root (luna r8).
+	prep_workflow
+	restore_root "$FEEDS"
+	$SUDO rm -rf "$DL"
+	$SUDO touch "$DL"
+	$SUDO chown 1000:1000 "$DL"
+	$SUDO chmod 644 "$DL"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "regular file as cache root must fail closed for a non-root runner"
+	else
+		ok "regular file as cache root fails closed for a non-root runner"
+	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
@@ -204,6 +229,18 @@ else
 		bad "symlinked feeds root must fail closed for root as well"
 	else
 		ok "symlinked feeds root fails closed for root"
+	fi
+	# Case 16 (root): regular file in place of the DL root fails closed.
+	prep_workflow
+	restore_root "$FEEDS"
+	rm -rf "$DL"
+	touch "$DL"
+	chown 1000:1000 "$DL"
+	chmod 644 "$DL"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "regular file as cache root must fail closed for root as well"
+	else
+		ok "regular file as cache root fails closed for root"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Host test for sdk_matrix_cache_dirs ownership handling.
+#
+# v0.1.36 publish regression (2026-08-25): the workflow "Prepare SDK cache
+# dirs" step runs `sudo chown -R 1000:1000 .ci-sdk-cache` BEFORE the build, so
+# on a GitHub-hosted runner (uid 1001) the cache dirs are already
+# buildbot-owned when sdk_matrix_cache_dirs runs. The function's unconditional
+# non-root `chown -R 1000:1000` then fails with EPERM (a non-owner cannot
+# chown) and the fail-closed path aborts the whole publish.
+#
+# Correct behavior: skip the chown when ownership is already correct (CI state)
+# and only chmod as root/owner; keep fail-closed for genuinely wrong owners.
+# Requires passwordless sudo to set up buildbot-owned dirs; SKIPs otherwise.
+# shellcheck disable=SC2317
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../scripts/lib/sdk-matrix.sh
+source "$ROOT/scripts/lib/sdk-matrix.sh"
+
+fail=0
+ok() { echo "ok: $*"; }
+bad() { echo "FAIL: $*" >&2; fail=1; }
+
+if ! sudo -n true 2>/dev/null; then
+	echo "SKIP: passwordless sudo unavailable (cannot simulate buildbot-owned cache)"
+	exit 0
+fi
+
+WORK="$(mktemp -d /tmp/sdk-cache-owner.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+DL="$WORK/dl"
+FEEDS="$WORK/feeds/24.10.8"
+mkdir -p "$DL" "$FEEDS"
+SDK_MATRIX_VERSION_LABEL=24.10.8
+export OWRT_SDK_DL_CACHE="$DL" OWRT_SDK_FEEDS_CACHE="$FEEDS"
+
+# Case 1 (the regression): CI state — dirs already buildbot-owned by the
+# workflow's sudo chown. Must pass for any uid (root or a 1001 runner).
+sudo chown -R 1000:1000 "$WORK"
+if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+	ok "buildbot-owned cache dirs pass (no redundant chown)"
+else
+	bad "buildbot-owned cache dirs must pass (v0.1.36 chown regression)"
+fi
+
+# Case 2: fail-closed still holds — wrong owner (root) and no way to fix as
+# a non-root runner must abort. Not applicable when running as root.
+if [[ "$(id -u)" -ne 0 ]]; then
+	sudo chown -R 0:0 "$WORK"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "root-owned cache dirs must fail closed for a non-root runner"
+	else
+		ok "root-owned cache dirs fail closed for a non-root runner"
+	fi
+else
+	echo "skip: running as root — fail-closed case not applicable"
+fi
+
+[ "$fail" = "0" ] || exit 1
+echo "ALL TESTS PASSED"

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -210,6 +210,38 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "world-writable cache fails closed for a non-root runner"
 	fi
+	# Case 20: the legit feeds src-link symlink (fwlive -> /work/fwlive/
+	# openwrt-feed) must PASS — link modes are meaningless (skipped by mode
+	# checks) and the src-link target is the only allowed link (luna r10).
+	prep_workflow
+	$SUDO ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
+	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		ok "legit src-link symlink in feeds cache passes"
+	else
+		bad "legit src-link symlink must pass for a non-root runner"
+	fi
+	# Case 21: fail-closed — disallowed nested symlink (target outside the
+	# workspace) cannot be repaired by chmod; non-root fails closed (luna r10).
+	prep_workflow
+	$SUDO ln -s /etc/passwd "$DL/evil"
+	$SUDO chown -h 1000:1000 "$DL/evil"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "disallowed nested symlink must fail closed for a non-root runner"
+	else
+		ok "disallowed nested symlink fails closed for a non-root runner"
+	fi
+	# Case 23: fail-closed — world-writable regular FILE inside DL (file-level
+	# coverage for the g+w/o+w rejection; luna r10 Minor).
+	prep_workflow
+	$SUDO touch "$DL/ww"
+	$SUDO chown 1000:1000 "$DL/ww"
+	$SUDO chmod 666 "$DL/ww"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "world-writable file must fail closed for a non-root runner"
+	else
+		ok "world-writable file fails closed for a non-root runner"
+	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
@@ -283,6 +315,31 @@ else
 		fi
 	else
 		bad "root caller must succeed by repairing world-writable modes"
+	fi
+	# Case 22 (root): disallowed nested symlink fails closed for root too —
+	# chmod cannot repair link modes, so the rescan still flags it (luna r10).
+	prep_workflow
+	ln -s /etc/passwd "$DL/evil"
+	chown -h 1000:1000 "$DL/evil"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "disallowed nested symlink must fail closed for root as well"
+	else
+		ok "disallowed nested symlink fails closed for root"
+	fi
+	# Case 24 (root): world-writable regular file is REPAIRED to 0644.
+	prep_workflow
+	rm -f "$DL/evil"
+	touch "$DL/ww"
+	chown 1000:1000 "$DL/ww"
+	chmod 666 "$DL/ww"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		if [[ "$(stat -c %a "$DL/ww")" == "644" ]]; then
+			ok "root caller repairs world-writable file (0644 after)"
+		else
+			bad "root caller must repair world-writable file (got $(stat -c %a "$DL/ww"))"
+		fi
+	else
+		bad "root caller must succeed by repairing the world-writable file"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -290,6 +290,31 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "chained index symlink fails closed for a non-root runner"
 	fi
+	# Case 34: fail-closed — a link NAME with a trailing newline must not split
+	# the NUL-less enumeration and slip past as the valid fwlive link (luna r15).
+	prep_workflow
+	$SUDO rm -rf "$FEEDS/base" "$FEEDS/evil.index"
+	$SUDO rm -f "$FEEDS/fwlive"
+	$SUDO ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
+	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
+	$SUDO ln -s /builder "$FEEDS/fwlive"$'\n'
+	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"$'\n'
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "newline-suffixed link name must fail closed for a non-root runner"
+	else
+		ok "newline-suffixed link name fails closed for a non-root runner"
+	fi
+	# Case 35: fail-closed — the src-link exception is location-blind no more:
+	# a link in dl/ targeting /work/fwlive/openwrt-feed must fail (luna r15).
+	prep_workflow
+	$SUDO rm -f "$FEEDS/fwlive"$'\n'
+	$SUDO ln -s /work/fwlive/openwrt-feed "$DL/fwlive"
+	$SUDO chown -h 1000:1000 "$DL/fwlive"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "dl/ link claiming the src-link target must fail closed"
+	else
+		ok "dl/ link claiming the src-link target fails closed"
+	fi
 	# Case 27: fail-closed — the index allowlist constrains the TARGET: an
 	# absolute-target link (evil.index -> /etc/passwd) must not pass (luna r12).
 	prep_workflow
@@ -469,6 +494,19 @@ else
 		ok "base_root/package link passes for root"
 	else
 		bad "legit base link must pass for root"
+	fi
+	# Case 36 (root): newline-suffixed link name fails closed for root too.
+	prep_workflow
+	rm -rf "$FEEDS/base" "$FEEDS/base_root"
+	rm -f "$FEEDS/fwlive"
+	ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
+	chown -h 1000:1000 "$FEEDS/fwlive"
+	ln -s /builder "$FEEDS/fwlive"$'\n'
+	chown -h 1000:1000 "$FEEDS/fwlive"$'\n'
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "newline-suffixed link name must fail closed for root as well"
+	else
+		ok "newline-suffixed link name fails closed for root"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -281,6 +281,27 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "escaping index symlink fails closed for a non-root runner"
 	fi
+	# Case 29: OpenWrt `src-git --root=package base` (25.12/snapshot cells)
+	# materializes feeds/base -> base_root/package — legit, must pass (luna r13).
+	prep_workflow
+	$SUDO rm -f "$FEEDS/evil.targetindex"
+	$SUDO ln -s base_root/package "$FEEDS/base"
+	$SUDO chown -h 1000:1000 "$FEEDS/base"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		ok "base_root/package link passes"
+	else
+		bad "legit base link must pass for a non-root runner"
+	fi
+	# Case 31: fail-closed — a newline-bearing override must not truncate the
+	# component walk (luna r13 Minor).
+	prep_workflow
+	export OWRT_SDK_DL_CACHE=$'rel\n/evil'
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "newline-bearing override must fail closed for a non-root runner"
+	else
+		ok "newline-bearing override fails closed for a non-root runner"
+	fi
+	export OWRT_SDK_DL_CACHE="$DL"
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
@@ -403,6 +424,16 @@ else
 		bad "absolute-target index symlink must fail closed for root as well"
 	else
 		ok "absolute-target index symlink fails closed for root"
+	fi
+	# Case 30 (root): feeds/base -> base_root/package passes for root too.
+	prep_workflow
+	rm -f "$FEEDS/evil.index"
+	ln -s base_root/package "$FEEDS/base"
+	chown -h 1000:1000 "$FEEDS/base"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		ok "base_root/package link passes for root"
+	else
+		bad "legit base link must pass for root"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -8,9 +8,10 @@
 # non-root `chown -R 1000:1000` then fails with EPERM (a non-owner cannot
 # chown) and the fail-closed path aborts the whole publish.
 #
-# Correct behavior: skip the chown when ownership is already correct (CI state)
-# and only chmod as root/owner; keep fail-closed for genuinely wrong owners.
-# Requires passwordless sudo to set up buildbot-owned dirs; SKIPs otherwise.
+# Correct behavior: skip chown only when BOTH cache trees are fully
+# buildbot-owned (the CI state) and only chmod as root/owner; keep fail-closed
+# for wrong owners (tree roots OR nested entries). Requires passwordless sudo
+# to set up buildbot-owned dirs; SKIPs otherwise (GH runners have it).
 # shellcheck disable=SC2317
 set -euo pipefail
 
@@ -28,7 +29,7 @@ if ! sudo -n true 2>/dev/null; then
 fi
 
 WORK="$(mktemp -d /tmp/sdk-cache-owner.XXXXXX)"
-trap 'rm -rf "$WORK"' EXIT
+trap 'sudo rm -rf "$WORK"' EXIT
 
 DL="$WORK/dl"
 FEEDS="$WORK/feeds/24.10.8"
@@ -36,26 +37,42 @@ mkdir -p "$DL" "$FEEDS"
 SDK_MATRIX_VERSION_LABEL=24.10.8
 export OWRT_SDK_DL_CACHE="$DL" OWRT_SDK_FEEDS_CACHE="$FEEDS"
 
-# Case 1 (the regression): CI state — dirs already buildbot-owned by the
-# workflow's sudo chown. Must pass for any uid (root or a 1001 runner).
-sudo chown -R 1000:1000 "$WORK"
+# Workflow-equivalent prep: buildbot ownership + least-privilege modes, same
+# as the "Prepare SDK cache dirs" step (u=rwX,g=rX,o=rX keeps the uid-1001
+# runner able to traverse the tree).
+prep_workflow() {
+	sudo chown -R 1000:1000 "$WORK"
+	sudo chmod -R u=rwX,g=rX,o=rX "$WORK"
+}
+
+# Case 1 (the regression): CI state — both trees buildbot-owned. Must pass
+# for any uid (root or a 1001 runner).
+prep_workflow
 if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
-	ok "buildbot-owned cache dirs pass (no redundant chown)"
+	ok "buildbot-owned cache trees pass (no redundant chown)"
 else
-	bad "buildbot-owned cache dirs must pass (v0.1.36 chown regression)"
+	bad "buildbot-owned cache trees must pass (v0.1.36 chown regression)"
 fi
 
-# Case 2: fail-closed still holds — wrong owner (root) and no way to fix as
-# a non-root runner must abort. Not applicable when running as root.
 if [[ "$(id -u)" -ne 0 ]]; then
+	# Case 2: fail-closed — wrong owner at a tree root with no way to fix.
 	sudo chown -R 0:0 "$WORK"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
-		bad "root-owned cache dirs must fail closed for a non-root runner"
+		bad "root-owned cache trees must fail closed for a non-root runner"
 	else
-		ok "root-owned cache dirs fail closed for a non-root runner"
+		ok "root-owned cache trees fail closed for a non-root runner"
+	fi
+	# Case 3: fail-closed — wrong owner on the FEEDS tree only (download tree
+	# looks fine): the skip decision must cover both cache trees.
+	prep_workflow
+	sudo chown -R 0:0 "$FEEDS"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "feeds-only wrong ownership must fail closed for a non-root runner"
+	else
+		ok "feeds-only wrong ownership fails closed for a non-root runner"
 	fi
 else
-	echo "skip: running as root — fail-closed case not applicable"
+	echo "skip: running as root — fail-closed cases not applicable"
 fi
 
 [ "$fail" = "0" ] || exit 1

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -9,9 +9,10 @@
 # chown) and the fail-closed path aborts the whole publish.
 #
 # Correct behavior: skip chown only when BOTH cache trees are fully
-# buildbot-owned (the CI state) and only chmod as root/owner; keep fail-closed
-# for wrong owners (tree roots OR nested entries). Requires passwordless sudo
-# to set up buildbot-owned dirs; SKIPs otherwise (GH runners have it).
+# buildbot-owned (roots AND nested entries, verified by a scan that fails
+# closed on errors) and only chmod as root/owner; wrong ownership is repaired
+# by root or fails closed for non-root. Requires passwordless sudo to set up
+# buildbot-owned dirs; SKIPs otherwise (GH runners have it).
 # shellcheck disable=SC2317
 set -euo pipefail
 
@@ -71,8 +72,42 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "feeds-only wrong ownership fails closed for a non-root runner"
 	fi
+	# Case 4: fail-closed — nested stray wrong-owned file inside an otherwise
+	# buildbot-owned tree (roots look fine).
+	prep_workflow
+	touch "$DL/stray"
+	sudo chown 0:0 "$DL/stray"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "nested wrong-owned file must fail closed for a non-root runner"
+	else
+		ok "nested wrong-owned file fails closed for a non-root runner"
+	fi
+	# Case 5: fail-closed — unreadable subtree: the ownership scan must not
+	# read as a clean tree when it cannot traverse everything.
+	prep_workflow
+	mkdir -p "$DL/nested"
+	sudo chmod 700 "$DL/nested"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "unreadable subtree must fail closed for a non-root runner"
+	else
+		ok "unreadable subtree fails closed for a non-root runner"
+	fi
 else
-	echo "skip: running as root — fail-closed cases not applicable"
+	echo "skip: running as root — non-root fail-closed cases not applicable"
+	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
+	# chown), not chmodded into a state uid 1000 cannot write.
+	mkdir -p "$DL/nested"
+	touch "$DL/nested/stray"
+	chown 0:0 "$DL/nested/stray"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		if [[ "$(stat -c %u "$DL/nested/stray")" == "1000" ]]; then
+			ok "root caller repairs nested wrong-owned file (uid 1000 after)"
+		else
+			bad "root caller must repair nested wrong-owned file (got uid $(stat -c %u "$DL/nested/stray"))"
+		fi
+	else
+		bad "root caller must succeed by repairing nested wrong ownership"
+	fi
 fi
 
 [ "$fail" = "0" ] || exit 1

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -11,8 +11,8 @@
 # Correct behavior: skip chown only when BOTH cache trees are fully
 # buildbot-owned (roots AND nested entries, verified by a scan that fails
 # closed on errors) and only chmod as root/owner; wrong ownership is repaired
-# by root or fails closed for non-root. Requires passwordless sudo to set up
-# buildbot-owned dirs; SKIPs otherwise (GH runners have it).
+# by root or fails closed for non-root. Non-root needs passwordless sudo to
+# set up buildbot-owned dirs (SKIPs otherwise); root runs without sudo.
 # shellcheck disable=SC2317
 set -euo pipefail
 
@@ -24,13 +24,17 @@ fail=0
 ok() { echo "ok: $*"; }
 bad() { echo "FAIL: $*" >&2; fail=1; }
 
-if ! sudo -n true 2>/dev/null; then
-	echo "SKIP: passwordless sudo unavailable (cannot simulate buildbot-owned cache)"
-	exit 0
+SUDO=""
+if [[ "$(id -u)" -ne 0 ]]; then
+	if ! sudo -n true 2>/dev/null; then
+		echo "SKIP: passwordless sudo unavailable (cannot simulate buildbot-owned cache)"
+		exit 0
+	fi
+	SUDO="sudo"
 fi
 
 WORK="$(mktemp -d /tmp/sdk-cache-owner.XXXXXX)"
-trap 'sudo rm -rf "$WORK"' EXIT
+trap "$SUDO rm -rf '$WORK'" EXIT
 
 DL="$WORK/dl"
 FEEDS="$WORK/feeds/24.10.8"
@@ -42,8 +46,8 @@ export OWRT_SDK_DL_CACHE="$DL" OWRT_SDK_FEEDS_CACHE="$FEEDS"
 # as the "Prepare SDK cache dirs" step (u=rwX,g=rX,o=rX keeps the uid-1001
 # runner able to traverse the tree).
 prep_workflow() {
-	sudo chown -R 1000:1000 "$WORK"
-	sudo chmod -R u=rwX,g=rX,o=rX "$WORK"
+	$SUDO chown -R 1000:1000 "$WORK"
+	$SUDO chmod -R u=rwX,g=rX,o=rX "$WORK"
 }
 
 # Case 1 (the regression): CI state — both trees buildbot-owned. Must pass
@@ -57,7 +61,7 @@ fi
 
 if [[ "$(id -u)" -ne 0 ]]; then
 	# Case 2: fail-closed — wrong owner at a tree root with no way to fix.
-	sudo chown -R 0:0 "$WORK"
+	$SUDO chown -R 0:0 "$WORK"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "root-owned cache trees must fail closed for a non-root runner"
 	else
@@ -66,27 +70,31 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	# Case 3: fail-closed — wrong owner on the FEEDS tree only (download tree
 	# looks fine): the skip decision must cover both cache trees.
 	prep_workflow
-	sudo chown -R 0:0 "$FEEDS"
+	$SUDO chown -R 0:0 "$FEEDS"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "feeds-only wrong ownership must fail closed for a non-root runner"
 	else
 		ok "feeds-only wrong ownership fails closed for a non-root runner"
 	fi
 	# Case 4: fail-closed — nested stray wrong-owned file inside an otherwise
-	# buildbot-owned tree (roots look fine).
+	# buildbot-owned tree (roots look fine). Entries inside the 1000:1000 tree
+	# must be created with sudo (the runner has no write access there).
 	prep_workflow
-	touch "$DL/stray"
-	sudo chown 0:0 "$DL/stray"
+	$SUDO touch "$DL/stray"
+	$SUDO chown 0:0 "$DL/stray"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "nested wrong-owned file must fail closed for a non-root runner"
 	else
 		ok "nested wrong-owned file fails closed for a non-root runner"
 	fi
-	# Case 5: fail-closed — unreadable subtree: the ownership scan must not
-	# read as a clean tree when it cannot traverse everything.
+	# Case 5: fail-closed — unreadable subtree (buildbot-owned but no traverse
+	# for other): the ownership scan must not read as a clean tree. The nested
+	# dir must be buildbot-owned so the failure is the scan error, not a
+	# wrong-owner mismatch.
 	prep_workflow
-	mkdir -p "$DL/nested"
-	sudo chmod 700 "$DL/nested"
+	$SUDO mkdir -p "$DL/nested"
+	$SUDO chown 1000:1000 "$DL/nested"
+	$SUDO chmod 700 "$DL/nested"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
 		bad "unreadable subtree must fail closed for a non-root runner"
 	else

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -232,8 +232,10 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		ok "disallowed nested symlink fails closed for a non-root runner"
 	fi
 	# Case 23: fail-closed — world-writable regular FILE inside DL (file-level
-	# coverage for the g+w/o+w rejection; luna r10 Minor).
+	# coverage for the g+w/o+w rejection; luna r10 Minor). The evil link from
+	# case 21 must not mask this.
 	prep_workflow
+	$SUDO rm -f "$DL/evil"
 	$SUDO touch "$DL/ww"
 	$SUDO chown 1000:1000 "$DL/ww"
 	$SUDO chmod 666 "$DL/ww"
@@ -241,6 +243,20 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		bad "world-writable file must fail closed for a non-root runner"
 	else
 		ok "world-writable file fails closed for a non-root runner"
+	fi
+	# Case 25: OpenWrt `scripts/feeds update` creates relative *.index /
+	# *.targetindex symlinks in the cached feeds tree — they are legit and
+	# must PASS alongside the src-link (luna r11).
+	prep_workflow
+	$SUDO ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
+	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
+	$SUDO ln -s base.index "$FEEDS/packages.index"
+	$SUDO ln -s base.targetindex "$FEEDS/packages.targetindex"
+	$SUDO chown -h 1000:1000 "$FEEDS/packages.index" "$FEEDS/packages.targetindex"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		ok "OpenWrt index symlinks in feeds cache pass"
+	else
+		bad "legit OpenWrt index symlinks must pass for a non-root runner"
 	fi
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
@@ -340,6 +356,19 @@ else
 		fi
 	else
 		bad "root caller must succeed by repairing the world-writable file"
+	fi
+	# Case 26 (root): the legit src-link + OpenWrt index symlinks pass for root
+	# too — the clean-tree chmod path must tolerate the links (luna r11 Nit).
+	prep_workflow
+	rm -f "$DL/ww"
+	ln -s /work/fwlive/openwrt-feed "$FEEDS/fwlive"
+	chown -h 1000:1000 "$FEEDS/fwlive"
+	ln -s base.index "$FEEDS/packages.index"
+	chown -h 1000:1000 "$FEEDS/packages.index"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		ok "legit symlinks pass for root too"
+	else
+		bad "legit src-link + index symlinks must pass for root"
 	fi
 fi
 

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -87,10 +87,9 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "nested wrong-owned file fails closed for a non-root runner"
 	fi
-	# Case 5: fail-closed — unreadable subtree (buildbot-owned but no traverse
-	# for other): the ownership scan must not read as a clean tree. The nested
-	# dir must be buildbot-owned so the failure is the scan error, not a
-	# wrong-owner mismatch.
+	# Case 5: fail-closed — buildbot-owned subtree with no group/other read or
+	# traverse (mode check; the scan-error branch is defense-in-depth, since
+	# any mode that denies find traversal also fails the mode checks below).
 	prep_workflow
 	$SUDO mkdir -p "$DL/nested"
 	$SUDO chown 1000:1000 "$DL/nested"
@@ -120,6 +119,29 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "symlinked cache root fails closed for a non-root runner"
 	fi
+	# Case 10: fail-closed — symlinked FEEDS root (each root is checked).
+	prep_workflow
+	$SUDO rm -rf "$FEEDS"
+	$SUDO ln -s "$WORK/feeds-target" "$FEEDS"
+	$SUDO mkdir -p "$WORK/feeds-target"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "symlinked feeds root must fail closed for a non-root runner"
+	else
+		ok "symlinked feeds root fails closed for a non-root runner"
+	fi
+	# Case 11: fail-closed — trailing-slash form of a symlinked root ('dl/'
+	# resolves to the target) must not bypass the symlink rejection (luna r6).
+	prep_workflow
+	$SUDO rm -rf "$DL"
+	$SUDO ln -s "$WORK/dl-target" "$DL"
+	$SUDO mkdir -p "$WORK/dl-target"
+	export OWRT_SDK_DL_CACHE="$DL/"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "trailing-slash symlinked root must fail closed for a non-root runner"
+	else
+		ok "trailing-slash symlinked root fails closed for a non-root runner"
+	fi
+	export OWRT_SDK_DL_CACHE="$DL"
 else
 	echo "skip: running as root — non-root fail-closed cases not applicable"
 	# Case 6 (root): nested stray wrong-owned file must be REPAIRED (recursive
@@ -147,6 +169,18 @@ else
 	else
 		ok "symlinked cache root fails closed for root"
 	fi
+	# Case 12 (root): trailing-slash form must not bypass the symlink rejection.
+	prep_workflow
+	rm -rf "$DL"
+	ln -s "$WORK/dl-target" "$DL"
+	mkdir -p "$WORK/dl-target"
+	export OWRT_SDK_DL_CACHE="$DL/"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "trailing-slash symlinked root must fail closed for root as well"
+	else
+		ok "trailing-slash symlinked root fails closed for root"
+	fi
+	export OWRT_SDK_DL_CACHE="$DL"
 fi
 
 [ "$fail" = "0" ] || exit 1

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -316,9 +316,11 @@ if [[ "$(id -u)" -ne 0 ]]; then
 		ok "dl/ link claiming the src-link target fails closed"
 	fi
 	# Case 37: fail-closed — a target with a TRAILING NEWLINE must not
-	# masquerade as the exact src-link exception (luna r16).
+	# masquerade as the exact src-link exception (luna r16). The fwlive link
+	# from case 34 must be reset first (set -e kills the branch at a
+	# duplicate ln).
 	prep_workflow
-	$SUDO rm -f "$DL/fwlive"
+	$SUDO rm -f "$DL/fwlive" "$FEEDS/fwlive"
 	$SUDO ln -s "/work/fwlive/openwrt-feed"$'\n' "$FEEDS/fwlive"
 	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
 	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then

--- a/tests/sdk-matrix-cache-owner.test.sh
+++ b/tests/sdk-matrix-cache-owner.test.sh
@@ -315,6 +315,29 @@ if [[ "$(id -u)" -ne 0 ]]; then
 	else
 		ok "dl/ link claiming the src-link target fails closed"
 	fi
+	# Case 37: fail-closed — a target with a TRAILING NEWLINE must not
+	# masquerade as the exact src-link exception (luna r16).
+	prep_workflow
+	$SUDO rm -f "$DL/fwlive"
+	$SUDO ln -s "/work/fwlive/openwrt-feed"$'\n' "$FEEDS/fwlive"
+	$SUDO chown -h 1000:1000 "$FEEDS/fwlive"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "trailing-newline src-link target must fail closed"
+	else
+		ok "trailing-newline src-link target fails closed"
+	fi
+	# Case 38: fail-closed — owner-write without owner-READ (mode 0244) must
+	# not pass: buildbot needs to read the cache (luna r16 Minor).
+	prep_workflow
+	$SUDO rm -f "$FEEDS/fwlive"
+	$SUDO touch "$DL/noread"
+	$SUDO chown 1000:1000 "$DL/noread"
+	$SUDO chmod 0244 "$DL/noread"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "owner-unreadable file must fail closed for a non-root runner"
+	else
+		ok "owner-unreadable file fails closed for a non-root runner"
+	fi
 	# Case 27: fail-closed — the index allowlist constrains the TARGET: an
 	# absolute-target link (evil.index -> /etc/passwd) must not pass (luna r12).
 	prep_workflow
@@ -507,6 +530,31 @@ else
 		bad "newline-suffixed link name must fail closed for root as well"
 	else
 		ok "newline-suffixed link name fails closed for root"
+	fi
+	# Case 39 (root): trailing-newline src-link target fails closed for root.
+	prep_workflow
+	rm -f "$FEEDS/fwlive"$'\n' "$FEEDS/fwlive"
+	ln -s "/work/fwlive/openwrt-feed"$'\n' "$FEEDS/fwlive"
+	chown -h 1000:1000 "$FEEDS/fwlive"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL" 2>/dev/null; then
+		bad "trailing-newline src-link target must fail closed for root as well"
+	else
+		ok "trailing-newline src-link target fails closed for root"
+	fi
+	# Case 40 (root): owner-unreadable file is REPAIRED to 0644.
+	prep_workflow
+	rm -f "$FEEDS/fwlive"
+	touch "$DL/noread"
+	chown 1000:1000 "$DL/noread"
+	chmod 0244 "$DL/noread"
+	if sdk_matrix_cache_dirs "$ROOT" "$SDK_MATRIX_VERSION_LABEL"; then
+		if [[ "$(stat -c %a "$DL/noread")" == "644" ]]; then
+			ok "root caller repairs owner-unreadable file (0644 after)"
+		else
+			bad "root caller must repair owner-unreadable file (got $(stat -c %a "$DL/noread"))"
+		fi
+	else
+		bad "root caller must succeed by repairing the owner-unreadable file"
 	fi
 fi
 


### PR DESCRIPTION
## What

v0.1.36 publish regression — the tag-push `publish-packages` run failed at the first SDK cell (21.02) with:

```
sdk-matrix: cannot chown .ci-sdk-cache to buildbot (uid 1000)
```

## Root cause

`scripts/lib/sdk-matrix.sh` `sdk_matrix_cache_dirs()` (added in #196) unconditionally ran `chown -R 1000:1000` on the cache dirs. The workflow's **Prepare SDK cache dirs** step already runs `sudo chown -R 1000:1000` first, so on a GitHub-hosted runner (uid 1001) the dirs are buildbot-owned by build time — and a non-owner cannot chown them (EPERM) → fail-closed abort. It only ever worked locally (dev uid 1000 = no-op owner change) and was never exercised in PR CI (host tests don't run the SDK matrix path).

## Fix

- Skip the chown when the dirs are **already buildbot-owned** (the CI state); only enforce when ownership is wrong and we can change it (root) — fail-closed preserved for genuinely wrong owners.
- `chmod` only as root/owner (a non-owner runner can't chmod uid-1000 dirs either; CI's sudo prepare already set modes).
- New host test `tests/sdk-matrix-cache-owner.test.sh`: reproduces the runner scenario (dirs sudo-chowned to 1000:1000, then `sdk_matrix_cache_dirs` must pass) + keeps a fail-closed case. Skips without passwordless sudo (runs in PR CI on GH runners).
- Wired into `scripts/fwlive-test.sh`.

## Verified

- Old code + uid-1001 setpriv sim → exact CI error (`cannot chown`); new code → pass. Same dirs/modes as the workflow.
- `./scripts/fwlive-test.sh` green locally.

## Test plan

- [x] Host gate `./scripts/fwlive-test.sh` green
- [ ] CI (host smoke + new cache-owner test on runner uid 1001)
- [ ] luna gate
- [ ] Tag re-point v0.1.36 → re-run publish (release not created yet — tag move safe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDK cache validation for ownership, permissions, nested entries, and directory traversal.
  * Enforced fail-closed behavior for ownership or permission mismatches and unreadable cache areas.
  * Added recursive ownership and permission repair for appropriately privileged operations.

* **Tests**
  * Added coverage for nested ownership errors, unreadable subtrees, permission issues, and recursive repairs.
  * Added Firewall Live regression coverage for SDK cache handling.

* **Documentation**
  * Documented SDK cache ownership and permission requirements and enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->