### PR TITLE
prep(upstream): harden cut + drop phantom rpcd list backend

### DIFF
--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -73,14 +73,14 @@ Alternatives (not primary):
 
 ### Upstream cut into `openwrt/luci`
 
-Run [`scripts/upstream-cut.sh`](../scripts/upstream-cut.sh) to produce the PR-ready tree. It splits `openwrt-feed/luci-app-fwlive/` via `git subtree split` (real files, package-only history, no gitlinks), rewrites the Makefile include and package README links, and verifies the result. Output: `out/upstream/luci-app-fwlive/`.
+Run [`scripts/upstream-cut.sh`](../scripts/upstream-cut.sh) to produce the PR-ready tree. It splits `openwrt-feed/luci-app-fwlive/` via `git subtree split` (real files, package-only history, no gitlinks), rewrites the Makefile include and package README / GENERATED comments, drops `po/{de,ru,zh_Hans}` and `fwlive.css` (first luci PR is `.pot` only; view loads `css.js`), and verifies the result. Output: `out/upstream/luci-app-fwlive/`. Keep feed `.po` files in this monorepo for the binary feed.
 
 Then, to open the upstream PR:
 
 - [ ] Copy `out/upstream/luci-app-fwlive/` into `luci/applications/luci-app-fwlive/` in a `openwrt/luci` fork
 - [ ] Makefile include is already `include ../../luci.mk` (script rewrites it; feed path stays as-is in this monorepo)
 - [ ] Package `README.md` links point at GitHub (script rewrites monorepo `docs/` paths; they die after the copy)
-- [ ] Confirm `po/templates/luci-app-fwlive.pot` is included
+- [ ] Refresh `po/templates/luci-app-fwlive.pot` with luci `./build/i18n-scan.pl applications/luci-app-fwlive` (same commit); copy `.pot` back here and `msgmerge` feed `.po` files
 - [ ] State Apache-2.0 in the PR body (`PKG_LICENSE` is already set; no `PKG_LICENSE_FILES` needed to match peer LuCI apps)
 
 ## Package conventions (verified)

--- a/openwrt-feed/luci-app-fwlive/po/de/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/de/luci-app-fwlive.po
@@ -12,615 +12,598 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: htdocs/luci-static/resources/fwlive/logging.js:250
-#: htdocs/luci-static/resources/fwlive/logging.js:254
-msgid " then ping the router."
-msgstr " und pingen Sie den Router."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:907
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:884
 msgid "%d matching · %d/%d stored"
 msgstr "%d matching · %d/%d stored"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:910
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:887
 msgid "0 matching · %d/%d stored"
 msgstr "0 matching · %d/%d stored"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:246
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:250
 msgid "Accessible (teal/orange)"
 msgstr "Barrierefrei (teal/orange)"
 
-#: htdocs/luci-static/resources/fwlive/table.js:32
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:32
 msgid "Action"
 msgstr "Aktion"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:617
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:594
 msgid "Administrator access is required to disable logging."
 msgstr "Zum Deaktivieren der Protokollierung sind Administratorrechte erforderlich."
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:588
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:562
 msgid "Administrator access is required to enable logging."
 msgstr "Zum Aktivieren der Protokollierung sind Administratorrechte erforderlich."
 
-#: htdocs/luci-static/resources/fwlive/logging.js:119
-msgid "allow/deny rules, LAN logging, or anything else."
-msgstr "allow/deny rules, LAN logging, or anything else."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1543
-msgid "Any action"
-msgstr "Beliebige Aktion"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:109
-msgid "Before you enable logging"
-msgstr "Before you enable logging"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:809
-msgid "buffer full"
-msgstr "Puffer voll"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:573
-msgid "Cannot enable logging until kernel log modules are installed."
-msgstr "Protokollierung kann erst aktiviert werden, wenn die Kernel-Log-Module installiert sind."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:112
-msgid "Changes:"
-msgstr "Changes:"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1529
-msgid "Chip style"
-msgstr "Chip-Stil"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1593
-msgid "Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels."
-msgstr "Der Chip-Stil bestimmt, wie Einschluss- und Ausschluss-Chips aussehen (Beschriftungen, Symbole oder Ton). Standard ist Beschriftungen."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:245
-msgid "Classic (green/red)"
-msgstr "Klassisch (grÃ¼n/rot)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1515
-msgid "Classic uses green/red; Accessible uses teal/orange"
-msgstr "Klassisch verwendet grÃ¼n/rot; Barrierefrei verwendet teal/orange"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:133
-msgid "Clear all"
-msgstr "Alle lÃ¶schen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
-msgstr "Zelle anklicken zum Filtern · ≠ auf einem Chip zum Ausschließen · Strg+Klick auf eine Regel für Firewall-Einstellungen · in der Einfachen Ansicht Zeile anklicken für die vollständige Meldung"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
-msgstr "Klicken Sie auf eine Zeile (Zeit oder andere Nicht-Link-Zellen), um die vollständige Log-Zeile zu sehen (Einfache Ansicht)."
-
-#: htdocs/luci-static/resources/fwlive/table.js:113
-msgid "Click a row for the full message"
-msgstr "Zeile anklicken für die vollständige Meldung"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1592
-msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-msgstr "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:925
-msgid "Connection lost — retrying…"
-msgstr "Connection lost — retrying…"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:608
-msgid "Could not disable logging."
-msgstr "Protokollierung konnte nicht deaktiviert werden."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:575
-msgid "Could not enable logging."
-msgstr "Protokollierung konnte nicht aktiviert werden."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:81
-msgid "default 10/minute"
-msgstr "Standard 10/Minute"
-
-#: htdocs/luci-static/resources/fwlive/table.js:40
-msgid "Destination"
-msgstr "Ziel"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1563
-msgid "Destination IP contains (! to exclude)"
-msgstr "Ziel-IP enthÃ¤lt (! zum AusschlieÃen)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1564
-msgid "Destination port (! to exclude)"
-msgstr "Ziel-Port (! zum AusschlieÃen)"
-
-#: htdocs/luci-static/resources/fwlive/table.js:37
-msgid "Dir"
-msgstr "Richtung"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "Disabling…"
-msgstr "Disabling…"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1481
-msgid "Display options"
-msgstr "Anzeigeoptionen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1588
-msgid "Display options hides Limit, row tint, hostnames, and chip style."
-msgstr "Anzeigeoptionen verbergen Limit, ZeilenfÃ¤rbung, Hostnamen und Chip-Stil."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:117
-msgid "Does not change:"
-msgstr "Does not change:"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:134
-msgid "Don’t show this again"
-msgstr "Don’t show this again"
-
-#: htdocs/luci-static/resources/fwlive/table.js:42
-msgid "DPort"
-msgstr "Ziel-Port"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-msgid "Enable logging"
-msgstr "Protokollierung aktivieren"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1587
-msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-msgstr "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-#: htdocs/luci-static/resources/fwlive/logging.js:226
-msgid "Enable WAN drop/reject logging"
-msgstr "Enable WAN drop/reject logging"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:100
-msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-msgstr "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-msgid "Enabling…"
-msgstr "Enabling…"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Exclude instead"
-msgstr "Stattdessen ausschlieÃen"
-
-#: htdocs/luci-static/resources/fwlive/links.js:53
-#: htdocs/luci-static/resources/fwlive/links.js:71
-msgid "Filter by %s"
-msgstr "Filtern nach %s"
-
-#: htdocs/luci-static/resources/fwlive/links.js:136
-msgid "Filter by interface"
-msgstr "Nach Schnittstelle filtern"
-
-#: htdocs/luci-static/resources/fwlive/links.js:112
-msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
-msgstr "Logs nach Regel filtern (Hinweis: %s). Strg+Klick Ã¶ffnet die Firewall-Einstellungen."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1527
-msgid "Filters look"
-msgstr "Filteroptik"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1442
-msgid "Firewall Live View"
-msgstr "Firewall-Live-Ansicht"
-
-#: htdocs/luci-static/resources/fwlive/table.js:43
-msgid "Flags"
-msgstr "Flags"
-
-#: htdocs/luci-static/resources/fwlive/table.js:45
-msgid "Flow"
-msgstr "Fluss"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1584
-msgid "Help"
-msgstr "Hilfe"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-msgid "Hide Detail"
-msgstr "Detail ausblenden"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-#: htdocs/luci-static/resources/view/status/fwlive.js:1505
-msgid "Hide row tint"
-msgstr "ZeileneinfÃ¤rbung ausblenden"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:876
-msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-msgstr "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1533
-msgid "How include vs exclude filters are shown on chips"
-msgstr "Wie Einschluss- und Ausschlussfilter auf Chips dargestellt werden"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1596
-msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
-msgstr "Wenn die ZeileneinfÃ¤rbung fehlt, verwendet das aktive LuCI-Theme mÃ¶glicherweise keine Erfolgs/Fehler-CSS-Variablen; fwlive fÃ¤llt auf lokale Farben zurÃ¼ck (air-gapped, keine Daten verlassen das GerÃ¤t)."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:201
-msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-msgstr "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-
-#: htdocs/luci-static/resources/fwlive/table.js:35
-msgid "IN"
-msgstr "EINGANG"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Include instead"
-msgstr "Stattdessen einschlieÃen"
-
-#: htdocs/luci-static/resources/fwlive/table.js:34
-msgid "Interface"
-msgstr "Schnittstelle"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1560
-msgid "Interface (prefix ! to exclude)"
-msgstr "Schnittstelle (! voranstellen zum AusschlieÃen)"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:35
-msgid "is"
-msgstr "ist"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:161
-#: htdocs/luci-static/resources/fwlive/logging.js:228
-msgid "I’ll configure this under Network → Firewall"
-msgstr "I’ll configure this under Network → Firewall"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:190
-msgid "Kernel log modules missing"
-msgstr "Kernel log modules missing"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:191
-msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
-msgstr "Kernel-Netfilter-Log-Module fehlen. Installieren Sie kmod-nf-log-ipv4 und kmod-nf-log-ipv6 (oder kmod-nf-log / kmod-nf-log6) und laden Sie dann die Firewall neu."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:329
-msgid "Labels"
-msgstr "Beschriftungen"
-
-#: htdocs/luci-static/resources/fwlive/table.js:44
-msgid "Len"
-msgstr "LÃ¤nge"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1487
-msgid "Limit"
-msgstr "Limit"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1485
-msgid "Live"
-msgstr "Live"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1494
-msgid "Live updates run until you Pause above."
-msgstr "Live-Updates laufen, bis Sie oben pausieren."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:804
-msgid "loading buffer"
-msgstr "Lade Puffer"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:904
-msgid "loading…"
-msgstr "loading…"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:206
-msgid "Logging is off on this router"
-msgstr "Logging is off on this router"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:248
-#: htdocs/luci-static/resources/fwlive/logging.js:252
-msgid "Manual test (System → Terminal): "
-msgstr "Manual test (System → Terminal): "
-
-#: htdocs/luci-static/resources/fwlive/table.js:46
-#: htdocs/luci-static/resources/fwlive/table.js:217
-msgid "Message"
-msgstr "Nachricht"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1235
-msgid "Message: one line"
-msgstr "Nachricht: einzeilig"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1236
-#: htdocs/luci-static/resources/view/status/fwlive.js:1475
-msgid "Message: wrap"
-msgstr "Nachricht: umbrechen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1558
-msgid "More filters"
-msgstr "Weitere Filter"
-
-#: htdocs/luci-static/resources/fwlive/links.js:37
-msgid "Network → Firewall"
-msgstr "Network → Firewall"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:183
-msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under "
-msgstr "Keine WAN-Firewall-Zone in /etc/config/firewall gefunden. Konfigurieren Sie Zonen unter "
-
-#: htdocs/luci-static/resources/fwlive/logging.js:181
-msgid "No WAN zone found"
-msgstr "No WAN zone found"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:45
-#: htdocs/luci-static/resources/fwlive/chips.js:52
-msgid "not"
-msgstr "nicht"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1551
-msgid "not block"
-msgstr "nicht blockieren"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1550
-msgid "not drop"
-msgstr "nicht verwerfen"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:159
-msgid "Not now"
-msgstr "Not now"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1549
-msgid "not pass"
-msgstr "nicht erlauben"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1552
-msgid "not reject"
-msgstr "nicht zurÃ¼ckweisen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1553
-msgid "not unknown"
-msgstr "nicht unbekannt"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:216
-msgid "Nothing changes until you click Enable."
-msgstr "Nothing changes until you click Enable."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:202
-msgid "Open firewall zone settings"
-msgstr "Firewall-Zonen-Einstellungen Ã¶ffnen"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:207
-msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-msgstr "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-
-#: htdocs/luci-static/resources/fwlive/table.js:36
-msgid "OUT"
-msgstr "AUSGANG"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1511
-msgid "Palette"
-msgstr "Palette"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-#: htdocs/luci-static/resources/view/status/fwlive.js:1461
-msgid "Pause"
-msgstr "Pause"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-msgid "Paused"
-msgstr "Pausiert"
-
-#: htdocs/luci-static/resources/fwlive/table.js:38
-msgid "Proto"
-msgstr "Protokoll"
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1541
-msgid "Quick search"
-msgstr "Schnellsuche"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:108
-msgid "Remove filter"
-msgstr "Filter entfernen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:811
-msgid "render paused (high rate)"
-msgstr "Rendering pausiert (hohe Rate)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-msgid "Resume"
-msgstr "Fortsetzen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1497
-msgid "Row look"
-msgstr "Zeilenoptik"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-msgid "Row tint"
-msgstr "ZeileneinfÃ¤rbung"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1594
-msgid "Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
-msgstr "ZeileneinfÃ¤rbung schaltet Pass/Deny-Hintergrundfarben. Wenn aktiv, wÃ¤hlen Sie Klassisch (grÃ¼n/rot, Standard) oder Barrierefrei (teal/orange). Aktionstext bleibt in beiden FÃ¤llen farbig."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1453
-msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
-msgstr "Die ZeileneinfÃ¤rbung verwendete einen lokalen Farbfallback, da das aktive LuCI-Theme keine Erlauben/Verweigern-HintergrÃ¼nde anwendet."
-
-#: htdocs/luci-static/resources/fwlive/table.js:33
-msgid "Rule"
-msgstr "Regel"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:813
-msgid "scroll frozen — scroll to top to follow live"
-msgstr "scroll frozen — scroll to top to follow live"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:114
-msgid "sets log on the WAN firewall zone and reloads the firewall."
-msgstr "sets log on the WAN firewall zone and reloads the firewall."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-#: htdocs/luci-static/resources/view/status/fwlive.js:1469
-msgid "Show Detail"
-msgstr "Detail anzeigen"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1523
-msgid "Show hostnames"
-msgstr "Hostnamen anzeigen"
-
-#: htdocs/luci-static/resources/fwlive/table.js:39
-msgid "Source"
-msgstr "Quelle"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1561
-msgid "Source IP contains (! to exclude)"
-msgstr "Quell-IP enthÃ¤lt (! zum AusschlieÃen)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1562
-msgid "Source port (! to exclude)"
-msgstr "Quell-Port (! zum AusschlieÃen)"
-
-#: htdocs/luci-static/resources/fwlive/table.js:41
-msgid "SPort"
-msgstr "Quell-Port"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:330
-msgid "Symbols"
-msgstr "Symbole"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1589
-msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
-msgstr "Die angezeigte Rate fÃ¼r WAN-Protokollierung ist das Zonen-log_limit. OpenWrt-Standard ist 10/Minute ohne explizites Limit; fwlive setzt diese Grenze nicht."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1586
-msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
-msgstr "Die Tabelle aktualisiert sich automatisch, wenn Ihre Firewall Verkehr protokolliert. Pause nutzen, wenn es zu schnell wird."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1454
-msgid "Theme tint fallback"
-msgstr "Theme-Farb-Fallback"
-
-#: htdocs/luci-static/resources/fwlive/table.js:31
-msgid "Time"
-msgstr "Zeit"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1503
-msgid "Toggle pass/deny row background colors"
-msgstr "Pass/Deny-Zeilenhintergrundfarben umschalten"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:331
-msgid "Tone"
-msgstr "Ton"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:124
-msgid "turn it back off with the WAN logging on control on the watch strip."
-msgstr "turn it back off with the WAN logging on control on the watch strip."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:215
-msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-msgstr "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:122
-msgid "Undo:"
-msgstr "Undo:"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1595
-msgid "Use Show Detail for all columns (flags, length, raw message)."
-msgstr "Verwenden Sie âDetail anzeigenâ fÃ¼r alle Spalten (Flags, LÃ¤nge, rohe Nachricht)."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:534
-msgid "using fw4"
-msgstr "mit fw4"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:532
-msgid "using iptables"
-msgstr "mit iptables"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:199
-msgid "Waiting for firewall events"
-msgstr "Waiting for firewall events"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:614
-msgid "WAN drop/reject logging is off."
-msgstr "WAN drop/reject logging is off."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:581
-msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-msgstr "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:200
-msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-msgstr "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:583
-msgid "WAN logging is already enabled."
-msgstr "WAN-Protokollierung ist bereits aktiviert."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "WAN logging on"
-msgstr "WAN-Protokollierung: EIN"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:88
-msgid "WAN logging on (%s). Click to disable."
-msgstr "WAN-Protokollierung: EIN (%s). Klicken zum Deaktivieren."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:77
-msgid "WAN logging unavailable: missing kernel log modules"
-msgstr "WAN-Protokollierung nicht verfÃ¼gbar: fehlende Kernel-Log-Module"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:70
-msgid "WAN logging unavailable: no WAN zone"
-msgstr "WAN-Protokollierung nicht verfÃ¼gbar: keine WAN-Zone"
-
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-#: htdocs/luci-static/resources/view/status/fwlive.js:1448
-msgid "· %s"
-msgstr "· %s"
-
-msgid "View"
-msgstr "Ansicht"
-
-msgid "Watching"
-msgstr "Beobachtet"
-
-msgid "Any protocol"
-msgstr "Beliebiges Protokoll"
-
-msgid "Common"
-msgstr "Häufig"
-
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1050
 msgid "Also seen"
 msgstr "Weitere"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:583
+msgid "Another change is staged for the firewall; apply or revert it first."
+msgstr "Eine andere Änderung an der Firewall ist vorgemerkt; zuerst anwenden oder verwerfen."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1615
+msgid "Any action"
+msgstr "Beliebige Aktion"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1043
+msgid "Any protocol"
+msgstr "Beliebiges Protokoll"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:113
+msgid "Before you enable logging"
+msgstr "Before you enable logging"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:545
+msgid "Cannot enable logging until kernel log modules are installed."
+msgstr "Protokollierung kann erst aktiviert werden, wenn die Kernel-Log-Module installiert sind."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:116
+msgid "Changes:"
+msgstr "Changes:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:249
+msgid "Classic (green/red)"
+msgstr "Klassisch (grÃ¼n/rot)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1599
+msgid "Classic uses green/red; Accessible uses teal/orange"
+msgstr "Klassisch verwendet grÃ¼n/rot; Barrierefrei verwendet teal/orange"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:116
+msgid "Clear all"
+msgstr "Alle lÃ¶schen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1655
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
+msgstr "Zelle anklicken zum Filtern · ≠ auf einem Chip zum Ausschließen · Strg+Klick auf eine Regel für Firewall-Einstellungen · in der Einfachen Ansicht Zeile anklicken für die vollständige Meldung"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1676
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr "Klicken Sie auf eine Zeile (Zeit oder andere Nicht-Link-Zellen), um die vollständige Log-Zeile zu sehen (Einfache Ansicht)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr "Zeile anklicken für die vollständige Meldung"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1677
+msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
+msgstr "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1044
+msgid "Common"
+msgstr "Häufig"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:902
+msgid "Connection lost — retrying…"
+msgstr "Connection lost — retrying…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:585
+msgid "Could not disable logging."
+msgstr "Protokollierung konnte nicht deaktiviert werden."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:549
+msgid "Could not enable logging."
+msgstr "Protokollierung konnte nicht aktiviert werden."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1637
+msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
+msgstr "Eigenes Protokoll (! zum Ausschließen). Überschreibt das Menü, wenn gesetzt."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:42
+msgid "DPort"
+msgstr "Ziel-Port"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:40
+msgid "Destination"
+msgstr "Ziel"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1648
+msgid "Destination IP contains (! to exclude)"
+msgstr "Ziel-IP enthÃ¤lt (! zum AusschlieÃen)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1649
+msgid "Destination port (! to exclude)"
+msgstr "Ziel-Port (! zum AusschlieÃen)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1540
+msgid "Detail"
+msgstr "Detail"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:37
+msgid "Dir"
+msgstr "Richtung"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:85
+msgid "Disabling…"
+msgstr "Disabling…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1573
+msgid "Display options"
+msgstr "Anzeigeoptionen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1673
+msgid "Display options on the bar set Limit, row tint, palette, and hostnames."
+msgstr "Anzeigeoptionen in der Leiste setzen Limit, Zeilenfärbung, Palette und Hostnamen."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:121
+msgid "Does not change:"
+msgstr "Does not change:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:138
+msgid "Don’t show this again"
+msgstr "Don’t show this again"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enable WAN drop/reject logging"
+msgstr "Enable WAN drop/reject logging"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:104
+msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+msgstr "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+msgid "Enable logging"
+msgstr "Protokollierung aktivieren"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1672
+msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
+msgstr "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enabling…"
+msgstr "Enabling…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1057
 msgid "Exclude"
 msgstr "Ausschließen"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Exclude instead"
+msgstr "Stattdessen ausschlieÃen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:53
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:71
+msgid "Filter by %s"
+msgstr "Filtern nach %s"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:136
+msgid "Filter by interface"
+msgstr "Nach Schnittstelle filtern"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:112
+msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
+msgstr "Logs nach Regel filtern (Hinweis: %s). Strg+Klick Ã¶ffnet die Firewall-Einstellungen."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1497
+#: applications/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json:3
+msgid "Firewall Live View"
+msgstr "Firewall-Live-Ansicht"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:43
+msgid "Flags"
+msgstr "Flags"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:45
+msgid "Flow"
+msgstr "Fluss"
+
+#: applications/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json:3
+msgid "Grant access to firewall live log view"
+msgstr "Zugriff auf die Live-Ansicht der Firewall-Protokolle gewähren"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1669
+msgid "Help"
+msgstr "Hilfe"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:853
+msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
+msgstr "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1048
 msgid "ICMPv6"
 msgstr "ICMPv6"
 
-msgid "not TCP"
-msgstr "nicht TCP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:35
+msgid "IN"
+msgstr "EINGANG"
 
-msgid "not UDP"
-msgstr "nicht UDP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1680
+msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
+msgstr "Wenn die ZeileneinfÃ¤rbung fehlt, verwendet das aktive LuCI-Theme mÃ¶glicherweise keine Erfolgs/Fehler-CSS-Variablen; fwlive fÃ¤llt auf lokale Farben zurÃ¼ck (air-gapped, keine Daten verlassen das GerÃ¤t)."
 
-msgid "not ICMP"
-msgstr "nicht ICMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:205
+msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
+msgstr "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
 
-msgid "not ICMPv6"
-msgstr "nicht ICMPv6"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Include instead"
+msgstr "Stattdessen einschlieÃen"
 
-msgid "not IGMP"
-msgstr "nicht IGMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:34
+msgid "Interface"
+msgstr "Schnittstelle"
 
-msgid "not GRE"
-msgstr "nicht GRE"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1645
+msgid "Interface (prefix ! to exclude)"
+msgstr "Schnittstelle (! voranstellen zum AusschlieÃen)"
 
-msgid "not ESP"
-msgstr "nicht ESP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:165
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:232
+msgid "I’ll configure this under Network → Firewall"
+msgstr "I’ll configure this under Network → Firewall"
 
-msgid "not AH"
-msgstr "nicht AH"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:194
+msgid "Kernel log modules missing"
+msgstr "Kernel log modules missing"
 
-msgid "not SCTP"
-msgstr "nicht SCTP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:195
+msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
+msgstr "Kernel-Netfilter-Log-Module fehlen. Installieren Sie kmod-nf-log-ipv4 und kmod-nf-log-ipv6 (oder kmod-nf-log / kmod-nf-log6) und laden Sie dann die Firewall neu."
 
-msgid "or type…"
-msgstr "oder tippen…"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:44
+msgid "Len"
+msgstr "LÃ¤nge"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1576
+msgid "Limit"
+msgstr "Limit"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:210
+msgid "Logging is off on this router"
+msgstr "Logging is off on this router"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:252
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:256
+msgid "Manual test (System → Terminal):"
+msgstr "Manueller Test (System → Terminal):"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:46
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:221
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1552
+msgid "Message"
+msgstr "Nachricht"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1643
+msgid "More filters"
+msgstr "Weitere Filter"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:37
+msgid "Network → Firewall"
+msgstr "Network → Firewall"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:187
+msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under"
+msgstr "Keine WAN-Firewall-Zone in /etc/config/firewall gefunden. Konfigurieren Sie Zonen unter"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:185
+msgid "No WAN zone found"
+msgstr "No WAN zone found"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:163
+msgid "Not now"
+msgstr "Not now"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:220
+msgid "Nothing changes until you click Enable."
+msgstr "Nothing changes until you click Enable."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:36
+msgid "OUT"
+msgstr "AUSGANG"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1567
+msgid "One line"
+msgstr "Einzeilig"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:206
+msgid "Open firewall zone settings"
+msgstr "Firewall-Zonen-Einstellungen Ã¶ffnen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:211
+msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
+msgstr "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1595
+msgid "Palette"
+msgstr "Palette"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1517
+msgid "Pause"
+msgstr "Pause"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+msgid "Paused"
+msgstr "Pausiert"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:38
+msgid "Proto"
+msgstr "Protokoll"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1631
 msgid "Protocol — common values"
 msgstr "Protokoll — häufige Werte"
 
-msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
-msgstr "Eigenes Protokoll (! zum Ausschließen). Überschreibt das Menü, wenn gesetzt."
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1613
+msgid "Quick search"
+msgstr "Schnellsuche"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:91
+msgid "Remove filter"
+msgstr "Filter entfernen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+msgid "Resume"
+msgstr "Fortsetzen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1588
+msgid "Row tint"
+msgstr "ZeileneinfÃ¤rbung"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1678
+msgid "Row tint shows pass/deny row backgrounds when checked. Choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
+msgstr "Zeilenfärbung zeigt Pass/Deny-Hintergrundfarben, wenn aktiviert. Wählen Sie Klassisch (grün/rot, Standard) oder Barrierefrei (teal/orange). Aktionstext bleibt in beiden Fällen farbig."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1507
+msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
+msgstr "Die ZeileneinfÃ¤rbung verwendete einen lokalen Farbfallback, da das aktive LuCI-Theme keine Erlauben/Verweigern-HintergrÃ¼nde anwendet."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:33
+msgid "Rule"
+msgstr "Regel"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:41
+msgid "SPort"
+msgstr "Quell-Port"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1607
+msgid "Show hostnames"
+msgstr "Hostnamen anzeigen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1586
+msgid "Show pass/deny row background colors"
+msgstr "Pass/Deny-Zeilenhintergrundfarben anzeigen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1533
+msgid "Simple"
+msgstr "Einfach"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:39
+msgid "Source"
+msgstr "Quelle"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1646
+msgid "Source IP contains (! to exclude)"
+msgstr "Quell-IP enthÃ¤lt (! zum AusschlieÃen)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1647
+msgid "Source port (! to exclude)"
+msgstr "Quell-Port (! zum AusschlieÃen)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1674
+msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
+msgstr "Die angezeigte Rate fÃ¼r WAN-Protokollierung ist das Zonen-log_limit. OpenWrt-Standard ist 10/Minute ohne explizites Limit; fwlive setzt diese Grenze nicht."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1671
+msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
+msgstr "Die Tabelle aktualisiert sich automatisch, wenn Ihre Firewall Verkehr protokolliert. Pause nutzen, wenn es zu schnell wird."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1508
+msgid "Theme tint fallback"
+msgstr "Theme-Farb-Fallback"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:31
+msgid "Time"
+msgstr "Zeit"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:219
+msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
+msgstr "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:126
+msgid "Undo:"
+msgstr "Undo:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1679
+msgid "Use Detail for all columns (flags, length, raw message)."
+msgstr "Verwenden Sie „Detail“ für alle Spalten (Flags, Länge, rohe Nachricht)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1521
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1525
+msgid "View"
+msgstr "Ansicht"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:591
+msgid "WAN drop/reject logging is off."
+msgstr "WAN drop/reject logging is off."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:204
+msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
+msgstr "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:555
+msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
+msgstr "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:557
+msgid "WAN logging is already enabled."
+msgstr "WAN-Protokollierung ist bereits aktiviert."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:88
+msgid "WAN logging on"
+msgstr "WAN-Protokollierung: EIN"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:94
+msgid "WAN logging on (%s). Click to disable."
+msgstr "WAN-Protokollierung: EIN (%s). Klicken zum Deaktivieren."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:77
+msgid "WAN logging unavailable: missing kernel log modules"
+msgstr "WAN-Protokollierung nicht verfÃ¼gbar: fehlende Kernel-Log-Module"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:70
+msgid "WAN logging unavailable: no WAN zone"
+msgstr "WAN-Protokollierung nicht verfÃ¼gbar: keine WAN-Zone"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:203
+msgid "Waiting for firewall events"
+msgstr "Waiting for firewall events"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1502
+msgid "Watching"
+msgstr "Beobachtet"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1560
+msgid "Wrap"
+msgstr "Umbrechen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:123
+msgid "allow/deny rules, LAN logging, or anything else."
+msgstr "allow/deny rules, LAN logging, or anything else."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:786
+msgid "buffer full"
+msgstr "Puffer voll"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:81
+msgid "default 10/minute"
+msgstr "Standard 10/Minute"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:28
+msgid "is"
+msgstr "ist"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:781
+msgid "loading buffer"
+msgstr "Lade Puffer"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:881
+msgid "loading…"
+msgstr "loading…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:37
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:44
+msgid "not"
+msgstr "nicht"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1065
+msgid "not AH"
+msgstr "nicht AH"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1064
+msgid "not ESP"
+msgstr "nicht ESP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1063
+msgid "not GRE"
+msgstr "nicht GRE"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1060
+msgid "not ICMP"
+msgstr "nicht ICMP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1061
+msgid "not ICMPv6"
+msgstr "nicht ICMPv6"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1062
+msgid "not IGMP"
+msgstr "nicht IGMP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1066
+msgid "not SCTP"
+msgstr "nicht SCTP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1058
+msgid "not TCP"
+msgstr "nicht TCP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1059
+msgid "not UDP"
+msgstr "nicht UDP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1623
+msgid "not block"
+msgstr "nicht blockieren"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1622
+msgid "not drop"
+msgstr "nicht verwerfen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1621
+msgid "not pass"
+msgstr "nicht erlauben"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1624
+msgid "not reject"
+msgstr "nicht zurÃ¼ckweisen"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1625
+msgid "not unknown"
+msgstr "nicht unbekannt"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1636
+msgid "or type…"
+msgstr "oder tippen…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:788
+msgid "render paused (high rate)"
+msgstr "Rendering pausiert (hohe Rate)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:790
+msgid "scroll frozen — scroll to top to follow live"
+msgstr "scroll frozen — scroll to top to follow live"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:118
+msgid "sets log on the WAN firewall zone and reloads the firewall."
+msgstr "sets log on the WAN firewall zone and reloads the firewall."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:254
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:258
+msgid "then ping the router."
+msgstr "dann den Router anpingen."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:128
+msgid "turn it back off with the WAN logging on control on the watch strip."
+msgstr "turn it back off with the WAN logging on control on the watch strip."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:506
+msgid "using fw4"
+msgstr "mit fw4"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:504
+msgid "using iptables"
+msgstr "mit iptables"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:89
+msgid "· %s"
+msgstr "· %s"

--- a/openwrt-feed/luci-app-fwlive/po/ru/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/ru/luci-app-fwlive.po
@@ -12,615 +12,598 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: htdocs/luci-static/resources/fwlive/logging.js:250
-#: htdocs/luci-static/resources/fwlive/logging.js:254
-msgid " then ping the router."
-msgstr " Ð·Ð°ÑÐµÐ¼ Ð²ÑÐ¿Ð¾Ð»Ð½Ð¸ÑÐµ ping Ð¼Ð°ÑÑÑÑÑÐ¸Ð·Ð°ÑÐ¾ÑÐ°."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:907
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:884
 msgid "%d matching · %d/%d stored"
 msgstr "%d matching · %d/%d stored"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:910
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:887
 msgid "0 matching · %d/%d stored"
 msgstr "0 matching · %d/%d stored"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:246
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:250
 msgid "Accessible (teal/orange)"
 msgstr "ÐÐ¾ÑÑÑÐ¿Ð½ÑÐ¹ (Ð±Ð¸ÑÑÐ·Ð¾Ð²ÑÐ¹/Ð¾ÑÐ°Ð½Ð¶ÐµÐ²ÑÐ¹)"
 
-#: htdocs/luci-static/resources/fwlive/table.js:32
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:32
 msgid "Action"
 msgstr "ÐÐµÐ¹ÑÑÐ²Ð¸Ðµ"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:617
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:594
 msgid "Administrator access is required to disable logging."
 msgstr "ÐÐ»Ñ Ð¾ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ñ ÑÑÐµÐ±ÑÑÑÑÑ Ð¿ÑÐ°Ð²Ð° Ð°Ð´Ð¼Ð¸Ð½Ð¸ÑÑÑÐ°ÑÐ¾ÑÐ°."
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:588
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:562
 msgid "Administrator access is required to enable logging."
 msgstr "ÐÐ»Ñ Ð²ÐºÐ»ÑÑÐµÐ½Ð¸Ñ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ñ ÑÑÐµÐ±ÑÑÑÑÑ Ð¿ÑÐ°Ð²Ð° Ð°Ð´Ð¼Ð¸Ð½Ð¸ÑÑÑÐ°ÑÐ¾ÑÐ°."
 
-#: htdocs/luci-static/resources/fwlive/logging.js:119
-msgid "allow/deny rules, LAN logging, or anything else."
-msgstr "allow/deny rules, LAN logging, or anything else."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1543
-msgid "Any action"
-msgstr "ÐÑÐ±Ð¾Ðµ Ð´ÐµÐ¹ÑÑÐ²Ð¸Ðµ"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:109
-msgid "Before you enable logging"
-msgstr "Before you enable logging"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:809
-msgid "buffer full"
-msgstr "Ð±ÑÑÐµÑ Ð·Ð°Ð¿Ð¾Ð»Ð½ÐµÐ½"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:573
-msgid "Cannot enable logging until kernel log modules are installed."
-msgstr "ÐÐµÐ²Ð¾Ð·Ð¼Ð¾Ð¶Ð½Ð¾ Ð²ÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ, Ð¿Ð¾ÐºÐ° Ð½Ðµ ÑÑÑÐ°Ð½Ð¾Ð²Ð»ÐµÐ½Ñ Ð¼Ð¾Ð´ÑÐ»Ð¸ Ð¶ÑÑÐ½Ð°Ð»Ð° ÑÐ´ÑÐ°."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:112
-msgid "Changes:"
-msgstr "Changes:"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1529
-msgid "Chip style"
-msgstr "Ð¡ÑÐ¸Ð»Ñ ÑÐ¸Ð¿Ð¾Ð²"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1593
-msgid "Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels."
-msgstr "Ð¡ÑÐ¸Ð»Ñ ÑÐ¸Ð¿Ð¾Ð² Ð·Ð°Ð´Ð°ÑÑ Ð²Ð¸Ð´ Ð²ÐºÐ»ÑÑÐµÐ½Ð¸Ñ Ð¸ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ (ÐÐ¾Ð´Ð¿Ð¸ÑÐ¸, Ð¡Ð¸Ð¼Ð²Ð¾Ð»Ñ Ð¸Ð»Ð¸ Ð¢Ð¾Ð½). ÐÐ¾ ÑÐ¼Ð¾Ð»ÑÐ°Ð½Ð¸Ñ â ÐÐ¾Ð´Ð¿Ð¸ÑÐ¸."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:245
-msgid "Classic (green/red)"
-msgstr "ÐÐ»Ð°ÑÑÐ¸ÑÐµÑÐºÐ¸Ð¹ (Ð·ÐµÐ»ÑÐ½ÑÐ¹/ÐºÑÐ°ÑÐ½ÑÐ¹)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1515
-msgid "Classic uses green/red; Accessible uses teal/orange"
-msgstr "ÐÐ»Ð°ÑÑÐ¸ÑÐµÑÐºÐ¸Ð¹ â Ð·ÐµÐ»ÑÐ½ÑÐ¹/ÐºÑÐ°ÑÐ½ÑÐ¹; Ð´Ð¾ÑÑÑÐ¿Ð½ÑÐ¹ â Ð±Ð¸ÑÑÐ·Ð¾Ð²ÑÐ¹/Ð¾ÑÐ°Ð½Ð¶ÐµÐ²ÑÐ¹"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:133
-msgid "Clear all"
-msgstr "ÐÑÐ¸ÑÑÐ¸ÑÑ Ð²ÑÑ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
-msgstr "Щёлкните ячейку для фильтра · ≠ на чипе для исключения · Ctrl+щелчок по правилу для настроек МЭ · в Простом виде щёлкните строку для полного сообщения"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
-msgstr "Щёлкните строку (Время или другие ячейки без ссылки), чтобы увидеть полную строку журнала (Простой вид)."
-
-#: htdocs/luci-static/resources/fwlive/table.js:113
-msgid "Click a row for the full message"
-msgstr "Щёлкните строку для полного сообщения"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1592
-msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-msgstr "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:925
-msgid "Connection lost — retrying…"
-msgstr "Connection lost — retrying…"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:608
-msgid "Could not disable logging."
-msgstr "ÐÐµ ÑÐ´Ð°Ð»Ð¾ÑÑ Ð¾ÑÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:575
-msgid "Could not enable logging."
-msgstr "ÐÐµ ÑÐ´Ð°Ð»Ð¾ÑÑ Ð²ÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:81
-msgid "default 10/minute"
-msgstr "Ð¿Ð¾ ÑÐ¼Ð¾Ð»ÑÐ°Ð½Ð¸Ñ 10/Ð¼Ð¸Ð½"
-
-#: htdocs/luci-static/resources/fwlive/table.js:40
-msgid "Destination"
-msgstr "ÐÐ°Ð·Ð½Ð°ÑÐµÐ½Ð¸Ðµ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1563
-msgid "Destination IP contains (! to exclude)"
-msgstr "IP Ð½Ð°Ð·Ð½Ð°ÑÐµÐ½Ð¸Ñ ÑÐ¾Ð´ÐµÑÐ¶Ð¸Ñ (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1564
-msgid "Destination port (! to exclude)"
-msgstr "ÐÐ¾ÑÑ Ð½Ð°Ð·Ð½Ð°ÑÐµÐ½Ð¸Ñ (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
-
-#: htdocs/luci-static/resources/fwlive/table.js:37
-msgid "Dir"
-msgstr "ÐÐ°Ð¿Ñ."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "Disabling…"
-msgstr "Disabling…"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1481
-msgid "Display options"
-msgstr "ÐÐ°ÑÐ°Ð¼ÐµÑÑÑ Ð¾ÑÐ¾Ð±ÑÐ°Ð¶ÐµÐ½Ð¸Ñ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1588
-msgid "Display options hides Limit, row tint, hostnames, and chip style."
-msgstr "ÐÐ°ÑÐ°Ð¼ÐµÑÑÑ Ð¾ÑÐ¾Ð±ÑÐ°Ð¶ÐµÐ½Ð¸Ñ ÑÐºÑÑÐ²Ð°ÑÑ Ð»Ð¸Ð¼Ð¸Ñ, Ð¾ÐºÑÐ°ÑÐºÑ ÑÑÑÐ¾Ðº, Ð¸Ð¼ÐµÐ½Ð° "
-
-#: htdocs/luci-static/resources/fwlive/logging.js:117
-msgid "Does not change:"
-msgstr "Does not change:"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:134
-msgid "Don’t show this again"
-msgstr "Don’t show this again"
-
-#: htdocs/luci-static/resources/fwlive/table.js:42
-msgid "DPort"
-msgstr "ÐÐ¾ÑÑ Ð½Ð°Ð·Ð½."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-msgid "Enable logging"
-msgstr "ÐÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1587
-msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-msgstr "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-#: htdocs/luci-static/resources/fwlive/logging.js:226
-msgid "Enable WAN drop/reject logging"
-msgstr "Enable WAN drop/reject logging"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:100
-msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-msgstr "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-msgid "Enabling…"
-msgstr "Enabling…"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Exclude instead"
-msgstr "ÐÑÐºÐ»ÑÑÐ¸ÑÑ Ð²Ð¼ÐµÑÑÐ¾ ÑÑÐ¾Ð³Ð¾"
-
-#: htdocs/luci-static/resources/fwlive/links.js:53
-#: htdocs/luci-static/resources/fwlive/links.js:71
-msgid "Filter by %s"
-msgstr "Ð¤Ð¸Ð»ÑÑÑ Ð¿Ð¾ %s"
-
-#: htdocs/luci-static/resources/fwlive/links.js:136
-msgid "Filter by interface"
-msgstr "Ð¤Ð¸Ð»ÑÑÑ Ð¿Ð¾ Ð¸Ð½ÑÐµÑÑÐµÐ¹ÑÑ"
-
-#: htdocs/luci-static/resources/fwlive/links.js:112
-msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
-msgstr "Ð¤Ð¸Ð»ÑÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¾Ð² Ð¿Ð¾ Ð¿ÑÐ°Ð²Ð¸Ð»Ñ (Ð¿Ð¾Ð´ÑÐºÐ°Ð·ÐºÐ°: %s). Ctrl+ÐºÐ»Ð¸Ðº Ð¾ÑÐºÑÑÐ²Ð°ÐµÑ Ð½Ð°ÑÑÑÐ¾Ð¹ÐºÐ¸ ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð°."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1527
-msgid "Filters look"
-msgstr "ÐÐ¸Ð´ ÑÐ¸Ð»ÑÑÑÐ¾Ð²"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1442
-msgid "Firewall Live View"
-msgstr "ÐÑÐ¾ÑÐ¼Ð¾ÑÑ ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð° Ð² ÑÐµÐ°Ð»ÑÐ½Ð¾Ð¼ Ð²ÑÐµÐ¼ÐµÐ½Ð¸"
-
-#: htdocs/luci-static/resources/fwlive/table.js:43
-msgid "Flags"
-msgstr "Ð¤Ð»Ð°Ð³Ð¸"
-
-#: htdocs/luci-static/resources/fwlive/table.js:45
-msgid "Flow"
-msgstr "ÐÐ¾ÑÐ¾Ðº"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1584
-msgid "Help"
-msgstr "Ð¡Ð¿ÑÐ°Ð²ÐºÐ°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-msgid "Hide Detail"
-msgstr "Ð¡ÐºÑÑÑÑ Ð´ÐµÑÐ°Ð»Ð¸"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-#: htdocs/luci-static/resources/view/status/fwlive.js:1505
-msgid "Hide row tint"
-msgstr "Ð¡ÐºÑÑÑÑ Ð¿Ð¾Ð´ÑÐ²ÐµÑÐºÑ ÑÑÑÐ¾Ðº"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:876
-msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-msgstr "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1533
-msgid "How include vs exclude filters are shown on chips"
-msgstr "ÐÐ°Ðº Ð½Ð° ÑÐ¸Ð¿Ð°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1596
-msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
-msgstr "ÐÑÐ»Ð¸ ÑÐ²ÐµÑÐ¾Ð²Ð°Ñ Ð¼Ð°ÑÐºÐ¸ÑÐ¾Ð²ÐºÐ° ÑÑÑÐ¾Ðº Ð¾ÑÑÑÑÑÑÐ²ÑÐµÑ, Ð°ÐºÑÐ¸Ð²Ð½Ð°Ñ ÑÐµÐ¼Ð° LuCI Ð¼Ð¾Ð¶ÐµÑ Ð½Ðµ ÑÐ¾Ð´ÐµÑÐ¶Ð°ÑÑ CSS-Ð¿ÐµÑÐµÐ¼ÐµÐ½Ð½ÑÐµ ÑÑÐ¿Ðµ"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:201
-msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-msgstr "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-
-#: htdocs/luci-static/resources/fwlive/table.js:35
-msgid "IN"
-msgstr "ÐÐ¥ÐÐ"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Include instead"
-msgstr "ÐÐºÐ»ÑÑÐ¸ÑÑ Ð²Ð¼ÐµÑÑÐ¾ ÑÑÐ¾Ð³Ð¾"
-
-#: htdocs/luci-static/resources/fwlive/table.js:34
-msgid "Interface"
-msgstr "ÐÐ½ÑÐµÑÑÐµÐ¹Ñ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1560
-msgid "Interface (prefix ! to exclude)"
-msgstr "ÐÐ½ÑÐµÑÑÐµÐ¹Ñ (! Ð² Ð½Ð°ÑÐ°Ð»Ðµ Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:35
-msgid "is"
-msgstr "ÐµÑÑÑ"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:161
-#: htdocs/luci-static/resources/fwlive/logging.js:228
-msgid "I’ll configure this under Network → Firewall"
-msgstr "I’ll configure this under Network → Firewall"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:190
-msgid "Kernel log modules missing"
-msgstr "Kernel log modules missing"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:191
-msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
-msgstr "ÐÑÑÑÑÑÑÐ²ÑÑÑ Ð¼Ð¾Ð´ÑÐ»Ð¸ Ð¶ÑÑÐ½Ð°Ð»Ð° netfilter ÑÐ´ÑÐ°. Ð£ÑÑÐ°Ð½Ð¾Ð²Ð¸ÑÐµ kmod-nf-log-ipv4 Ð¸ kmod-nf-log-ipv6 (Ð¸Ð»Ð¸ kmod-nf-log / kmod-nf-log6), Ð·Ð°ÑÐµÐ¼ Ð¿ÐµÑÐµÐ·Ð°Ð³ÑÑÐ·Ð¸ÑÐµ ÑÐ°Ð¹ÑÐ²Ð¾Ð»."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:329
-msgid "Labels"
-msgstr "ÐÐ¾Ð´Ð¿Ð¸ÑÐ¸"
-
-#: htdocs/luci-static/resources/fwlive/table.js:44
-msgid "Len"
-msgstr "ÐÐ»Ð¸Ð½Ð°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1487
-msgid "Limit"
-msgstr "ÐÐ¸Ð¼Ð¸Ñ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1485
-msgid "Live"
-msgstr "Live"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1494
-msgid "Live updates run until you Pause above."
-msgstr "Live-Ð¾Ð±Ð½Ð¾Ð²Ð»ÐµÐ½Ð¸Ñ Ð¸Ð´ÑÑ, Ð¿Ð¾ÐºÐ° Ð²Ñ Ð½Ðµ Ð½Ð°Ð¶Ð¼ÑÑÐµ ÐÐ°ÑÐ·Ð° Ð²ÑÑÐµ."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:804
-msgid "loading buffer"
-msgstr "Ð·Ð°Ð³ÑÑÐ·ÐºÐ° Ð±ÑÑÐµÑÐ°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:904
-msgid "loading…"
-msgstr "loading…"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:206
-msgid "Logging is off on this router"
-msgstr "Logging is off on this router"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:248
-#: htdocs/luci-static/resources/fwlive/logging.js:252
-msgid "Manual test (System → Terminal): "
-msgstr "Manual test (System → Terminal): "
-
-#: htdocs/luci-static/resources/fwlive/table.js:46
-#: htdocs/luci-static/resources/fwlive/table.js:217
-msgid "Message"
-msgstr "Ð¡Ð¾Ð¾Ð±ÑÐµÐ½Ð¸Ðµ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1235
-msgid "Message: one line"
-msgstr "Ð¡Ð¾Ð¾Ð±ÑÐµÐ½Ð¸Ðµ: Ð¾Ð´Ð½Ð° ÑÑÑÐ¾ÐºÐ°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1236
-#: htdocs/luci-static/resources/view/status/fwlive.js:1475
-msgid "Message: wrap"
-msgstr "Ð¡Ð¾Ð¾Ð±ÑÐµÐ½Ð¸Ðµ: Ð¿ÐµÑÐµÐ½Ð¾Ñ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1558
-msgid "More filters"
-msgstr "ÐÐ¾Ð»ÑÑÐµ ÑÐ¸Ð»ÑÑÑÐ¾Ð²"
-
-#: htdocs/luci-static/resources/fwlive/links.js:37
-msgid "Network → Firewall"
-msgstr "Network → Firewall"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:183
-msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under "
-msgstr "ÐÐ¾Ð½Ð° WAN ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð° Ð½Ðµ Ð½Ð°Ð¹Ð´ÐµÐ½Ð° Ð² /etc/config/firewall. ÐÐ°ÑÑÑÐ¾Ð¹ÑÐµ Ð·Ð¾Ð½Ñ Ð² "
-
-#: htdocs/luci-static/resources/fwlive/logging.js:181
-msgid "No WAN zone found"
-msgstr "No WAN zone found"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:45
-#: htdocs/luci-static/resources/fwlive/chips.js:52
-msgid "not"
-msgstr "Ð½Ðµ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1551
-msgid "not block"
-msgstr "Ð½Ðµ Ð±Ð»Ð¾ÐºÐ¸ÑÐ¾Ð²Ð°ÑÑ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1550
-msgid "not drop"
-msgstr "Ð½Ðµ Ð¾ÑÐ±ÑÐ°ÑÑÐ²Ð°ÑÑ"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:159
-msgid "Not now"
-msgstr "Not now"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1549
-msgid "not pass"
-msgstr "Ð½Ðµ Ð¿ÑÐ¾Ð¿ÑÑÐºÐ°ÑÑ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1552
-msgid "not reject"
-msgstr "Ð½Ðµ Ð¾ÑÐºÐ»Ð¾Ð½ÑÑÑ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1553
-msgid "not unknown"
-msgstr "Ð½Ðµ Ð½ÐµÐ¸Ð·Ð²ÐµÑÑÐ½Ð¾"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:216
-msgid "Nothing changes until you click Enable."
-msgstr "Nothing changes until you click Enable."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:202
-msgid "Open firewall zone settings"
-msgstr "ÐÑÐºÑÑÑÑ Ð½Ð°ÑÑÑÐ¾Ð¹ÐºÐ¸ Ð·Ð¾Ð½ ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð°"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:207
-msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-msgstr "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-
-#: htdocs/luci-static/resources/fwlive/table.js:36
-msgid "OUT"
-msgstr "ÐÐ«Ð¥ÐÐ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1511
-msgid "Palette"
-msgstr "ÐÐ°Ð»Ð¸ÑÑÐ°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-#: htdocs/luci-static/resources/view/status/fwlive.js:1461
-msgid "Pause"
-msgstr "ÐÐ°ÑÐ·Ð°"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-msgid "Paused"
-msgstr "ÐÐ°ÑÐ·Ð°"
-
-#: htdocs/luci-static/resources/fwlive/table.js:38
-msgid "Proto"
-msgstr "ÐÑÐ¾ÑÐ¾ÐºÐ¾Ð»"
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1541
-msgid "Quick search"
-msgstr "ÐÑÑÑÑÑÐ¹ Ð¿Ð¾Ð¸ÑÐº"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:108
-msgid "Remove filter"
-msgstr "Ð£Ð´Ð°Ð»Ð¸ÑÑ ÑÐ¸Ð»ÑÑÑ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:811
-msgid "render paused (high rate)"
-msgstr "ÑÐµÐ½Ð´ÐµÑÐ¸Ð½Ð³ Ð¿ÑÐ¸Ð¾ÑÑÐ°Ð½Ð¾Ð²Ð»ÐµÐ½ (Ð²ÑÑÐ¾ÐºÐ°Ñ ÑÐ°ÑÑÐ¾ÑÐ°)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-msgid "Resume"
-msgstr "ÐÑÐ¾Ð´Ð¾Ð»Ð¶Ð¸ÑÑ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1497
-msgid "Row look"
-msgstr "ÐÐ¸Ð´ ÑÑÑÐ¾Ðº"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-msgid "Row tint"
-msgstr "Ð¦Ð²ÐµÑ ÑÑÑÐ¾Ðº"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1594
-msgid "Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
-msgstr "ÐÐ¾Ð´ÑÐ²ÐµÑÐºÐ° ÑÑÑÐ¾Ðº Ð²ÐºÐ»ÑÑÐ°ÐµÑ ÑÐ¾Ð½Ñ pass/deny. ÐÐ¾Ð³Ð´Ð° Ð²ÐºÐ»ÑÑÐµÐ½Ð°, Ð²ÑÐ±ÐµÑÐ¸ÑÐµ ÐºÐ»Ð°ÑÑÐ¸ÑÐµÑÐºÐ¸Ð¹ (Ð·ÐµÐ»ÑÐ½ÑÐ¹/ÐºÑÐ°ÑÐ½ÑÐ¹, Ð¿Ð¾ ÑÐ¼Ð¾Ð»ÑÐ°Ð½Ð¸Ñ) Ð¸Ð»Ð¸ Ð´Ð¾ÑÑÑÐ¿Ð½ÑÐ¹ (Ð±Ð¸ÑÑÐ·Ð¾Ð²ÑÐ¹/Ð¾ÑÐ°Ð½Ð¶ÐµÐ²ÑÐ¹). Ð¦Ð²ÐµÑ ÑÐµÐºÑÑÐ° Ð´ÐµÐ¹ÑÑÐ²Ð¸Ñ ÑÐ¾"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1453
-msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
-msgstr "Ð¦Ð²ÐµÑÐ¾Ð²Ð°Ñ Ð¼Ð°ÑÐºÐ¸ÑÐ¾Ð²ÐºÐ° ÑÑÑÐ¾Ðº Ð¸ÑÐ¿Ð¾Ð»ÑÐ·Ð¾Ð²Ð°Ð»Ð° Ð»Ð¾ÐºÐ°Ð»ÑÐ½ÑÐ¹ Ð·Ð°Ð¿Ð°ÑÐ½Ð¾Ð¹ ÑÐ²ÐµÑ, ÑÐ°Ðº ÐºÐ°Ðº Ð°ÐºÑÐ¸Ð²Ð½Ð°Ñ ÑÐµÐ¼Ð° LuCI Ð½Ðµ Ð¿ÑÐ¸Ð¼ÐµÐ½ÑÐµÑ ÑÐ¾Ð½ Ð¿ÑÐ¾Ð¿ÑÑÐºÐ°/Ð¾ÑÐºÐ°Ð·Ð°."
-
-#: htdocs/luci-static/resources/fwlive/table.js:33
-msgid "Rule"
-msgstr "ÐÑÐ°Ð²Ð¸Ð»Ð¾"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:813
-msgid "scroll frozen — scroll to top to follow live"
-msgstr "scroll frozen — scroll to top to follow live"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:114
-msgid "sets log on the WAN firewall zone and reloads the firewall."
-msgstr "sets log on the WAN firewall zone and reloads the firewall."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-#: htdocs/luci-static/resources/view/status/fwlive.js:1469
-msgid "Show Detail"
-msgstr "ÐÐ¾ÐºÐ°Ð·Ð°ÑÑ Ð´ÐµÑÐ°Ð»Ð¸"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1523
-msgid "Show hostnames"
-msgstr "ÐÐ¾ÐºÐ°Ð·ÑÐ²Ð°ÑÑ Ð¸Ð¼ÐµÐ½Ð° "
-
-#: htdocs/luci-static/resources/fwlive/table.js:39
-msgid "Source"
-msgstr "ÐÑÑÐ¾ÑÐ½Ð¸Ðº"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1561
-msgid "Source IP contains (! to exclude)"
-msgstr "IP Ð¸ÑÑÐ¾ÑÐ½Ð¸ÐºÐ° ÑÐ¾Ð´ÐµÑÐ¶Ð¸Ñ (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1562
-msgid "Source port (! to exclude)"
-msgstr "ÐÐ¾ÑÑ Ð¸ÑÑÐ¾ÑÐ½Ð¸ÐºÐ° (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
-
-#: htdocs/luci-static/resources/fwlive/table.js:41
-msgid "SPort"
-msgstr "ÐÐ¾ÑÑ Ð¸ÑÑ."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:330
-msgid "Symbols"
-msgstr "Ð¡Ð¸Ð¼Ð²Ð¾Ð»Ñ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1589
-msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
-msgstr "ÐÐ¾ÐºÐ°Ð·Ð°Ð½Ð½Ð°Ñ ÑÐ°ÑÑÐ¾ÑÐ° WAN-Ð¶ÑÑÐ½Ð°Ð»Ð° â log_limit Ð·Ð¾Ð½Ñ. ÐÐ¾ ÑÐ¼Ð¾Ð»ÑÐ°Ð½Ð¸Ñ OpenWrt: 10/Ð¼Ð¸Ð½ Ð±ÐµÐ· ÑÐ²Ð½Ð¾Ð³Ð¾ Ð»Ð¸Ð¼Ð¸ÑÐ°; fwlive ÑÐ°Ð¼ Ð»Ð¸Ð¼Ð¸Ñ Ð½Ðµ Ð·Ð°Ð´Ð°ÑÑ."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1586
-msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
-msgstr "Ð¢Ð°Ð±Ð»Ð¸ÑÐ° Ð¾Ð±Ð½Ð¾Ð²Ð»ÑÐµÑÑÑ Ð°Ð²ÑÐ¾Ð¼Ð°ÑÐ¸ÑÐµÑÐºÐ¸, ÐºÐ¾Ð³Ð´Ð° ÑÐ°Ð¹ÑÐ²Ð¾Ð» Ð¿Ð¸ÑÐµÑ Ð² Ð¶ÑÑÐ½Ð°Ð». ÐÑÐ¿Ð¾Ð»ÑÐ·ÑÐ¹ÑÐµ ÐÐ°ÑÐ·Ñ, ÐµÑÐ»Ð¸ ÑÐ»Ð¸ÑÐºÐ¾Ð¼ Ð±ÑÑÑÑÐ¾."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1454
-msgid "Theme tint fallback"
-msgstr "ÐÐ°Ð¿Ð°ÑÐ½Ð¾Ð¹ ÑÐ²ÐµÑ ÑÐµÐ¼Ñ"
-
-#: htdocs/luci-static/resources/fwlive/table.js:31
-msgid "Time"
-msgstr "ÐÑÐµÐ¼Ñ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1503
-msgid "Toggle pass/deny row background colors"
-msgstr "ÐÐµÑÐµÐºÐ»ÑÑÐ¸ÑÑ ÑÐ²ÐµÑÐ° ÑÐ¾Ð½Ð° ÑÑÑÐ¾Ðº pass/deny"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:331
-msgid "Tone"
-msgstr "Ð¢Ð¾Ð½"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:124
-msgid "turn it back off with the WAN logging on control on the watch strip."
-msgstr "turn it back off with the WAN logging on control on the watch strip."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:215
-msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-msgstr "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:122
-msgid "Undo:"
-msgstr "Undo:"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1595
-msgid "Use Show Detail for all columns (flags, length, raw message)."
-msgstr "ÐÑÐ¿Ð¾Ð»ÑÐ·ÑÐ¹ÑÐµ Â«ÐÐ¾ÐºÐ°Ð·Ð°ÑÑ Ð´ÐµÑÐ°Ð»Ð¸Â» Ð´Ð»Ñ Ð²ÑÐµ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:534
-msgid "using fw4"
-msgstr "Ð¸ÑÐ¿Ð¾Ð»ÑÐ·ÑÐµÑÑÑ fw4"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:532
-msgid "using iptables"
-msgstr "Ð¸ÑÐ¿Ð¾Ð»ÑÐ·ÑÐµÑÑÑ iptables"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:199
-msgid "Waiting for firewall events"
-msgstr "Waiting for firewall events"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:614
-msgid "WAN drop/reject logging is off."
-msgstr "WAN drop/reject logging is off."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:581
-msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-msgstr "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:200
-msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-msgstr "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:583
-msgid "WAN logging is already enabled."
-msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ ÑÐ¶Ðµ Ð²ÐºÐ»ÑÑÐµÐ½Ð¾."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "WAN logging on"
-msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»: ÐÐÐ"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:88
-msgid "WAN logging on (%s). Click to disable."
-msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»: ÐÐÐ (%s). ÐÐ°Ð¶Ð¼Ð¸ÑÐµ, ÑÑÐ¾Ð±Ñ Ð¾ÑÐºÐ»ÑÑÐ¸ÑÑ."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:77
-msgid "WAN logging unavailable: missing kernel log modules"
-msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ Ð½ÐµÐ´Ð¾ÑÑÑÐ¿Ð½Ð¾: Ð¾ÑÑÑÑÑÑÐ²ÑÑÑ Ð¼Ð¾Ð´ÑÐ»Ð¸ Ð¶ÑÑÐ½Ð°Ð»Ð° ÑÐ´ÑÐ°"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:70
-msgid "WAN logging unavailable: no WAN zone"
-msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ Ð½ÐµÐ´Ð¾ÑÑÑÐ¿Ð½Ð¾: Ð½ÐµÑ Ð·Ð¾Ð½Ñ WAN"
-
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-#: htdocs/luci-static/resources/view/status/fwlive.js:1448
-msgid "· %s"
-msgstr "· %s"
-
-msgid "View"
-msgstr "Вид"
-
-msgid "Watching"
-msgstr "ÐÐ°Ð±Ð»ÑÐ´ÐµÐ½Ð¸Ðµ"
-
-msgid "Any protocol"
-msgstr "Любой протокол"
-
-msgid "Common"
-msgstr "Частые"
-
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1050
 msgid "Also seen"
 msgstr "Также встречаются"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:583
+msgid "Another change is staged for the firewall; apply or revert it first."
+msgstr "В брандмауэре уже есть другое незафиксированное изменение; сначала примените или отмените его."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1615
+msgid "Any action"
+msgstr "ÐÑÐ±Ð¾Ðµ Ð´ÐµÐ¹ÑÑÐ²Ð¸Ðµ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1043
+msgid "Any protocol"
+msgstr "Любой протокол"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:113
+msgid "Before you enable logging"
+msgstr "Before you enable logging"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:545
+msgid "Cannot enable logging until kernel log modules are installed."
+msgstr "ÐÐµÐ²Ð¾Ð·Ð¼Ð¾Ð¶Ð½Ð¾ Ð²ÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ, Ð¿Ð¾ÐºÐ° Ð½Ðµ ÑÑÑÐ°Ð½Ð¾Ð²Ð»ÐµÐ½Ñ Ð¼Ð¾Ð´ÑÐ»Ð¸ Ð¶ÑÑÐ½Ð°Ð»Ð° ÑÐ´ÑÐ°."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:116
+msgid "Changes:"
+msgstr "Changes:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:249
+msgid "Classic (green/red)"
+msgstr "ÐÐ»Ð°ÑÑÐ¸ÑÐµÑÐºÐ¸Ð¹ (Ð·ÐµÐ»ÑÐ½ÑÐ¹/ÐºÑÐ°ÑÐ½ÑÐ¹)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1599
+msgid "Classic uses green/red; Accessible uses teal/orange"
+msgstr "ÐÐ»Ð°ÑÑÐ¸ÑÐµÑÐºÐ¸Ð¹ â Ð·ÐµÐ»ÑÐ½ÑÐ¹/ÐºÑÐ°ÑÐ½ÑÐ¹; Ð´Ð¾ÑÑÑÐ¿Ð½ÑÐ¹ â Ð±Ð¸ÑÑÐ·Ð¾Ð²ÑÐ¹/Ð¾ÑÐ°Ð½Ð¶ÐµÐ²ÑÐ¹"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:116
+msgid "Clear all"
+msgstr "ÐÑÐ¸ÑÑÐ¸ÑÑ Ð²ÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1655
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
+msgstr "Щёлкните ячейку для фильтра · ≠ на чипе для исключения · Ctrl+щелчок по правилу для настроек МЭ · в Простом виде щёлкните строку для полного сообщения"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1676
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr "Щёлкните строку (Время или другие ячейки без ссылки), чтобы увидеть полную строку журнала (Простой вид)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr "Щёлкните строку для полного сообщения"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1677
+msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
+msgstr "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1044
+msgid "Common"
+msgstr "Частые"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:902
+msgid "Connection lost — retrying…"
+msgstr "Connection lost — retrying…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:585
+msgid "Could not disable logging."
+msgstr "ÐÐµ ÑÐ´Ð°Ð»Ð¾ÑÑ Ð¾ÑÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:549
+msgid "Could not enable logging."
+msgstr "ÐÐµ ÑÐ´Ð°Ð»Ð¾ÑÑ Ð²ÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1637
+msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
+msgstr "Свой протокол (! для исключения). Переопределяет меню, если задан."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:42
+msgid "DPort"
+msgstr "ÐÐ¾ÑÑ Ð½Ð°Ð·Ð½."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:40
+msgid "Destination"
+msgstr "ÐÐ°Ð·Ð½Ð°ÑÐµÐ½Ð¸Ðµ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1648
+msgid "Destination IP contains (! to exclude)"
+msgstr "IP Ð½Ð°Ð·Ð½Ð°ÑÐµÐ½Ð¸Ñ ÑÐ¾Ð´ÐµÑÐ¶Ð¸Ñ (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1649
+msgid "Destination port (! to exclude)"
+msgstr "ÐÐ¾ÑÑ Ð½Ð°Ð·Ð½Ð°ÑÐµÐ½Ð¸Ñ (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1540
+msgid "Detail"
+msgstr "Подробно"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:37
+msgid "Dir"
+msgstr "ÐÐ°Ð¿Ñ."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:85
+msgid "Disabling…"
+msgstr "Disabling…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1573
+msgid "Display options"
+msgstr "ÐÐ°ÑÐ°Ð¼ÐµÑÑÑ Ð¾ÑÐ¾Ð±ÑÐ°Ð¶ÐµÐ½Ð¸Ñ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1673
+msgid "Display options on the bar set Limit, row tint, palette, and hostnames."
+msgstr "Параметры отображения на панели задают лимит, окраску строк, палитру и имена узлов."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:121
+msgid "Does not change:"
+msgstr "Does not change:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:138
+msgid "Don’t show this again"
+msgstr "Don’t show this again"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enable WAN drop/reject logging"
+msgstr "Enable WAN drop/reject logging"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:104
+msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+msgstr "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+msgid "Enable logging"
+msgstr "ÐÐºÐ»ÑÑÐ¸ÑÑ Ð¶ÑÑÐ½Ð°Ð»"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1672
+msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
+msgstr "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enabling…"
+msgstr "Enabling…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1057
 msgid "Exclude"
 msgstr "Исключить"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Exclude instead"
+msgstr "ÐÑÐºÐ»ÑÑÐ¸ÑÑ Ð²Ð¼ÐµÑÑÐ¾ ÑÑÐ¾Ð³Ð¾"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:53
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:71
+msgid "Filter by %s"
+msgstr "Ð¤Ð¸Ð»ÑÑÑ Ð¿Ð¾ %s"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:136
+msgid "Filter by interface"
+msgstr "Ð¤Ð¸Ð»ÑÑÑ Ð¿Ð¾ Ð¸Ð½ÑÐµÑÑÐµÐ¹ÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:112
+msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
+msgstr "Ð¤Ð¸Ð»ÑÑÑ Ð¶ÑÑÐ½Ð°Ð»Ð¾Ð² Ð¿Ð¾ Ð¿ÑÐ°Ð²Ð¸Ð»Ñ (Ð¿Ð¾Ð´ÑÐºÐ°Ð·ÐºÐ°: %s). Ctrl+ÐºÐ»Ð¸Ðº Ð¾ÑÐºÑÑÐ²Ð°ÐµÑ Ð½Ð°ÑÑÑÐ¾Ð¹ÐºÐ¸ ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð°."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1497
+#: applications/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json:3
+msgid "Firewall Live View"
+msgstr "ÐÑÐ¾ÑÐ¼Ð¾ÑÑ ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð° Ð² ÑÐµÐ°Ð»ÑÐ½Ð¾Ð¼ Ð²ÑÐµÐ¼ÐµÐ½Ð¸"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:43
+msgid "Flags"
+msgstr "Ð¤Ð»Ð°Ð³Ð¸"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:45
+msgid "Flow"
+msgstr "ÐÐ¾ÑÐ¾Ðº"
+
+#: applications/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json:3
+msgid "Grant access to firewall live log view"
+msgstr "Предоставить доступ к живому просмотру журнала межсетевого экрана"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1669
+msgid "Help"
+msgstr "Ð¡Ð¿ÑÐ°Ð²ÐºÐ°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:853
+msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
+msgstr "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1048
 msgid "ICMPv6"
 msgstr "ICMPv6"
 
-msgid "not TCP"
-msgstr "не TCP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:35
+msgid "IN"
+msgstr "ÐÐ¥ÐÐ"
 
-msgid "not UDP"
-msgstr "не UDP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1680
+msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
+msgstr "ÐÑÐ»Ð¸ ÑÐ²ÐµÑÐ¾Ð²Ð°Ñ Ð¼Ð°ÑÐºÐ¸ÑÐ¾Ð²ÐºÐ° ÑÑÑÐ¾Ðº Ð¾ÑÑÑÑÑÑÐ²ÑÐµÑ, Ð°ÐºÑÐ¸Ð²Ð½Ð°Ñ ÑÐµÐ¼Ð° LuCI Ð¼Ð¾Ð¶ÐµÑ Ð½Ðµ ÑÐ¾Ð´ÐµÑÐ¶Ð°ÑÑ CSS-Ð¿ÐµÑÐµÐ¼ÐµÐ½Ð½ÑÐµ ÑÑÐ¿Ðµ"
 
-msgid "not ICMP"
-msgstr "не ICMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:205
+msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
+msgstr "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
 
-msgid "not ICMPv6"
-msgstr "не ICMPv6"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Include instead"
+msgstr "ÐÐºÐ»ÑÑÐ¸ÑÑ Ð²Ð¼ÐµÑÑÐ¾ ÑÑÐ¾Ð³Ð¾"
 
-msgid "not IGMP"
-msgstr "не IGMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:34
+msgid "Interface"
+msgstr "ÐÐ½ÑÐµÑÑÐµÐ¹Ñ"
 
-msgid "not GRE"
-msgstr "не GRE"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1645
+msgid "Interface (prefix ! to exclude)"
+msgstr "ÐÐ½ÑÐµÑÑÐµÐ¹Ñ (! Ð² Ð½Ð°ÑÐ°Ð»Ðµ Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
 
-msgid "not ESP"
-msgstr "не ESP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:165
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:232
+msgid "I’ll configure this under Network → Firewall"
+msgstr "I’ll configure this under Network → Firewall"
 
-msgid "not AH"
-msgstr "не AH"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:194
+msgid "Kernel log modules missing"
+msgstr "Kernel log modules missing"
 
-msgid "not SCTP"
-msgstr "не SCTP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:195
+msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
+msgstr "ÐÑÑÑÑÑÑÐ²ÑÑÑ Ð¼Ð¾Ð´ÑÐ»Ð¸ Ð¶ÑÑÐ½Ð°Ð»Ð° netfilter ÑÐ´ÑÐ°. Ð£ÑÑÐ°Ð½Ð¾Ð²Ð¸ÑÐµ kmod-nf-log-ipv4 Ð¸ kmod-nf-log-ipv6 (Ð¸Ð»Ð¸ kmod-nf-log / kmod-nf-log6), Ð·Ð°ÑÐµÐ¼ Ð¿ÐµÑÐµÐ·Ð°Ð³ÑÑÐ·Ð¸ÑÐµ ÑÐ°Ð¹ÑÐ²Ð¾Ð»."
 
-msgid "or type…"
-msgstr "или введите…"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:44
+msgid "Len"
+msgstr "ÐÐ»Ð¸Ð½Ð°"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1576
+msgid "Limit"
+msgstr "ÐÐ¸Ð¼Ð¸Ñ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:210
+msgid "Logging is off on this router"
+msgstr "Logging is off on this router"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:252
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:256
+msgid "Manual test (System → Terminal):"
+msgstr "Ручной тест (Система → Терминал):"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:46
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:221
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1552
+msgid "Message"
+msgstr "Ð¡Ð¾Ð¾Ð±ÑÐµÐ½Ð¸Ðµ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1643
+msgid "More filters"
+msgstr "ÐÐ¾Ð»ÑÑÐµ ÑÐ¸Ð»ÑÑÑÐ¾Ð²"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:37
+msgid "Network → Firewall"
+msgstr "Network → Firewall"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:187
+msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under"
+msgstr "Зона WAN брандмауэра не найдена в /etc/config/firewall. Настройте зоны в"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:185
+msgid "No WAN zone found"
+msgstr "No WAN zone found"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:163
+msgid "Not now"
+msgstr "Not now"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:220
+msgid "Nothing changes until you click Enable."
+msgstr "Nothing changes until you click Enable."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:36
+msgid "OUT"
+msgstr "ÐÐ«Ð¥ÐÐ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1567
+msgid "One line"
+msgstr "Одна строка"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:206
+msgid "Open firewall zone settings"
+msgstr "ÐÑÐºÑÑÑÑ Ð½Ð°ÑÑÑÐ¾Ð¹ÐºÐ¸ Ð·Ð¾Ð½ ÑÐ°Ð¹ÑÐ²Ð¾Ð»Ð°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:211
+msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
+msgstr "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1595
+msgid "Palette"
+msgstr "ÐÐ°Ð»Ð¸ÑÑÐ°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1517
+msgid "Pause"
+msgstr "ÐÐ°ÑÐ·Ð°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+msgid "Paused"
+msgstr "ÐÐ°ÑÐ·Ð°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:38
+msgid "Proto"
+msgstr "ÐÑÐ¾ÑÐ¾ÐºÐ¾Ð»"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1631
 msgid "Protocol — common values"
 msgstr "Протокол — частые значения"
 
-msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
-msgstr "Свой протокол (! для исключения). Переопределяет меню, если задан."
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1613
+msgid "Quick search"
+msgstr "ÐÑÑÑÑÑÐ¹ Ð¿Ð¾Ð¸ÑÐº"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:91
+msgid "Remove filter"
+msgstr "Ð£Ð´Ð°Ð»Ð¸ÑÑ ÑÐ¸Ð»ÑÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+msgid "Resume"
+msgstr "ÐÑÐ¾Ð´Ð¾Ð»Ð¶Ð¸ÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1588
+msgid "Row tint"
+msgstr "Ð¦Ð²ÐµÑ ÑÑÑÐ¾Ðº"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1678
+msgid "Row tint shows pass/deny row backgrounds when checked. Choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
+msgstr "Подсветка строк показывает фоны pass/deny, когда включена. Выберите классический (зелёный/красный, по умолчанию) или доступный (бирюзовый/оранжевый). Цвет текста действия сохраняется в любом случае."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1507
+msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
+msgstr "Ð¦Ð²ÐµÑÐ¾Ð²Ð°Ñ Ð¼Ð°ÑÐºÐ¸ÑÐ¾Ð²ÐºÐ° ÑÑÑÐ¾Ðº Ð¸ÑÐ¿Ð¾Ð»ÑÐ·Ð¾Ð²Ð°Ð»Ð° Ð»Ð¾ÐºÐ°Ð»ÑÐ½ÑÐ¹ Ð·Ð°Ð¿Ð°ÑÐ½Ð¾Ð¹ ÑÐ²ÐµÑ, ÑÐ°Ðº ÐºÐ°Ðº Ð°ÐºÑÐ¸Ð²Ð½Ð°Ñ ÑÐµÐ¼Ð° LuCI Ð½Ðµ Ð¿ÑÐ¸Ð¼ÐµÐ½ÑÐµÑ ÑÐ¾Ð½ Ð¿ÑÐ¾Ð¿ÑÑÐºÐ°/Ð¾ÑÐºÐ°Ð·Ð°."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:33
+msgid "Rule"
+msgstr "ÐÑÐ°Ð²Ð¸Ð»Ð¾"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:41
+msgid "SPort"
+msgstr "ÐÐ¾ÑÑ Ð¸ÑÑ."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1607
+msgid "Show hostnames"
+msgstr "ÐÐ¾ÐºÐ°Ð·ÑÐ²Ð°ÑÑ Ð¸Ð¼ÐµÐ½Ð° "
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1586
+msgid "Show pass/deny row background colors"
+msgstr "Показывать цвета фона строк pass/deny"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1533
+msgid "Simple"
+msgstr "Простой"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:39
+msgid "Source"
+msgstr "ÐÑÑÐ¾ÑÐ½Ð¸Ðº"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1646
+msgid "Source IP contains (! to exclude)"
+msgstr "IP Ð¸ÑÑÐ¾ÑÐ½Ð¸ÐºÐ° ÑÐ¾Ð´ÐµÑÐ¶Ð¸Ñ (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1647
+msgid "Source port (! to exclude)"
+msgstr "ÐÐ¾ÑÑ Ð¸ÑÑÐ¾ÑÐ½Ð¸ÐºÐ° (! Ð´Ð»Ñ Ð¸ÑÐºÐ»ÑÑÐµÐ½Ð¸Ñ)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1674
+msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
+msgstr "ÐÐ¾ÐºÐ°Ð·Ð°Ð½Ð½Ð°Ñ ÑÐ°ÑÑÐ¾ÑÐ° WAN-Ð¶ÑÑÐ½Ð°Ð»Ð° â log_limit Ð·Ð¾Ð½Ñ. ÐÐ¾ ÑÐ¼Ð¾Ð»ÑÐ°Ð½Ð¸Ñ OpenWrt: 10/Ð¼Ð¸Ð½ Ð±ÐµÐ· ÑÐ²Ð½Ð¾Ð³Ð¾ Ð»Ð¸Ð¼Ð¸ÑÐ°; fwlive ÑÐ°Ð¼ Ð»Ð¸Ð¼Ð¸Ñ Ð½Ðµ Ð·Ð°Ð´Ð°ÑÑ."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1671
+msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
+msgstr "Ð¢Ð°Ð±Ð»Ð¸ÑÐ° Ð¾Ð±Ð½Ð¾Ð²Ð»ÑÐµÑÑÑ Ð°Ð²ÑÐ¾Ð¼Ð°ÑÐ¸ÑÐµÑÐºÐ¸, ÐºÐ¾Ð³Ð´Ð° ÑÐ°Ð¹ÑÐ²Ð¾Ð» Ð¿Ð¸ÑÐµÑ Ð² Ð¶ÑÑÐ½Ð°Ð». ÐÑÐ¿Ð¾Ð»ÑÐ·ÑÐ¹ÑÐµ ÐÐ°ÑÐ·Ñ, ÐµÑÐ»Ð¸ ÑÐ»Ð¸ÑÐºÐ¾Ð¼ Ð±ÑÑÑÑÐ¾."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1508
+msgid "Theme tint fallback"
+msgstr "ÐÐ°Ð¿Ð°ÑÐ½Ð¾Ð¹ ÑÐ²ÐµÑ ÑÐµÐ¼Ñ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:31
+msgid "Time"
+msgstr "ÐÑÐµÐ¼Ñ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:219
+msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
+msgstr "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:126
+msgid "Undo:"
+msgstr "Undo:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1679
+msgid "Use Detail for all columns (flags, length, raw message)."
+msgstr "Используйте «Подробно» для всех столбцов (флаги, длина, исходное сообщение)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1521
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1525
+msgid "View"
+msgstr "Вид"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:591
+msgid "WAN drop/reject logging is off."
+msgstr "WAN drop/reject logging is off."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:204
+msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
+msgstr "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:555
+msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
+msgstr "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:557
+msgid "WAN logging is already enabled."
+msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ ÑÐ¶Ðµ Ð²ÐºÐ»ÑÑÐµÐ½Ð¾."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:88
+msgid "WAN logging on"
+msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»: ÐÐÐ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:94
+msgid "WAN logging on (%s). Click to disable."
+msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»: ÐÐÐ (%s). ÐÐ°Ð¶Ð¼Ð¸ÑÐµ, ÑÑÐ¾Ð±Ñ Ð¾ÑÐºÐ»ÑÑÐ¸ÑÑ."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:77
+msgid "WAN logging unavailable: missing kernel log modules"
+msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ Ð½ÐµÐ´Ð¾ÑÑÑÐ¿Ð½Ð¾: Ð¾ÑÑÑÑÑÑÐ²ÑÑÑ Ð¼Ð¾Ð´ÑÐ»Ð¸ Ð¶ÑÑÐ½Ð°Ð»Ð° ÑÐ´ÑÐ°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:70
+msgid "WAN logging unavailable: no WAN zone"
+msgstr "WAN-Ð¶ÑÑÐ½Ð°Ð»Ð¸ÑÐ¾Ð²Ð°Ð½Ð¸Ðµ Ð½ÐµÐ´Ð¾ÑÑÑÐ¿Ð½Ð¾: Ð½ÐµÑ Ð·Ð¾Ð½Ñ WAN"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:203
+msgid "Waiting for firewall events"
+msgstr "Waiting for firewall events"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1502
+msgid "Watching"
+msgstr "ÐÐ°Ð±Ð»ÑÐ´ÐµÐ½Ð¸Ðµ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1560
+msgid "Wrap"
+msgstr "Перенос"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:123
+msgid "allow/deny rules, LAN logging, or anything else."
+msgstr "allow/deny rules, LAN logging, or anything else."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:786
+msgid "buffer full"
+msgstr "Ð±ÑÑÐµÑ Ð·Ð°Ð¿Ð¾Ð»Ð½ÐµÐ½"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:81
+msgid "default 10/minute"
+msgstr "Ð¿Ð¾ ÑÐ¼Ð¾Ð»ÑÐ°Ð½Ð¸Ñ 10/Ð¼Ð¸Ð½"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:28
+msgid "is"
+msgstr "ÐµÑÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:781
+msgid "loading buffer"
+msgstr "Ð·Ð°Ð³ÑÑÐ·ÐºÐ° Ð±ÑÑÐµÑÐ°"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:881
+msgid "loading…"
+msgstr "loading…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:37
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:44
+msgid "not"
+msgstr "Ð½Ðµ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1065
+msgid "not AH"
+msgstr "не AH"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1064
+msgid "not ESP"
+msgstr "не ESP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1063
+msgid "not GRE"
+msgstr "не GRE"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1060
+msgid "not ICMP"
+msgstr "не ICMP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1061
+msgid "not ICMPv6"
+msgstr "не ICMPv6"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1062
+msgid "not IGMP"
+msgstr "не IGMP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1066
+msgid "not SCTP"
+msgstr "не SCTP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1058
+msgid "not TCP"
+msgstr "не TCP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1059
+msgid "not UDP"
+msgstr "не UDP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1623
+msgid "not block"
+msgstr "Ð½Ðµ Ð±Ð»Ð¾ÐºÐ¸ÑÐ¾Ð²Ð°ÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1622
+msgid "not drop"
+msgstr "Ð½Ðµ Ð¾ÑÐ±ÑÐ°ÑÑÐ²Ð°ÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1621
+msgid "not pass"
+msgstr "Ð½Ðµ Ð¿ÑÐ¾Ð¿ÑÑÐºÐ°ÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1624
+msgid "not reject"
+msgstr "Ð½Ðµ Ð¾ÑÐºÐ»Ð¾Ð½ÑÑÑ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1625
+msgid "not unknown"
+msgstr "Ð½Ðµ Ð½ÐµÐ¸Ð·Ð²ÐµÑÑÐ½Ð¾"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1636
+msgid "or type…"
+msgstr "или введите…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:788
+msgid "render paused (high rate)"
+msgstr "ÑÐµÐ½Ð´ÐµÑÐ¸Ð½Ð³ Ð¿ÑÐ¸Ð¾ÑÑÐ°Ð½Ð¾Ð²Ð»ÐµÐ½ (Ð²ÑÑÐ¾ÐºÐ°Ñ ÑÐ°ÑÑÐ¾ÑÐ°)"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:790
+msgid "scroll frozen — scroll to top to follow live"
+msgstr "scroll frozen — scroll to top to follow live"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:118
+msgid "sets log on the WAN firewall zone and reloads the firewall."
+msgstr "sets log on the WAN firewall zone and reloads the firewall."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:254
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:258
+msgid "then ping the router."
+msgstr "затем выполните ping маршрутизатора."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:128
+msgid "turn it back off with the WAN logging on control on the watch strip."
+msgstr "turn it back off with the WAN logging on control on the watch strip."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:506
+msgid "using fw4"
+msgstr "Ð¸ÑÐ¿Ð¾Ð»ÑÐ·ÑÐµÑÑÑ fw4"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:504
+msgid "using iptables"
+msgstr "Ð¸ÑÐ¿Ð¾Ð»ÑÐ·ÑÐµÑÑÑ iptables"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:89
+msgid "· %s"
+msgstr "· %s"

--- a/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot
+++ b/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot
@@ -1,626 +1,636 @@
 msgid ""
-msgstr ""
-"Project-Id-Version: luci-app-fwlive\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-31 02:17+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: htdocs/luci-static/resources/fwlive/logging.js:250
-#: htdocs/luci-static/resources/fwlive/logging.js:254
-msgid " then ping the router."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:907
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:884
 msgid "%d matching · %d/%d stored"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:910
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:887
 msgid "0 matching · %d/%d stored"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:246
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:250
 msgid "Accessible (teal/orange)"
 msgstr ""
 
-#: htdocs/luci-static/resources/fwlive/table.js:32
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:32
 msgid "Action"
 msgstr ""
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:617
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:594
 msgid "Administrator access is required to disable logging."
 msgstr ""
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:588
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:562
 msgid "Administrator access is required to enable logging."
 msgstr ""
 
-#: htdocs/luci-static/resources/fwlive/logging.js:119
-msgid "allow/deny rules, LAN logging, or anything else."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1543
-msgid "Any action"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:109
-msgid "Before you enable logging"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:809
-msgid "buffer full"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:573
-msgid "Cannot enable logging until kernel log modules are installed."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:112
-msgid "Changes:"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1529
-msgid "Chip style"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1593
-msgid "Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:245
-msgid "Classic (green/red)"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1515
-msgid "Classic uses green/red; Accessible uses teal/orange"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/chips.js:133
-msgid "Clear all"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:113
-msgid "Click a row for the full message"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1592
-msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:925
-msgid "Connection lost — retrying…"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:608
-msgid "Could not disable logging."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:575
-msgid "Could not enable logging."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:81
-msgid "default 10/minute"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:40
-msgid "Destination"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1563
-msgid "Destination IP contains (! to exclude)"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1564
-msgid "Destination port (! to exclude)"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:37
-msgid "Dir"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "Disabling…"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1481
-msgid "Display options"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1588
-msgid "Display options hides Limit, row tint, hostnames, and chip style."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:117
-msgid "Does not change:"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:134
-msgid "Don’t show this again"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:42
-msgid "DPort"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-msgid "Enable logging"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1587
-msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-#: htdocs/luci-static/resources/fwlive/logging.js:226
-msgid "Enable WAN drop/reject logging"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:100
-msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-#: htdocs/luci-static/resources/fwlive/logging.js:226
-msgid "Enabling…"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Exclude instead"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/links.js:53
-#: htdocs/luci-static/resources/fwlive/links.js:71
-msgid "Filter by %s"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/links.js:136
-msgid "Filter by interface"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/links.js:112
-msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1527
-msgid "Filters look"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1442
-msgid "Firewall Live View"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:43
-msgid "Flags"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:45
-msgid "Flow"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1584
-msgid "Help"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-msgid "Hide Detail"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-#: htdocs/luci-static/resources/view/status/fwlive.js:1505
-msgid "Hide row tint"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:876
-msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1533
-msgid "How include vs exclude filters are shown on chips"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1596
-msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:201
-msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:35
-msgid "IN"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Include instead"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:34
-msgid "Interface"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1560
-msgid "Interface (prefix ! to exclude)"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/chips.js:35
-msgid "is"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:161
-#: htdocs/luci-static/resources/fwlive/logging.js:228
-msgid "I’ll configure this under Network → Firewall"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:190
-msgid "Kernel log modules missing"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:191
-msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:329
-msgid "Labels"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:44
-msgid "Len"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1487
-msgid "Limit"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1485
-msgid "Live"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1494
-msgid "Live updates run until you Pause above."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:804
-msgid "loading buffer"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:904
-msgid "loading…"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:206
-msgid "Logging is off on this router"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:248
-#: htdocs/luci-static/resources/fwlive/logging.js:252
-msgid "Manual test (System → Terminal): "
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:46
-#: htdocs/luci-static/resources/fwlive/table.js:217
-msgid "Message"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1235
-msgid "Message: one line"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1236
-#: htdocs/luci-static/resources/view/status/fwlive.js:1475
-msgid "Message: wrap"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1558
-msgid "More filters"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/links.js:37
-msgid "Network → Firewall"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:183
-msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under "
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:181
-msgid "No WAN zone found"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/chips.js:45
-#: htdocs/luci-static/resources/fwlive/chips.js:52
-msgid "not"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1551
-msgid "not block"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1550
-msgid "not drop"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:159
-msgid "Not now"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1549
-msgid "not pass"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1552
-msgid "not reject"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1553
-msgid "not unknown"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:216
-msgid "Nothing changes until you click Enable."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:202
-msgid "Open firewall zone settings"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:207
-msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:36
-msgid "OUT"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1511
-msgid "Palette"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-#: htdocs/luci-static/resources/view/status/fwlive.js:1461
-msgid "Pause"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-msgid "Paused"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:38
-msgid "Proto"
-msgstr ""
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1541
-msgid "Quick search"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/chips.js:108
-msgid "Remove filter"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:811
-msgid "render paused (high rate)"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-msgid "Resume"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1497
-msgid "Row look"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-msgid "Row tint"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1594
-msgid "Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1453
-msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:33
-msgid "Rule"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:813
-msgid "scroll frozen — scroll to top to follow live"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:114
-msgid "sets log on the WAN firewall zone and reloads the firewall."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-#: htdocs/luci-static/resources/view/status/fwlive.js:1469
-msgid "Show Detail"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1523
-msgid "Show hostnames"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:39
-msgid "Source"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1561
-msgid "Source IP contains (! to exclude)"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1562
-msgid "Source port (! to exclude)"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:41
-msgid "SPort"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:330
-msgid "Symbols"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1589
-msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1586
-msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1454
-msgid "Theme tint fallback"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/table.js:31
-msgid "Time"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1503
-msgid "Toggle pass/deny row background colors"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:331
-msgid "Tone"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:124
-msgid "turn it back off with the WAN logging on control on the watch strip."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:215
-msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:122
-msgid "Undo:"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1595
-msgid "Use Show Detail for all columns (flags, length, raw message)."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:534
-msgid "using fw4"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:532
-msgid "using iptables"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:199
-msgid "Waiting for firewall events"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:614
-msgid "WAN drop/reject logging is off."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:581
-msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:200
-msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:583
-msgid "WAN logging is already enabled."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:89
-msgid "WAN logging on"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:95
-msgid "WAN logging on (%s). Click to disable."
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:77
-msgid "WAN logging unavailable: missing kernel log modules"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:70
-msgid "WAN logging unavailable: no WAN zone"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-#: htdocs/luci-static/resources/view/status/fwlive.js:1453
-msgid "Watching"
-msgstr ""
-
-#: htdocs/luci-static/resources/fwlive/logging.js:90
-msgid "· %s"
-msgstr ""
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1475
-msgid "View"
-msgstr ""
-
-msgid "Any protocol"
-msgstr ""
-
-msgid "Common"
-msgstr ""
-
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1050
 msgid "Also seen"
 msgstr ""
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:583
+msgid "Another change is staged for the firewall; apply or revert it first."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1615
+msgid "Any action"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1043
+msgid "Any protocol"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:113
+msgid "Before you enable logging"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:545
+msgid "Cannot enable logging until kernel log modules are installed."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:116
+msgid "Changes:"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:249
+msgid "Classic (green/red)"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1599
+msgid "Classic uses green/red; Accessible uses teal/orange"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:116
+msgid "Clear all"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1655
+msgid ""
+"Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for "
+"firewall settings · in Simple view, click a row for the full message"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1676
+msgid ""
+"Click a row (Time or other non-link cells) to see the full log line (Simple "
+"view)."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1677
+msgid ""
+"Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a "
+"chip) to exclude."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1044
+msgid "Common"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:902
+msgid "Connection lost — retrying…"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:585
+msgid "Could not disable logging."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:549
+msgid "Could not enable logging."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1637
+msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:42
+msgid "DPort"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:40
+msgid "Destination"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1648
+msgid "Destination IP contains (! to exclude)"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1649
+msgid "Destination port (! to exclude)"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1540
+msgid "Detail"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:37
+msgid "Dir"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:85
+msgid "Disabling…"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1573
+msgid "Display options"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1673
+msgid "Display options on the bar set Limit, row tint, palette, and hostnames."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:121
+msgid "Does not change:"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:138
+msgid "Don’t show this again"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enable WAN drop/reject logging"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:104
+msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+msgid "Enable logging"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1672
+msgid ""
+"Enable logging turns on WAN zone drop/reject logging only (same as Network → "
+"Firewall). It does not add rules or log normal LAN browsing."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enabling…"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1057
 msgid "Exclude"
 msgstr ""
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Exclude instead"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:53
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:71
+msgid "Filter by %s"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:136
+msgid "Filter by interface"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:112
+msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1497
+#: applications/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json:3
+msgid "Firewall Live View"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:43
+msgid "Flags"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:45
+msgid "Flow"
+msgstr ""
+
+#: applications/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json:3
+msgid "Grant access to firewall live log view"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1669
+msgid "Help"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:853
+msgid ""
+"High event rate — table refresh is throttled to protect the browser. The "
+"buffer still updates; refresh will resume automatically."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1048
 msgid "ICMPv6"
 msgstr ""
 
-msgid "not TCP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:35
+msgid "IN"
 msgstr ""
 
-msgid "not UDP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1680
+msgid ""
+"If Row tint looks missing, the active LuCI theme may omit success/error or "
+"info/warn CSS variables; fwlive falls back to local colors (air-gapped, no "
+"data leaves the device)."
 msgstr ""
 
-msgid "not ICMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:205
+msgid ""
+"If the WAN is quiet, wait for probes or use the optional ping check in "
+"Help / the enabling-logs guide."
 msgstr ""
 
-msgid "not ICMPv6"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Include instead"
 msgstr ""
 
-msgid "not IGMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:34
+msgid "Interface"
 msgstr ""
 
-msgid "not GRE"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1645
+msgid "Interface (prefix ! to exclude)"
 msgstr ""
 
-msgid "not ESP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:165
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:232
+msgid "I’ll configure this under Network → Firewall"
 msgstr ""
 
-msgid "not AH"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:194
+msgid "Kernel log modules missing"
 msgstr ""
 
-msgid "not SCTP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:195
+msgid ""
+"Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-"
+"nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
 msgstr ""
 
-msgid "or type…"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:44
+msgid "Len"
 msgstr ""
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1576
+msgid "Limit"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:210
+msgid "Logging is off on this router"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:252
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:256
+msgid "Manual test (System → Terminal):"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:46
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:221
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1552
+msgid "Message"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1643
+msgid "More filters"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:37
+msgid "Network → Firewall"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:187
+msgid ""
+"No WAN firewall zone found in /etc/config/firewall. Configure zones under"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:185
+msgid "No WAN zone found"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:163
+msgid "Not now"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:220
+msgid "Nothing changes until you click Enable."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:36
+msgid "OUT"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1567
+msgid "One line"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:206
+msgid "Open firewall zone settings"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:211
+msgid ""
+"OpenWrt does not write firewall events to the log until you turn logging on. "
+"Live View only shows what the firewall already logs — it does not add allow/"
+"deny rules."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1595
+msgid "Palette"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1517
+msgid "Pause"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+msgid "Paused"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:38
+msgid "Proto"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1631
 msgid "Protocol — common values"
 msgstr ""
 
-msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1613
+msgid "Quick search"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:91
+msgid "Remove filter"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+msgid "Resume"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1588
+msgid "Row tint"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1678
+msgid ""
+"Row tint shows pass/deny row backgrounds when checked. Choose Classic (green/"
+"red, default) or Accessible (teal/orange). Action text stays colored either "
+"way."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1507
+msgid ""
+"Row tint used a local color fallback because the active LuCI theme did not "
+"apply pass/deny backgrounds."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:33
+msgid "Rule"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:41
+msgid "SPort"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1607
+msgid "Show hostnames"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1586
+msgid "Show pass/deny row background colors"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1533
+msgid "Simple"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:39
+msgid "Source"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1646
+msgid "Source IP contains (! to exclude)"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1647
+msgid "Source port (! to exclude)"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1674
+msgid ""
+"The rate shown for WAN logging is the firewall zone log_limit. OpenWrt "
+"defaults to 10/minute when no explicit limit is configured; fwlive does not "
+"impose this cap."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1671
+msgid ""
+"The table updates automatically when your firewall logs traffic. Use Pause "
+"if it moves too fast."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1508
+msgid "Theme tint fallback"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:31
+msgid "Time"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:219
+msgid ""
+"Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → "
+"Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal "
+"LAN browsing is not logged."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:126
+msgid "Undo:"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1679
+msgid "Use Detail for all columns (flags, length, raw message)."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1521
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1525
+msgid "View"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:591
+msgid "WAN drop/reject logging is off."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:204
+msgid ""
+"WAN drop/reject logging is on. Blocked inbound WAN traffic will show up "
+"here. Normal LAN browsing will not."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:555
+msgid ""
+"WAN drop/reject logging is on. Blocked inbound traffic should appear here as "
+"it happens — not normal LAN browsing."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:557
+msgid "WAN logging is already enabled."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:88
+msgid "WAN logging on"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:94
+msgid "WAN logging on (%s). Click to disable."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:77
+msgid "WAN logging unavailable: missing kernel log modules"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:70
+msgid "WAN logging unavailable: no WAN zone"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:203
+msgid "Waiting for firewall events"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1502
+msgid "Watching"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1560
+msgid "Wrap"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:123
+msgid "allow/deny rules, LAN logging, or anything else."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:786
+msgid "buffer full"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:81
+msgid "default 10/minute"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:28
+msgid "is"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:781
+msgid "loading buffer"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:881
+msgid "loading…"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:37
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:44
+msgid "not"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1065
+msgid "not AH"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1064
+msgid "not ESP"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1063
+msgid "not GRE"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1060
+msgid "not ICMP"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1061
+msgid "not ICMPv6"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1062
+msgid "not IGMP"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1066
+msgid "not SCTP"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1058
+msgid "not TCP"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1059
+msgid "not UDP"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1623
+msgid "not block"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1622
+msgid "not drop"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1621
+msgid "not pass"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1624
+msgid "not reject"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1625
+msgid "not unknown"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1636
+msgid "or type…"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:788
+msgid "render paused (high rate)"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:790
+msgid "scroll frozen — scroll to top to follow live"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:118
+msgid "sets log on the WAN firewall zone and reloads the firewall."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:254
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:258
+msgid "then ping the router."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:128
+msgid "turn it back off with the WAN logging on control on the watch strip."
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:506
+msgid "using fw4"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:504
+msgid "using iptables"
+msgstr ""
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:89
+msgid "· %s"
 msgstr ""

--- a/openwrt-feed/luci-app-fwlive/po/zh_Hans/luci-app-fwlive.po
+++ b/openwrt-feed/luci-app-fwlive/po/zh_Hans/luci-app-fwlive.po
@@ -12,615 +12,598 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: htdocs/luci-static/resources/fwlive/logging.js:250
-#: htdocs/luci-static/resources/fwlive/logging.js:254
-msgid " then ping the router."
-msgstr "ï¼ç¶å ping è·¯ç±å¨ã"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:907
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:884
 msgid "%d matching · %d/%d stored"
 msgstr "%d matching · %d/%d stored"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:910
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:887
 msgid "0 matching · %d/%d stored"
 msgstr "0 matching · %d/%d stored"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:246
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:250
 msgid "Accessible (teal/orange)"
 msgstr "å¯è®¿é®ï¼éç»¿/æ©è²ï¼"
 
-#: htdocs/luci-static/resources/fwlive/table.js:32
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:32
 msgid "Action"
 msgstr "å¨ä½"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:617
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:594
 msgid "Administrator access is required to disable logging."
 msgstr "éè¦ç®¡çåæéæè½"
 
-#: htdocs/luci-static/resources/view/status/fwlive.js:588
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:562
 msgid "Administrator access is required to enable logging."
 msgstr "éè¦ç®¡çåæéæè½å¼å¯æ¥å¿è®°å½ã"
 
-#: htdocs/luci-static/resources/fwlive/logging.js:119
-msgid "allow/deny rules, LAN logging, or anything else."
-msgstr "allow/deny rules, LAN logging, or anything else."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1543
-msgid "Any action"
-msgstr "ææå¨ä½"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:109
-msgid "Before you enable logging"
-msgstr "Before you enable logging"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:809
-msgid "buffer full"
-msgstr "ç¼å²åºå·²æ»¡"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:573
-msgid "Cannot enable logging until kernel log modules are installed."
-msgstr "å"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:112
-msgid "Changes:"
-msgstr "Changes:"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1529
-msgid "Chip style"
-msgstr "æ ç­¾æ ·å¼"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1593
-msgid "Chip style chooses how include vs exclude chips look (Labels, Symbols, or Tone). Default is Labels."
-msgstr "æ ç­¾æ ·å¼å³å®å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:245
-msgid "Classic (green/red)"
-msgstr "ç»"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1515
-msgid "Classic uses green/red; Accessible uses teal/orange"
-msgstr "ç»"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:133
-msgid "Clear all"
-msgstr "æ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1570
-msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
-msgstr "点击单元格筛选 · 芯片上的 ≠ 排除 · Ctrl+点击规则打开防火墙设置 · 在简单视图中点击行查看完整消息"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1591
-msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
-msgstr "点击一行（时间或其他非链接单元格）可查看完整日志行（简单视图）。"
-
-#: htdocs/luci-static/resources/fwlive/table.js:113
-msgid "Click a row for the full message"
-msgstr "点击行可查看完整消息"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1592
-msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-msgstr "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:925
-msgid "Connection lost — retrying…"
-msgstr "Connection lost — retrying…"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:608
-msgid "Could not disable logging."
-msgstr "æ æ³"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:575
-msgid "Could not enable logging."
-msgstr "æ æ³å¼å¯æ¥å¿è®°å½ã"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:81
-msgid "default 10/minute"
-msgstr "é»è®¤ 10 æ¡/åé"
-
-#: htdocs/luci-static/resources/fwlive/table.js:40
-msgid "Destination"
-msgstr "ç®æ å°å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1563
-msgid "Destination IP contains (! to exclude)"
-msgstr "ç®æ  IP å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1564
-msgid "Destination port (! to exclude)"
-msgstr "ç®æ ç«¯å£ï¼! è¡¨ç¤ºæé¤ï¼"
-
-#: htdocs/luci-static/resources/fwlive/table.js:37
-msgid "Dir"
-msgstr "æ¹å"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "Disabling…"
-msgstr "Disabling…"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1481
-msgid "Display options"
-msgstr "æ¾ç¤ºéé¡¹"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1588
-msgid "Display options hides Limit, row tint, hostnames, and chip style."
-msgstr "æ¾ç¤ºéé¡¹å¯æ¶èµ·è¡æ°éå¶ãè¡çè²ãä¸»æºååè¯çæ ·å¼ã"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:117
-msgid "Does not change:"
-msgstr "Does not change:"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:134
-msgid "Don’t show this again"
-msgstr "Don’t show this again"
-
-#: htdocs/luci-static/resources/fwlive/table.js:42
-msgid "DPort"
-msgstr "ç®æ ç«¯å£"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-msgid "Enable logging"
-msgstr "å¼å¯æ¥å¿"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1587
-msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-msgstr "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-#: htdocs/luci-static/resources/fwlive/logging.js:226
-msgid "Enable WAN drop/reject logging"
-msgstr "Enable WAN drop/reject logging"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:100
-msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-msgstr "Enable WAN zone drop/reject logging (same as Network → Firewall)."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:103
-#: htdocs/luci-static/resources/fwlive/logging.js:146
-msgid "Enabling…"
-msgstr "Enabling…"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Exclude instead"
-msgstr "æ¹ä¸ºæé¤"
-
-#: htdocs/luci-static/resources/fwlive/links.js:53
-#: htdocs/luci-static/resources/fwlive/links.js:71
-msgid "Filter by %s"
-msgstr "æ %s ç­é"
-
-#: htdocs/luci-static/resources/fwlive/links.js:136
-msgid "Filter by interface"
-msgstr "ææ¥å£ç­é"
-
-#: htdocs/luci-static/resources/fwlive/links.js:112
-msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
-msgstr "æè§åç­éæ¥å¿ï¼æç¤ºï¼%sï¼ãCtrl+ç¹å»å¯æå¼é²ç«å¢è®¾ç½®ã"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1527
-msgid "Filters look"
-msgstr "è¿æ»¤å¨å¤è§"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1442
-msgid "Firewall Live View"
-msgstr "é²ç«å¢å®æ¶è§å¾"
-
-#: htdocs/luci-static/resources/fwlive/table.js:43
-msgid "Flags"
-msgstr "æ å¿"
-
-#: htdocs/luci-static/resources/fwlive/table.js:45
-msgid "Flow"
-msgstr "æµ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1584
-msgid "Help"
-msgstr "å¸®å©"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-msgid "Hide Detail"
-msgstr "éèè¯¦æ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-#: htdocs/luci-static/resources/view/status/fwlive.js:1505
-msgid "Hide row tint"
-msgstr "éèè¡çè²"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:876
-msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-msgstr "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1533
-msgid "How include vs exclude filters are shown on chips"
-msgstr "æ ç­¾ä¸å¦ä½æ¾ç¤ºå"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1596
-msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
-msgstr "å¦æè¡æè²çèµ·æ¥ç¼ºå¤±ï¼å½å LuCI ä¸»é¢å¯è½æªæä¾æå/éè¯¯ CSS åéï¼fwlive ä¼åéå°æ¬å°é¢è²ï¼éç¦»è¿è¡ï¼æ°æ®ä¸ä¼ç¦»å¼æ¬æºï¼ã"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:201
-msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-msgstr "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
-
-#: htdocs/luci-static/resources/fwlive/table.js:35
-msgid "IN"
-msgstr "IN"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:97
-msgid "Include instead"
-msgstr "æ¹ä¸ºå"
-
-#: htdocs/luci-static/resources/fwlive/table.js:34
-msgid "Interface"
-msgstr "æ¥å£"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1560
-msgid "Interface (prefix ! to exclude)"
-msgstr "æ¥å£ï¼! åç¼è¡¨ç¤ºæé¤ï¼"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:35
-msgid "is"
-msgstr "æ¯"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:161
-#: htdocs/luci-static/resources/fwlive/logging.js:228
-msgid "I’ll configure this under Network → Firewall"
-msgstr "I’ll configure this under Network → Firewall"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:190
-msgid "Kernel log modules missing"
-msgstr "Kernel log modules missing"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:191
-msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
-msgstr "ç¼ºå°å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:329
-msgid "Labels"
-msgstr "æå­"
-
-#: htdocs/luci-static/resources/fwlive/table.js:44
-msgid "Len"
-msgstr "é¿åº¦"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1487
-msgid "Limit"
-msgstr "éå¶"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1485
-msgid "Live"
-msgstr "å®æ¶"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1494
-msgid "Live updates run until you Pause above."
-msgstr "å®æ¶æ´æ°ä¼æç»­è¿è¡ï¼ç´å°ä½ å¨ä¸æ¹æåã"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:804
-msgid "loading buffer"
-msgstr "æ­£å¨å è½½ç¼å²åº"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:904
-msgid "loading…"
-msgstr "loading…"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:206
-msgid "Logging is off on this router"
-msgstr "Logging is off on this router"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:248
-#: htdocs/luci-static/resources/fwlive/logging.js:252
-msgid "Manual test (System → Terminal): "
-msgstr "Manual test (System → Terminal): "
-
-#: htdocs/luci-static/resources/fwlive/table.js:46
-#: htdocs/luci-static/resources/fwlive/table.js:217
-msgid "Message"
-msgstr "æ¶æ¯"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1235
-msgid "Message: one line"
-msgstr "æ¶æ¯ï¼åè¡"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1236
-#: htdocs/luci-static/resources/view/status/fwlive.js:1475
-msgid "Message: wrap"
-msgstr "æ¶æ¯ï¼èªå¨æ¢è¡"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1558
-msgid "More filters"
-msgstr "æ´å¤ç­é"
-
-#: htdocs/luci-static/resources/fwlive/links.js:37
-msgid "Network → Firewall"
-msgstr "Network → Firewall"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:183
-msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under "
-msgstr "å¨ /etc/config/firewall ä¸­æªæ¾å° WAN é²ç«å¢åºåãè¯·å¨ä»¥ä¸ä½ç½®"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:181
-msgid "No WAN zone found"
-msgstr "No WAN zone found"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:45
-#: htdocs/luci-static/resources/fwlive/chips.js:52
-msgid "not"
-msgstr "é"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1551
-msgid "not block"
-msgstr "éé»æ­¢"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1550
-msgid "not drop"
-msgstr "éä¸¢å¼"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:159
-msgid "Not now"
-msgstr "Not now"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1549
-msgid "not pass"
-msgstr "éæ¾è¡"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1552
-msgid "not reject"
-msgstr "éæç»"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1553
-msgid "not unknown"
-msgstr "éæªç¥"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:216
-msgid "Nothing changes until you click Enable."
-msgstr "Nothing changes until you click Enable."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:202
-msgid "Open firewall zone settings"
-msgstr "æå¼é²ç«å¢åºåè®¾ç½®"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:207
-msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-msgstr "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
-
-#: htdocs/luci-static/resources/fwlive/table.js:36
-msgid "OUT"
-msgstr "åºæ¥å£"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1511
-msgid "Palette"
-msgstr "Palette"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-#: htdocs/luci-static/resources/view/status/fwlive.js:1461
-msgid "Pause"
-msgstr "æå"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-msgid "Paused"
-msgstr "å·²æå"
-
-#: htdocs/luci-static/resources/fwlive/table.js:38
-msgid "Proto"
-msgstr "åè®®"
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1541
-msgid "Quick search"
-msgstr "å¿«éæç´¢"
-
-#: htdocs/luci-static/resources/fwlive/chips.js:108
-msgid "Remove filter"
-msgstr "ç§»é¤ç­é"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:811
-msgid "render paused (high rate)"
-msgstr "æ¸²ææåï¼éçè¿é«ï¼"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:977
-msgid "Resume"
-msgstr "ç»§ç»­"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1497
-msgid "Row look"
-msgstr "è¡å¤è§"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:301
-msgid "Row tint"
-msgstr "è¡æè²"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1594
-msgid "Row tint toggles pass/deny row backgrounds. When on, choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
-msgstr "è¡çè²åæ¢æ¾è¡/æç»è¡èæ¯ãå¼å¯æ¶å¯éæ©ç»"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1453
-msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
-msgstr "è¡æè²ä½¿ç¨äºæ¬å°é¢è²åéï¼å ä¸ºå½å LuCI ä¸»é¢æªåºç¨æ¾è¡/æç»èæ¯è²ã"
-
-#: htdocs/luci-static/resources/fwlive/table.js:33
-msgid "Rule"
-msgstr "è§å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:813
-msgid "scroll frozen — scroll to top to follow live"
-msgstr "scroll frozen — scroll to top to follow live"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:114
-msgid "sets log on the WAN firewall zone and reloads the firewall."
-msgstr "sets log on the WAN firewall zone and reloads the firewall."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:470
-#: htdocs/luci-static/resources/view/status/fwlive.js:1469
-msgid "Show Detail"
-msgstr "æ¾ç¤ºè¯¦æ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1523
-msgid "Show hostnames"
-msgstr "æ¾ç¤ºä¸»æºå"
-
-#: htdocs/luci-static/resources/fwlive/table.js:39
-msgid "Source"
-msgstr "æºå°å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1561
-msgid "Source IP contains (! to exclude)"
-msgstr "æº IP å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1562
-msgid "Source port (! to exclude)"
-msgstr "æºç«¯å£ï¼! è¡¨ç¤ºæé¤ï¼"
-
-#: htdocs/luci-static/resources/fwlive/table.js:41
-msgid "SPort"
-msgstr "æºç«¯å£"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:330
-msgid "Symbols"
-msgstr "ç¬¦å·"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1589
-msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
-msgstr "WAN æ¥å¿æ¾ç¤ºçéçæ¯é²ç«å¢åºåç log_limitãæª"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1586
-msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
-msgstr "é²ç«å¢å"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1454
-msgid "Theme tint fallback"
-msgstr "ä¸»é¢çè²åé"
-
-#: htdocs/luci-static/resources/fwlive/table.js:31
-msgid "Time"
-msgstr "æ¶é´"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1503
-msgid "Toggle pass/deny row background colors"
-msgstr "åæ¢æ¾è¡/æç»è¡èæ¯è²"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:331
-msgid "Tone"
-msgstr "è²è°"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:124
-msgid "turn it back off with the WAN logging on control on the watch strip."
-msgstr "turn it back off with the WAN logging on control on the watch strip."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:215
-msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-msgstr "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:122
-msgid "Undo:"
-msgstr "Undo:"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:1595
-msgid "Use Show Detail for all columns (flags, length, raw message)."
-msgstr "ä½¿ç¨ãæ¾ç¤ºè¯¦æ"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:534
-msgid "using fw4"
-msgstr "ä½¿ç¨ fw4"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:532
-msgid "using iptables"
-msgstr "ä½¿ç¨ iptables"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:199
-msgid "Waiting for firewall events"
-msgstr "Waiting for firewall events"
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:614
-msgid "WAN drop/reject logging is off."
-msgstr "WAN drop/reject logging is off."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:581
-msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-msgstr "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
-
-#: htdocs/luci-static/resources/fwlive/logging.js:200
-msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-msgstr "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:583
-msgid "WAN logging is already enabled."
-msgstr "WAN æ¥å¿å·²å¤äºå¼å¯ç¶æã"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:91
-msgid "WAN logging on"
-msgstr "WAN æ¥å¿ï¼å¼"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:88
-msgid "WAN logging on (%s). Click to disable."
-msgstr "WAN æ¥å¿ï¼å¼ï¼%sï¼ãç¹å»å¯"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:77
-msgid "WAN logging unavailable: missing kernel log modules"
-msgstr "WAN æ¥å¿ä¸å¯ç¨ï¼ç¼ºå°å"
-
-#: htdocs/luci-static/resources/fwlive/logging.js:70
-msgid "WAN logging unavailable: no WAN zone"
-msgstr "WAN æ¥å¿ä¸å¯ç¨ï¼æ  WAN åºå"
-
-
-
-#: htdocs/luci-static/resources/view/status/fwlive.js:975
-#: htdocs/luci-static/resources/view/status/fwlive.js:1448
-msgid "· %s"
-msgstr "· %s"
-
-msgid "View"
-msgstr "视图"
-
-msgid "Watching"
-msgstr "çè§ä¸­"
-
-msgid "Any protocol"
-msgstr "任意协议"
-
-msgid "Common"
-msgstr "常用"
-
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1050
 msgid "Also seen"
 msgstr "其他常见"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:583
+msgid "Another change is staged for the firewall; apply or revert it first."
+msgstr "防火墙另有未提交的更改；请先应用或还原。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1615
+msgid "Any action"
+msgstr "ææå¨ä½"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1043
+msgid "Any protocol"
+msgstr "任意协议"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:113
+msgid "Before you enable logging"
+msgstr "Before you enable logging"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:545
+msgid "Cannot enable logging until kernel log modules are installed."
+msgstr "å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:116
+msgid "Changes:"
+msgstr "Changes:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:249
+msgid "Classic (green/red)"
+msgstr "ç»"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1599
+msgid "Classic uses green/red; Accessible uses teal/orange"
+msgstr "ç»"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:116
+msgid "Clear all"
+msgstr "æ"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1655
+msgid "Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message"
+msgstr "点击单元格筛选 · 芯片上的 ≠ 排除 · Ctrl+点击规则打开防火墙设置 · 在简单视图中点击行查看完整消息"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1676
+msgid "Click a row (Time or other non-link cells) to see the full log line (Simple view)."
+msgstr "点击一行（时间或其他非链接单元格）可查看完整日志行（简单视图）。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:113
+msgid "Click a row for the full message"
+msgstr "点击行可查看完整消息"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1677
+msgid "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
+msgstr "Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1044
+msgid "Common"
+msgstr "常用"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:902
+msgid "Connection lost — retrying…"
+msgstr "Connection lost — retrying…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:585
+msgid "Could not disable logging."
+msgstr "æ æ³"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:549
+msgid "Could not enable logging."
+msgstr "æ æ³å¼å¯æ¥å¿è®°å½ã"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1637
+msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
+msgstr "自定义协议（! 排除）。有内容时覆盖菜单。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:42
+msgid "DPort"
+msgstr "ç®æ ç«¯å£"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:40
+msgid "Destination"
+msgstr "ç®æ å°å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1648
+msgid "Destination IP contains (! to exclude)"
+msgstr "ç®æ  IP å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1649
+msgid "Destination port (! to exclude)"
+msgstr "ç®æ ç«¯å£ï¼! è¡¨ç¤ºæé¤ï¼"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1540
+msgid "Detail"
+msgstr "详细"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:37
+msgid "Dir"
+msgstr "æ¹å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:85
+msgid "Disabling…"
+msgstr "Disabling…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1573
+msgid "Display options"
+msgstr "æ¾ç¤ºéé¡¹"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1673
+msgid "Display options on the bar set Limit, row tint, palette, and hostnames."
+msgstr "栏上的显示选项可设置行数限制、行着色、调色板和主机名。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:121
+msgid "Does not change:"
+msgstr "Does not change:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:138
+msgid "Don’t show this again"
+msgstr "Don’t show this again"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enable WAN drop/reject logging"
+msgstr "Enable WAN drop/reject logging"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:104
+msgid "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+msgstr "Enable WAN zone drop/reject logging (same as Network → Firewall)."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+msgid "Enable logging"
+msgstr "å¼å¯æ¥å¿"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1672
+msgid "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
+msgstr "Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:107
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:150
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:230
+msgid "Enabling…"
+msgstr "Enabling…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1057
 msgid "Exclude"
 msgstr "排除"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Exclude instead"
+msgstr "æ¹ä¸ºæé¤"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:53
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:71
+msgid "Filter by %s"
+msgstr "æ %s ç­é"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:136
+msgid "Filter by interface"
+msgstr "ææ¥å£ç­é"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:112
+msgid "Filter logs by rule (hint: %s). Ctrl+click to open firewall settings."
+msgstr "æè§åç­éæ¥å¿ï¼æç¤ºï¼%sï¼ãCtrl+ç¹å»å¯æå¼é²ç«å¢è®¾ç½®ã"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1497
+#: applications/luci-app-fwlive/root/usr/share/luci/menu.d/luci-app-fwlive.json:3
+msgid "Firewall Live View"
+msgstr "é²ç«å¢å®æ¶è§å¾"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:43
+msgid "Flags"
+msgstr "æ å¿"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:45
+msgid "Flow"
+msgstr "æµ"
+
+#: applications/luci-app-fwlive/root/usr/share/rpcd/acl.d/luci-app-fwlive.json:3
+msgid "Grant access to firewall live log view"
+msgstr "授予防火墙实时日志视图的访问权限"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1669
+msgid "Help"
+msgstr "å¸®å©"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:853
+msgid "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
+msgstr "High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1048
 msgid "ICMPv6"
 msgstr "ICMPv6"
 
-msgid "not TCP"
-msgstr "非 TCP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:35
+msgid "IN"
+msgstr "IN"
 
-msgid "not UDP"
-msgstr "非 UDP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1680
+msgid "If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device)."
+msgstr "å¦æè¡æè²çèµ·æ¥ç¼ºå¤±ï¼å½å LuCI ä¸»é¢å¯è½æªæä¾æå/éè¯¯ CSS åéï¼fwlive ä¼åéå°æ¬å°é¢è²ï¼éç¦»è¿è¡ï¼æ°æ®ä¸ä¼ç¦»å¼æ¬æºï¼ã"
 
-msgid "not ICMP"
-msgstr "非 ICMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:205
+msgid "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
+msgstr "If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide."
 
-msgid "not ICMPv6"
-msgstr "非 ICMPv6"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:80
+msgid "Include instead"
+msgstr "æ¹ä¸ºå"
 
-msgid "not IGMP"
-msgstr "非 IGMP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:34
+msgid "Interface"
+msgstr "æ¥å£"
 
-msgid "not GRE"
-msgstr "非 GRE"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1645
+msgid "Interface (prefix ! to exclude)"
+msgstr "æ¥å£ï¼! åç¼è¡¨ç¤ºæé¤ï¼"
 
-msgid "not ESP"
-msgstr "非 ESP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:165
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:232
+msgid "I’ll configure this under Network → Firewall"
+msgstr "I’ll configure this under Network → Firewall"
 
-msgid "not AH"
-msgstr "非 AH"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:194
+msgid "Kernel log modules missing"
+msgstr "Kernel log modules missing"
 
-msgid "not SCTP"
-msgstr "非 SCTP"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:195
+msgid "Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall."
+msgstr "ç¼ºå°å"
 
-msgid "or type…"
-msgstr "或输入…"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:44
+msgid "Len"
+msgstr "é¿åº¦"
 
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1576
+msgid "Limit"
+msgstr "éå¶"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:210
+msgid "Logging is off on this router"
+msgstr "Logging is off on this router"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:252
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:256
+msgid "Manual test (System → Terminal):"
+msgstr "手动测试（系统 → 终端）："
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:46
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:221
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1547
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1552
+msgid "Message"
+msgstr "æ¶æ¯"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1643
+msgid "More filters"
+msgstr "æ´å¤ç­é"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js:37
+msgid "Network → Firewall"
+msgstr "Network → Firewall"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:187
+msgid "No WAN firewall zone found in /etc/config/firewall. Configure zones under"
+msgstr "在 /etc/config/firewall 中未找到 WAN 防火墙区域。请在以下位置配置区域"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:185
+msgid "No WAN zone found"
+msgstr "No WAN zone found"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:163
+msgid "Not now"
+msgstr "Not now"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:220
+msgid "Nothing changes until you click Enable."
+msgstr "Nothing changes until you click Enable."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:36
+msgid "OUT"
+msgstr "åºæ¥å£"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1567
+msgid "One line"
+msgstr "单行"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:206
+msgid "Open firewall zone settings"
+msgstr "æå¼é²ç«å¢åºåè®¾ç½®"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:211
+msgid "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
+msgstr "OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1595
+msgid "Palette"
+msgstr "Palette"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1517
+msgid "Pause"
+msgstr "æå"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+msgid "Paused"
+msgstr "å·²æå"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:38
+msgid "Proto"
+msgstr "åè®®"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1631
 msgid "Protocol — common values"
 msgstr "协议 — 常用值"
 
-msgid "Custom protocol (prefix ! to exclude). Overrides the menu when set."
-msgstr "自定义协议（! 排除）。有内容时覆盖菜单。"
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1613
+msgid "Quick search"
+msgstr "å¿«éæç´¢"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:91
+msgid "Remove filter"
+msgstr "ç§»é¤ç­é"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:953
+msgid "Resume"
+msgstr "ç»§ç»­"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1588
+msgid "Row tint"
+msgstr "è¡æè²"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1678
+msgid "Row tint shows pass/deny row backgrounds when checked. Choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way."
+msgstr "勾选后行着色显示放行/拒绝行背景。可选经典（绿/红，默认）或无障碍（青绿/橙）。操作文本在两种模式下均保持着色。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1507
+msgid "Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds."
+msgstr "è¡æè²ä½¿ç¨äºæ¬å°é¢è²åéï¼å ä¸ºå½å LuCI ä¸»é¢æªåºç¨æ¾è¡/æç»èæ¯è²ã"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:33
+msgid "Rule"
+msgstr "è§å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:41
+msgid "SPort"
+msgstr "æºç«¯å£"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1607
+msgid "Show hostnames"
+msgstr "æ¾ç¤ºä¸»æºå"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1586
+msgid "Show pass/deny row background colors"
+msgstr "显示放行/拒绝行背景色"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1533
+msgid "Simple"
+msgstr "简洁"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:39
+msgid "Source"
+msgstr "æºå°å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1646
+msgid "Source IP contains (! to exclude)"
+msgstr "æº IP å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1647
+msgid "Source port (! to exclude)"
+msgstr "æºç«¯å£ï¼! è¡¨ç¤ºæé¤ï¼"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1674
+msgid "The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap."
+msgstr "WAN æ¥å¿æ¾ç¤ºçéçæ¯é²ç«å¢åºåç log_limitãæª"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1671
+msgid "The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast."
+msgstr "é²ç«å¢å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1508
+msgid "Theme tint fallback"
+msgstr "ä¸»é¢çè²åé"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js:31
+msgid "Time"
+msgstr "æ¶é´"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:219
+msgid "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
+msgstr "Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:126
+msgid "Undo:"
+msgstr "Undo:"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1679
+msgid "Use Detail for all columns (flags, length, raw message)."
+msgstr "使用「详细」可查看全部列（标志、长度、原始消息）。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1521
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1525
+msgid "View"
+msgstr "视图"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:591
+msgid "WAN drop/reject logging is off."
+msgstr "WAN drop/reject logging is off."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:204
+msgid "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
+msgstr "WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:555
+msgid "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
+msgstr "WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:557
+msgid "WAN logging is already enabled."
+msgstr "WAN æ¥å¿å·²å¤äºå¼å¯ç¶æã"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:88
+msgid "WAN logging on"
+msgstr "WAN æ¥å¿ï¼å¼"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:94
+msgid "WAN logging on (%s). Click to disable."
+msgstr "WAN æ¥å¿ï¼å¼ï¼%sï¼ãç¹å»å¯"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:77
+msgid "WAN logging unavailable: missing kernel log modules"
+msgstr "WAN æ¥å¿ä¸å¯ç¨ï¼ç¼ºå°å"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:70
+msgid "WAN logging unavailable: no WAN zone"
+msgstr "WAN æ¥å¿ä¸å¯ç¨ï¼æ  WAN åºå"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:203
+msgid "Waiting for firewall events"
+msgstr "Waiting for firewall events"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:951
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1502
+msgid "Watching"
+msgstr "çè§ä¸­"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1560
+msgid "Wrap"
+msgstr "自动换行"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:123
+msgid "allow/deny rules, LAN logging, or anything else."
+msgstr "allow/deny rules, LAN logging, or anything else."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:786
+msgid "buffer full"
+msgstr "ç¼å²åºå·²æ»¡"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:81
+msgid "default 10/minute"
+msgstr "é»è®¤ 10 æ¡/åé"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:28
+msgid "is"
+msgstr "æ¯"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:781
+msgid "loading buffer"
+msgstr "æ­£å¨å è½½ç¼å²åº"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:881
+msgid "loading…"
+msgstr "loading…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:37
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js:44
+msgid "not"
+msgstr "é"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1065
+msgid "not AH"
+msgstr "非 AH"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1064
+msgid "not ESP"
+msgstr "非 ESP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1063
+msgid "not GRE"
+msgstr "非 GRE"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1060
+msgid "not ICMP"
+msgstr "非 ICMP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1061
+msgid "not ICMPv6"
+msgstr "非 ICMPv6"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1062
+msgid "not IGMP"
+msgstr "非 IGMP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1066
+msgid "not SCTP"
+msgstr "非 SCTP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1058
+msgid "not TCP"
+msgstr "非 TCP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1059
+msgid "not UDP"
+msgstr "非 UDP"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1623
+msgid "not block"
+msgstr "éé»æ­¢"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1622
+msgid "not drop"
+msgstr "éä¸¢å¼"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1621
+msgid "not pass"
+msgstr "éæ¾è¡"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1624
+msgid "not reject"
+msgstr "éæç»"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1625
+msgid "not unknown"
+msgstr "éæªç¥"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:1636
+msgid "or type…"
+msgstr "或输入…"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:788
+msgid "render paused (high rate)"
+msgstr "æ¸²ææåï¼éçè¿é«ï¼"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:790
+msgid "scroll frozen — scroll to top to follow live"
+msgstr "scroll frozen — scroll to top to follow live"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:118
+msgid "sets log on the WAN firewall zone and reloads the firewall."
+msgstr "sets log on the WAN firewall zone and reloads the firewall."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:254
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:258
+msgid "then ping the router."
+msgstr "然后 ping 路由器。"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:128
+msgid "turn it back off with the WAN logging on control on the watch strip."
+msgstr "turn it back off with the WAN logging on control on the watch strip."
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:506
+msgid "using fw4"
+msgstr "ä½¿ç¨ fw4"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js:504
+msgid "using iptables"
+msgstr "ä½¿ç¨ iptables"
+
+#: applications/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js:89
+msgid "· %s"
+msgstr "· %s"

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -579,7 +579,9 @@ case "$1" in
 		exit $?
 		;;
 	list)
-		echo '{"rules":{},"backend":"unknown","poll":{"addresses":[]},"resolve":{"addresses":[]},"logging_status":{},"enable_wan_logging":{},"disable_wan_logging":{}}'
+		# Method names only — args objects describe call parameters.
+		# "backend" is a rules reply field, not a method.
+		echo '{"rules":{},"poll":{"addresses":[]},"resolve":{"addresses":[]},"logging_status":{},"enable_wan_logging":{},"disable_wan_logging":{}}'
 		;;
 	call)
 		case "$2" in

--- a/scripts/upstream-cut.sh
+++ b/scripts/upstream-cut.sh
@@ -99,7 +99,7 @@ fi
 css_js="$OUT/htdocs/luci-static/resources/fwlive/css.js"
 if [ -f "$css_js" ]; then
 	sed -i \
-		's|^\* GENERATED — do not edit\. Edit fwlive\.css and run: node scripts/embed-fwlive-css\.js$|* Snapshot from the fwlive monorepo. Style source is regenerated upstream of this tree.|' \
+		's|^ \* GENERATED — do not edit\. Edit fwlive\.css and run: node scripts/embed-fwlive-css\.js$| * Snapshot from the fwlive monorepo. Style source is regenerated upstream of this tree.|' \
 		"$css_js"
 fi
 

--- a/scripts/upstream-cut.sh
+++ b/scripts/upstream-cut.sh
@@ -27,6 +27,10 @@ PKG=openwrt-feed/luci-app-fwlive
 OUT="${1:-out/upstream/luci-app-fwlive}"
 SPLIT_BRANCH="upstream/luci-app-fwlive"
 GITHUB_BLOB="https://github.com/lucas-albers-lz4/fwlive/blob/master"
+# Locale dirs kept in the feed for the binary release; first luci PR ships .pot only.
+DROP_PO_LANGS=(de ru zh_Hans)
+# Source for embed-fwlive-css.js; view loads css.js (styleText), not this asset.
+DROP_CSS=1
 
 # The split branch is regenerable by definition — force-recreate each run.
 git branch -D "$SPLIT_BRANCH" >/dev/null 2>&1 || true
@@ -37,8 +41,8 @@ git subtree split --prefix="$PKG" --branch="$SPLIT_BRANCH" >/dev/null
 # A PR-able package must be plain files. Any gitlink means a submodule leaked
 # into the tree and upstream cannot build it.
 if git ls-tree -r "$SPLIT_BRANCH" | grep -q " commit "; then
-    echo "ERROR: split tree contains gitlinks (submodules) — not PR-able upstream" >&2
-    exit 1
+	echo "ERROR: split tree contains gitlinks (submodules) — not PR-able upstream" >&2
+	exit 1
 fi
 
 echo "== 2/5 export tree to $OUT =="
@@ -51,59 +55,149 @@ echo "== 3/5 rewrite monorepo-relative references =="
 # the shared luci.mk two levels up.
 # shellcheck disable=SC2016  # $TOPDIR must stay literal for sed
 sed -i 's|include $(TOPDIR)/feeds/luci/luci.mk|include ../../luci.mk|' \
-    "$OUT/Makefile"
+	"$OUT/Makefile"
 
 # Drop the monorepo feed-wiring header comment — it references files that do
 # not exist in the luci tree (openwrt-feed/README.md, feeds.conf.example).
 # Keep the SPDX line; real luci apps start clean from there.
 sed -i '/^# Wire feed first/,/^$/d' "$OUT/Makefile"
 
-# Package README links into monorepo docs/ die after the copy; point them at
-# the canonical GitHub copies so they survive the cut.
+# First luci PR: .pot only. Empty locale dirs still make luci.mk emit empty
+# luci-i18n-* packages — remove the directories entirely.
+for lang in "${DROP_PO_LANGS[@]}"; do
+	rm -rf "$OUT/po/$lang"
+done
+
+if [ "$DROP_CSS" -eq 1 ]; then
+	rm -f "$OUT/htdocs/luci-static/resources/fwlive/fwlive.css"
+fi
+
+# Package README: GitHub docs links; no core/ citation; list proto.js.
 # shellcheck disable=SC2016  # '"$GITHUB_BLOB"' splice is deliberate
 sed -i \
-    -e 's|\[`\.\./\.\./docs/user/installation\.md`\](\.\./\.\./docs/user/installation\.md)|[installation guide]('"$GITHUB_BLOB"'/docs/user/installation.md)|' \
-    -e 's|\[`\.\./\.\./docs/developer/README\.md`\](\.\./\.\./docs/developer/README\.md)|[developer documentation]('"$GITHUB_BLOB"'/docs/developer/README.md)|' \
-    "$OUT/README.md"
+	-e 's|\[`\.\./\.\./docs/user/installation\.md`\](\.\./\.\./docs/user/installation\.md)|[installation guide]('"$GITHUB_BLOB"'/docs/user/installation.md)|' \
+	-e 's|\[`\.\./\.\./docs/developer/README\.md`\](\.\./\.\./docs/developer/README.md)|[developer documentation]('"$GITHUB_BLOB"'/docs/developer/README.md)|' \
+	-e 's|Parser/filter module (mirror of repo `core/fwlive-log.js`)|Parser/filter module (`CLASSIFY_SPEC` + LuCI helpers)|' \
+	"$OUT/README.md"
+
+if ! grep -q 'proto\.js' "$OUT/README.md"; then
+	sed -i \
+		'/resources\/fwlive\/hostname\.js/a\
+| `htdocs/luci-static/resources/fwlive/proto.js` | Protocol name/number helpers |' \
+		"$OUT/README.md"
+fi
+
+# GENERATED / sync comments must not point at monorepo paths absent from luci.
+shell_gen="$OUT/root/usr/libexec/fwlive-is-firewall-event.sh"
+if [ -f "$shell_gen" ]; then
+	sed -i \
+		-e 's|^# GENERATED FILE — do not edit. Run: \./scripts/gen-all\.sh$|# Snapshot from the fwlive monorepo (lucas-albers-lz4/fwlive). Do not edit by hand.|' \
+		-e 's|^# source: core/fwlive-log\.js CLASSIFY_SPEC$|# CLASSIFY_SPEC parity with htdocs/.../fwlive/log.js — regenerate upstream of this tree.|' \
+		"$shell_gen"
+fi
+
+css_js="$OUT/htdocs/luci-static/resources/fwlive/css.js"
+if [ -f "$css_js" ]; then
+	sed -i \
+		's|^\* GENERATED — do not edit\. Edit fwlive\.css and run: node scripts/embed-fwlive-css\.js$|* Snapshot from the fwlive monorepo. Style source is regenerated upstream of this tree.|' \
+		"$css_js"
+fi
+
+log_js="$OUT/htdocs/luci-static/resources/fwlive/log.js"
+if [ -f "$log_js" ]; then
+	sed -i \
+		-e 's|Shared classify logic mirrors core/fwlive-log\.js CLASSIFY_SPEC — keep in sync|Shared CLASSIFY_SPEC — keep in sync with the fwlive monorepo|' \
+		-e 's|(gen-luci-wrapper\.js gates full-spec drift; \./scripts/gen-all\.sh verifies)\.| (regenerate upstream of this tree).|' \
+		"$log_js"
+fi
+
+constants_js="$OUT/htdocs/luci-static/resources/fwlive/constants.js"
+if [ -f "$constants_js" ]; then
+	sed -i \
+		's|Keep in sync with openwrt-feed/luci-app-fwlive/Makefile PKG_VERSION\.|Keep in sync with Makefile PKG_VERSION.|' \
+		"$constants_js"
+fi
 
 echo "== 4/5 verify =="
 fail=0
 
-src_count=$(git ls-tree -r --name-only "master:$PKG" | wc -l)
+src_count=$(git ls-tree -r --name-only "HEAD:$PKG" | wc -l)
+drop_count=${#DROP_PO_LANGS[@]}
+if [ "$DROP_CSS" -eq 1 ]; then
+	drop_count=$((drop_count + 1))
+fi
+expected=$((src_count - drop_count))
 out_count=$(find "$OUT" -type f | wc -l)
-if [ "$src_count" -ne "$out_count" ]; then
-    echo "  FAIL: file count mismatch (source $src_count, out $out_count)" >&2
-    fail=1
+if [ "$out_count" -ne "$expected" ]; then
+	echo "  FAIL: file count mismatch (source $src_count - $drop_count drops = $expected, out $out_count)" >&2
+	fail=1
+fi
+
+for lang in "${DROP_PO_LANGS[@]}"; do
+	if [ -e "$OUT/po/$lang" ]; then
+		echo "  FAIL: po/$lang still present (first luci PR is .pot only)" >&2
+		fail=1
+	fi
+done
+
+if [ "$DROP_CSS" -eq 1 ] && [ -f "$OUT/htdocs/luci-static/resources/fwlive/fwlive.css" ]; then
+	echo "  FAIL: fwlive.css still present (view loads css.js)" >&2
+	fail=1
 fi
 
 if ! grep -q '^include ../../luci.mk' "$OUT/Makefile"; then
-    echo "  FAIL: Makefile include not rewritten to ../../luci.mk" >&2
-    fail=1
+	echo "  FAIL: Makefile include not rewritten to ../../luci.mk" >&2
+	fail=1
 fi
 
 if grep -rn '\.\./\.\./docs' "$OUT/README.md" >/dev/null 2>&1; then
-    echo "  FAIL: monorepo-relative docs links remain in README.md" >&2
-    fail=1
+	echo "  FAIL: monorepo-relative docs links remain in README.md" >&2
+	fail=1
+fi
+
+if grep -q 'core/fwlive-log' "$OUT/README.md" >/dev/null 2>&1; then
+	echo "  FAIL: README still cites core/fwlive-log.js" >&2
+	fail=1
+fi
+
+if ! grep -q 'proto\.js' "$OUT/README.md"; then
+	echo "  FAIL: README missing proto.js row" >&2
+	fail=1
 fi
 
 if [ ! -f "$OUT/po/templates/luci-app-fwlive.pot" ]; then
-    echo "  FAIL: po/templates/luci-app-fwlive.pot missing" >&2
-    fail=1
+	echo "  FAIL: po/templates/luci-app-fwlive.pot missing" >&2
+	fail=1
 fi
 
 if grep -rn 'TOPDIR)/feeds/luci' "$OUT/Makefile" >/dev/null 2>&1; then
-    echo "  FAIL: feed-path luci.mk include remains in Makefile" >&2
-    fail=1
+	echo "  FAIL: feed-path luci.mk include remains in Makefile" >&2
+	fail=1
+fi
+
+if grep -qE 'openwrt-feed/|\./scripts/gen-all|core/fwlive-log|embed-fwlive-css' \
+	"$OUT/htdocs/luci-static/resources/fwlive/constants.js" \
+	"$OUT/htdocs/luci-static/resources/fwlive/css.js" \
+	"$OUT/htdocs/luci-static/resources/fwlive/log.js" \
+	"$OUT/root/usr/libexec/fwlive-is-firewall-event.sh" 2>/dev/null; then
+	echo "  FAIL: monorepo-only paths remain in cut comments" >&2
+	fail=1
+fi
+
+if ! grep -q 'PKG_VERSION:=' "$OUT/Makefile"; then
+	echo "  FAIL: PKG_VERSION missing (keep lockstep with APP_VERSION)" >&2
+	fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then
-    echo "Upstream cut FAILED — fix the checks above." >&2
-    exit 1
+	echo "Upstream cut FAILED — fix the checks above." >&2
+	exit 1
 fi
 
-echo "  OK: $out_count files match source; Makefile include rewritten;"
-echo "  OK: no monorepo-relative docs links; po template present"
+echo "  OK: $out_count files (source $src_count minus $drop_count); Makefile include rewritten;"
+echo "  OK: no monorepo-relative docs links; po template present; locale dirs dropped"
 
 echo "== 5/5 next steps =="
 echo "  Copy $OUT into a luci fork at luci/applications/luci-app-fwlive/"
-echo "  and open the upstream PR. Apache-2.0 in PR body (PKG_LICENSE already set)."
+echo "  Run luci ./build/i18n-scan.pl on that tree for a fresh .pot, then open the PR."
+echo "  Apache-2.0 in PR body (PKG_LICENSE already set)."


### PR DESCRIPTION
## Summary
- Drop the non-method `backend` key from rpcd `list` JSON (`backend` is a `rules` reply field only).
- Harden `scripts/upstream-cut.sh` for the first `openwrt/luci` PR: drop `po/{de,ru,zh_Hans}` and `fwlive.css`, rewrite monorepo-only README/GENERATED/`constants.js` comments, keep `PKG_VERSION`, verify file counts.
- Refresh `po/templates/luci-app-fwlive.pot` via luci `i18n-scan.pl` (menu title + ACL description) and msgmerge feed locales.

Tracking: #209. Luna + Bugbot approved on the branch before filing. CodeRabbit next on this PR; only folded code fixes (not bot comments) will be re-cut into the luci branch before filing upstream.

## Test plan
- [x] `./scripts/fwlive-test.sh`
- [x] `./scripts/validate-baseline.sh`
- [x] `./scripts/upstream-cut.sh` → 21 files, no locale dirs / no `fwlive.css`, no monorepo paths in cut comments
- [ ] CodeRabbit round complete; triage and fold fixes if any
- [ ] After merge (or once prep is final): re-cut and update `lucas-albers-lz4/luci` branch `luci-app-fwlive-add` before opening the `openwrt/luci` PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the upstream export checklist with current guidance for generated files, locale catalogs, translation templates, and documentation checks.

- **Translations**
  - Refreshed German, Russian, and Simplified Chinese translations.
  - Added translated strings for filtering, protocols, logging, status messages, display options, accessibility themes, and table controls.
  - Removed outdated translation entries and updated source references.

- **Bug Fixes**
  - Corrected the advertised RPC interface so backend details are reported consistently without exposing an unsupported top-level method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->