### PR TITLE
docs(ste): unify vocabulary — make sure that / configuration

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 ## Installation & Setup
 
-### The table is empty after install — what's wrong?
+### The table is empty after install — what is wrong?
 
 **Nothing.** Live View shows whatever OpenWrt is logging. Stock images log almost no firewall traffic until you turn logging on.
 
@@ -24,9 +24,9 @@ Yes. The package is **`_all`** (architecture-independent LuCI JS + shell) — on
 
 ## Usage
 
-### Why don't I see my LAN browsing traffic?
+### Why do I not see my LAN browsing traffic?
 
-Zone logging only logs **rejected and dropped** traffic on that zone. Normal LAN→WAN accepted traffic doesn't appear unless you add explicit **`log`** rules. See [Rule-level logging](user/enabling-firewall-logs.md#rule-level-logging-specific-policies).
+Zone logging only logs **rejected and dropped** traffic on that zone. Normal LAN→WAN accepted traffic does not appear unless you add explicit **`log`** rules. See [Rule-level logging](user/enabling-firewall-logs.md#rule-level-logging-specific-policies).
 
 ### How do I see only dropped packets?
 
@@ -38,7 +38,7 @@ The URL hash stores all active filters, limit, and view mode. Just copy the URL 
 
 ### Why do some rows have no Rule column data?
 
-Live View shows a **Rule** label only when the nft log line includes a **prefix** (e.g. `log prefix "my-rule "`) and fw4 can resolve it to a UCI rule name. Rules without `log prefix` don't carry enough metadata.
+Live View shows a **Rule** label only when the nft log line includes a **prefix** (e.g. `log prefix "my-rule "`) and fw4 can resolve it to a UCI rule name. Rules without `log prefix` do not carry enough metadata.
 
 ### What does "Enable logging" on the page actually do?
 
@@ -52,7 +52,7 @@ It sets `option log '1'` on your WAN firewall zone via ubus and reloads the fire
 
 Check that:
 1. `luci-app-fwlive` and `luci-base` are installed
-2. You're logged into LuCI (the page shows live data only after authentication)
+2. You are logged into LuCI (the page shows live data only after authentication)
 3. The menu appears at **Status → Firewall Live View**
 4. `logread | grep SRC=` shows lines — if not, fix firewall logging first
 
@@ -72,9 +72,9 @@ cat /proc/sys/net/netfilter/nf_log/2    # should be nf_log_ipv4, not "none"
 
 If missing, install `kmod-nf-log-ipv4` / `kmod-nf-log-ipv6`. See [Kernel module check](user/enabling-firewall-logs.md#3-check-kernel-logging-modules-only-if-logs-are-missing).
 
-### Docker rootfs experiment: `nft log` doesn't work
+### Docker rootfs experiment: `nft log` does not work
 
-Docker containers use the **host kernel**, not the OpenWrt kernel. `nft` counters and accept/drop work, but **`nft log` often never reaches `logread`** because kernel modules don't match.
+Docker containers use the **host kernel**, not the OpenWrt kernel. `nft` counters and accept/drop work, but **`nft log` often never reaches `logread`** because kernel modules do not match.
 
 Workaround: inject a fake firewall line manually:
 ```sh

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ Product: **LuCI Firewall Live View** — OPNsense Live View–style operator UX 
 ## Development approach (agreed)
 
 - **Small steps** — ship one behavior at a time; accept in QEMU LuCI + one CLI check.
-- **Light testing** — `./scripts/fwlive-test.sh` + manual browser smoke; no comprehensive suite required.
+- **Light testing** — `./scripts/fwlive-test.sh` + manual browser smoke; no full test suite required.
 - **Backport awareness** — edge cases will surface on 23.05 / armsr; fix as we hit them.
 
 **Test loop per step:**

--- a/docs/armvirt-armsr-testing.md
+++ b/docs/armvirt-armsr-testing.md
@@ -45,7 +45,7 @@ Then build **`luci-app-fwlive`** with the SDK ([`minimal-build-sdk.md`](minimal-
    sudo ./scripts/qemu-lab-prepare-image.sh
    sudo OWRT_IMG=lab/images/openwrt-x86-64.img ./scripts/qemu-lab-prepare-image.sh
    ```
-3. **Networking (verified, same as x86 lab):** single **`-nic user,hostfwd=...`** + guest LAN **DHCP**. Prepare the image before first boot:
+3. **Networking (tested, same as x86 lab):** single **`-nic user,hostfwd=...`** + guest LAN **DHCP**. Prepare the image before first boot:
    ```sh
    sudo OWRT_IMG=lab/images/openwrt-armsr-armv8.img ./scripts/qemu-lab-prepare-image.sh
    ```

--- a/docs/binary-feed.md
+++ b/docs/binary-feed.md
@@ -196,7 +196,7 @@ Store **private** keys only in GitHub Actions secrets. Never commit them to eith
 - `OPKG_FEED_SECRET_KEY` must be the **usign** secret from `usign -G` (two lines: `untrusted comment:` + `RWâ€¦` base64). The **openssl RSA** key is only for `APK_FEED_SECRET_KEY`.
 - Pasting the secret into GitHub as **one line** (no newline between comment and key) makes usign fail with **`Premature end of file`**. Either paste the file verbatim with its line break, or store **`base64 -w0 opkg-secret.key`** in the secret (CI auto-decodes).
 
-Verify locally before updating GitHub secrets:
+Make sure that the feed works locally before you update the GitHub secrets:
 
 ```sh
 OPKG_FEED_SECRET_KEY=./opkg-secret.key OPKG_FEED_PUBLIC_KEY=./public.key \
@@ -219,7 +219,7 @@ Expected apk secret shape: PEM `-----BEGIN PRIVATE KEY-----` (openssl genrsa out
 
 On **tag push** (`v*`) or manual workflow dispatch, [`.github/workflows/publish-packages.yml`](../.github/workflows/publish-packages.yml):
 
-1. Validates signing keys via [`validate-feed-keys.sh`](../scripts/validate-feed-keys.sh) (before build).
+1. Checks the signing keys via [`validate-feed-keys.sh`](../scripts/validate-feed-keys.sh) (before build).
 2. Builds `luci-app-fwlive` for **21.02**, **22.03**, **23.05**, **24.10**, **25.12** (Docker SDK, pinned feeds).
 3. Runs [`verify-reproducible-build.sh`](../scripts/verify-reproducible-build.sh) (double-build sha256 gate).
 4. Stages signed feed via [`publish-packages.sh`](../scripts/publish-packages.sh).
@@ -274,7 +274,7 @@ a lock change never restores a stale tree. Note: GHA caches are **ref-scoped** â
 publishes do not warm-hit across tags; the bind mounts still speed local rebuilds and
 same-ref re-runs. A lock stamp under feeds forces refresh when pins change.
 
-Verify locally:
+Make sure that the build is reproducible:
 
 ```sh
 ./scripts/verify-reproducible-build.sh

--- a/docs/binary-feed.md
+++ b/docs/binary-feed.md
@@ -196,7 +196,7 @@ Store **private** keys only in GitHub Actions secrets. Never commit them to eith
 - `OPKG_FEED_SECRET_KEY` must be the **usign** secret from `usign -G` (two lines: `untrusted comment:` + `RW…` base64). The **openssl RSA** key is only for `APK_FEED_SECRET_KEY`.
 - Pasting the secret into GitHub as **one line** (no newline between comment and key) makes usign fail with **`Premature end of file`**. Either paste the file verbatim with its line break, or store **`base64 -w0 opkg-secret.key`** in the secret (CI auto-decodes).
 
-Make sure that the feed works locally before you update the GitHub secrets:
+Make sure that the signing keys work locally before you update the GitHub secrets:
 
 ```sh
 OPKG_FEED_SECRET_KEY=./opkg-secret.key OPKG_FEED_PUBLIC_KEY=./public.key \

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -55,10 +55,10 @@ flowchart TB
 | Output encoding | Renderers must emit untrusted values as text nodes; server map keys are additionally gated by `is_uci_style_name` — [Security model § Invariants](security-model.md#invariants) |
 | Log filter injection | `fwlive-log-filter.sh` feeds messages as data through jsonfilter/grep stdin — not a shell-injection surface |
 | Log content is untrusted | Every parsed field is attacker-influenced regardless of who wrote the firewall rule — [Security model § Untrusted input inventory](security-model.md#untrusted-input-inventory) |
-| Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off; server validates IPv4/IPv6 shape before lookup |
+| Opt-in hostnames | `fwlive.resolve` via `getent`; checkbox default off; server checks the IPv4/IPv6 shape before lookup |
 | `core/` + LuCI mirror | Parser tested without browser or router |
-| LuCI gate (not generator) | `gen-luci-wrapper.js` verifies full `CLASSIFY_SPEC` equality + preserve markers; shared classify in `log.js` stays hand-maintained (no text-transform codegen). Core has no `@fwlive-codegen:luci-begin/end` markers — only LuCI has a preserve region for presentation helpers. |
-| nft/fw4 primary | Validated on **21.02.7** (fw3 lab), **22.03.7**, **23.05.5**, **24.10.8**, **25.12.5** lab matrix |
+| LuCI gate (not generator) | `gen-luci-wrapper.js` checks full `CLASSIFY_SPEC` equality + preserve markers; shared classify in `log.js` stays hand-maintained (no text-transform codegen). Core has no `@fwlive-codegen:luci-begin/end` markers — only LuCI has a preserve region for presentation helpers. |
+| nft/fw4 primary | Tested on **21.02.7** (fw3 lab), **22.03.7**, **23.05.5**, **24.10.8**, **25.12.5** lab matrix |
 | iptables LOG | Primary on **21.02.x** (fw3); best-effort on **22.03+** when nft absent — same logd pipe; rule map from `iptables-save` |
 | OPNsense as reference | Interaction and layout patterns, not PHP/Volt port |
 | Keep monorepo + `src-link` | See [Feed layout decision](#feed-layout-decision) |

--- a/docs/developer/build-and-test.md
+++ b/docs/developer/build-and-test.md
@@ -37,7 +37,7 @@ constructor (`fakeE`) that never builds DOM. Renderer tests therefore assert on
 descriptive objects, which is fine for structure but means **a value reaching an
 HTML sink instead of a text node is invisible to them**.
 
-When changing a renderer, make sure that it works through an `E()` that reproduces upstream
+When changing a renderer, make sure that an `E()` reproduces upstream
 `dom.append` semantics. Recipe: `.cursor/skills/security-audit/SKILL.md`.
 
 ## Live View CSS (`fwlive.css` → `css.js`)

--- a/docs/developer/build-and-test.md
+++ b/docs/developer/build-and-test.md
@@ -27,7 +27,7 @@ Covers parser sync (`core/` vs LuCI `log.js`), schema, filters, CLI pipeline,
 shell codegen + LuCI wrapper gate (`./scripts/gen-all.sh`), and shellcheck on shipped
 `root/usr/libexec` scripts (`./scripts/fwlive-shellcheck.sh`). Optional: `SH='busybox sh' node tests/fwlive-shell-filter.test.js`.
 
-Docs changes must pass the link checker — it validates relative paths **and**
+Docs changes must pass the link checker — it checks relative paths **and**
 heading anchors against a GitHub-style slugger.
 
 ### Renderer tests do not render
@@ -37,7 +37,7 @@ constructor (`fakeE`) that never builds DOM. Renderer tests therefore assert on
 descriptive objects, which is fine for structure but means **a value reaching an
 HTML sink instead of a text node is invisible to them**.
 
-When changing a renderer, verify through an `E()` that reproduces upstream
+When changing a renderer, make sure that it works through an `E()` that reproduces upstream
 `dom.append` semantics. Recipe: `.cursor/skills/security-audit/SKILL.md`.
 
 ## Live View CSS (`fwlive.css` → `css.js`)

--- a/docs/developer/coderabbit.md
+++ b/docs/developer/coderabbit.md
@@ -1,4 +1,4 @@
-# Working gracefully with CodeRabbit
+# Working with CodeRabbit
 
 This repo runs CodeRabbit as an automated PR reviewer. The protocol below keeps
 review cycles efficient — one coherent review round over a stable diff, no
@@ -24,7 +24,7 @@ CodeRabbit, that is separate — do not paste this repo’s review threads.
   starts a new incremental round covering the commits since the last review
   (skipped while auto-review is paused or when the plan/rate limit is hit).
 - Manual commands can be used as manual triggers, even on drafts and
-  regardless of auto-review config, but they consume the same plan/rate-limit
+  regardless of auto-review configuration, but they consume the same plan/rate-limit
   allowance as automatic reviews and are subject to availability:
   - `@coderabbitai review` — incremental review on demand
   - `@coderabbitai full review` — full re-review from scratch

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -2,7 +2,7 @@
 
 ## Principles
 
-- **Small steps** — one behavior per change; make sure that it works in CLI and QEMU LuCI when the change is UI-related
+- **Small steps** — one behavior per change. For UI changes, make sure that it works in CLI and QEMU LuCI.
 - **Parser sync** — edit `CLASSIFY_SPEC` in `core/fwlive-log.js`, mirror the same object in `htdocs/.../fwlive/log.js`, run `./scripts/gen-all.sh` (regenerates shell; gates LuCI full-spec drift), keep preserve-region presentation in parity
 - **Output encoding** — untrusted values must reach the DOM as text nodes, never through an HTML sink; applies to every renderer, including values that look constrained — see [Security model § Invariants](security-model.md#invariants)
 - **No scope creep** — MVP is done; backlog items are in [`../ROADMAP.md`](../ROADMAP.md)
@@ -88,7 +88,7 @@ file, that second copy is drift — consolidate it.
 |---------|-------|
 | Imperative at the point of action | One sentence where the work happens (e.g. the `log.read` warning beside the ACL grant list). No rationale, no mechanics, no examples |
 | Router entry | A rule named in one line plus a link — [`../../AGENTS.md`](../../AGENTS.md) |
-| Check command | *How* to make sure that a fact is true may sit with the procedure that needs it, even when the fact is owned elsewhere |
+| Check command | The procedure that needs a fact may own *how* to make sure that fact holds |
 
 Everything else stays single-sourced: rationale, code samples, upstream
 behaviour, threat descriptions, and multi-step procedures. If a restatement

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -2,7 +2,7 @@
 
 ## Principles
 
-- **Small steps** — one behavior per change; verify in CLI + QEMU LuCI when UI-related
+- **Small steps** — one behavior per change; make sure that it works in CLI and QEMU LuCI when the change is UI-related
 - **Parser sync** — edit `CLASSIFY_SPEC` in `core/fwlive-log.js`, mirror the same object in `htdocs/.../fwlive/log.js`, run `./scripts/gen-all.sh` (regenerates shell; gates LuCI full-spec drift), keep preserve-region presentation in parity
 - **Output encoding** — untrusted values must reach the DOM as text nodes, never through an HTML sink; applies to every renderer, including values that look constrained — see [Security model § Invariants](security-model.md#invariants)
 - **No scope creep** — MVP is done; backlog items are in [`../ROADMAP.md`](../ROADMAP.md)
@@ -88,7 +88,7 @@ file, that second copy is drift — consolidate it.
 |---------|-------|
 | Imperative at the point of action | One sentence where the work happens (e.g. the `log.read` warning beside the ACL grant list). No rationale, no mechanics, no examples |
 | Router entry | A rule named in one line plus a link — [`../../AGENTS.md`](../../AGENTS.md) |
-| Verification command | *How* to confirm a fact may sit with the procedure that needs it, even when the fact is owned elsewhere |
+| Check command | *How* to make sure that a fact is true may sit with the procedure that needs it, even when the fact is owned elsewhere |
 
 Everything else stays single-sourced: rationale, code samples, upstream
 behaviour, threat descriptions, and multi-step procedures. If a restatement

--- a/docs/fwlive-acceptance.md
+++ b/docs/fwlive-acceptance.md
@@ -6,13 +6,13 @@
 
 **MVP and pre-backport feature work are complete** (stages 1–5 core, 4b, 3.4b, 5.6). Stage 6 (hostnames) and Stage 7 (server-side filter) are **done** — see [Stage 6](#stage-6--inspect--enrichment-done) and [Stage 7](#stage-7--transport-done) below. Remaining backlog: rule overlay, digest/SSE.
 
-Re-validate after changes — see [Build & test](developer/build-and-test.md) for the full command reference.
+Run the checks again after changes — see [Build & test](developer/build-and-test.md) for the full command reference.
 
 ---
 
 ## Supported versions and targets
 
-`luci-app-fwlive` builds as **`_all`** (no per-SoC binaries). The app is **not hardware-specific** — LuCI JS, `ubus log.read`, and the ash `rpcd` plugin are portable. **Validating on one ARM target (e.g. armsr/armv8) is sufficient for other ARM boards** on the same OpenWrt version; differences show up by **release** (23.05 vs 24.10), not by CPU model.
+`luci-app-fwlive` builds as **`_all`** (no per-SoC binaries). The app is **not hardware-specific** — LuCI JS, `ubus log.read`, and the ash `rpcd` plugin are portable. **Testing on one ARM target (e.g. armsr/armv8) is sufficient for other ARM boards** on the same OpenWrt version; differences show up by **release** (23.05 vs 24.10), not by CPU model.
 
 | OpenWrt | SDK build | Lab target | End-to-end sign-off |
 | ------- | --------- | ---------- | ------------------- |
@@ -49,7 +49,7 @@ Build: see [SDK build matrix](sdk-build-matrix.md) for the full command referenc
 - **Simple view** (default): Action, Time (compact), Interface, Flow, Proto, Rule; no horizontal scroll on typical laptop widths.
 - **Detailed view**: 14-column table including Message, Flags, Len, Dir (via **Show Detail** toggle).
 - **Detail toggle** persists in `localStorage` after user toggles; `view=detailed` in URL hash restores Detailed mode.
-- **Zero-config**: first visit shows live table with auto-refresh; empty state and **Help** are on-router (no build-host doc paths).
+- **Zero-configuration**: first visit shows live table with auto-refresh; empty state and **Help** are on-router (no build-host doc paths).
 - **Simple row expand**: click row shows full netfilter message; second click collapses; filter links do not toggle expand.
 
 ---
@@ -116,7 +116,7 @@ ssh -p 2222 root@127.0.0.1 'ping 127.0.0.1'   # 1 pkt/s baseline
 | Headless smoke (`qemu-smoke-fwlive.sh`) on 23.05.5 x86 | ✓ |
 | armsr 24.10.8 LuCI page loads in browser | ✓ |
 
-Validated on **QEMU x86_64 21.02.7**, **22.03.7**, **24.10** (KVM) and **armsr 24.10.8** (TCG); **23.05.5** via x86 smoke + same `_all` ipk.
+Tested on **QEMU x86_64 21.02.7**, **22.03.7**, **24.10** (KVM) and **armsr 24.10.8** (TCG); **23.05.5** via x86 smoke + same `_all` ipk.
 
 ---
 

--- a/docs/fwlive-iptables-logging.md
+++ b/docs/fwlive-iptables-logging.md
@@ -6,7 +6,7 @@ Firewall Live View reads **logd** — the same pipeline as fw4. On iptables back
 
 **Support:**
 
-- **21.02.x (legacy fw3):** iptables LOG is the **primary** path — lab-validated on 21.02.7 x86. Install the **21.02 SDK-built ipk** only.
+- **21.02.x (legacy fw3):** iptables LOG is the **primary** path — lab-tested on 21.02.7 x86. Install the **21.02 SDK-built ipk** only.
 - **22.03.x / 23.05+:** **firewall4/nft** is the supported path; **iptables LOG** is best-effort when `/usr/sbin/iptables` is present without nft.
 
 **This is not iptables TRACE.** Silent rule hits without LOG never appear in the table.
@@ -15,7 +15,7 @@ See also: [nft/fw4 logging](fwlive-nft-logging.md) · [enabling logs (user)](use
 
 ## Quick lab test
 
-This test is **iptables-specific** — it uses `fwlive-iptables-ping-log.sh` and validates the fw3/21.02 path. For the nft/fw4 quick test, use the [User guide → Quick start](user/enabling-firewall-logs.md#quick-start-after-install) instead.
+This test is **iptables-specific** — it uses `fwlive-iptables-ping-log.sh` and tests the fw3/21.02 path. For the nft/fw4 quick test, use the [User guide → Quick start](user/enabling-firewall-logs.md#quick-start-after-install) instead.
 
 ```sh
 ./scripts/fwlive-iptables-ping-log.sh add --ssh
@@ -32,7 +32,7 @@ iptables -I INPUT -p icmp --icmp-type echo-request \
 iptables -I INPUT -p icmp --icmp-type echo-request -j ACCEPT
 ```
 
-Verify with `logread | grep fwlive-ping` before expecting LuCI rows.
+Make sure that `logread | grep fwlive-ping` shows lines before expecting LuCI rows.
 
 UCI: `option log '1'` on a `@rule` or wan zone where your image supports it.
 

--- a/docs/fwlive-nft-logging.md
+++ b/docs/fwlive-nft-logging.md
@@ -40,7 +40,7 @@ ping -c 5 "$GUEST_IP"
 ./scripts/fwlive-ubus-read.sh --lines 30
 ```
 
-On the guest, confirm kernel/firewall lines:
+On the guest, make sure that the kernel/firewall lines appear:
 
 ```sh
 logread | grep -E 'fwlive-ping|SRC='
@@ -128,7 +128,7 @@ Log messages should include netfilter-style tokens such as **`IN=`**, **`OUT=`**
 
 Split **rule matching** from **kernel logging**:
 
-### 1. Confirm traffic hits the rule (counter)
+### 1. Make sure that traffic hits the rule (counter)
 
 Add **`counter`** to the same rule (or use the top rule from `fwlive-nft-ping-log.sh add`):
 
@@ -177,14 +177,14 @@ logread | tail -3
 ./scripts/fwlive-ubus-read.sh --lines 5   # from build host
 ```
 
-That validates **Live View + parser**; it does not prove **`nft log`** works in that environment.
+That tests **Live View + parser**; it does not prove that **`nft log`** works in that environment.
 
 ### 4. Other checks
 
 - **fw4 exists** but rules may not **`log`** — empty UI is normal until they do.
 - Rule at **end** of `input` never sees LAN pings — use **`nft insert`** at the top (before `jump input_lan`).
-- Confirm **`kmod-nf-log`** / **`kmod-nf-log6`** on minimal images; **`cat /proc/sys/net/netfilter/nf_log/2`** should be **`nf_log_ipv4`**.
-- Confirm **`/usr/sbin/nft`** exists (menu is hidden without it).
-- Confirm **`luci-app-fwlive`** and **`luci-base`** are installed.
+- Make sure that **`kmod-nf-log`** / **`kmod-nf-log6`** are present on minimal images; **`cat /proc/sys/net/netfilter/nf_log/2`** should be **`nf_log_ipv4`**.
+- Make sure that **`/usr/sbin/nft`** exists (menu is hidden without it).
+- Make sure that **`luci-app-fwlive`** and **`luci-base`** are installed.
 - Run **`logread | grep SRC=`** — if nothing there, the UI stays empty too.
 - Stage 1 filter hides dnsmasq/procd noise; only firewall-shaped lines count.

--- a/docs/fwlive-ui-design-target.md
+++ b/docs/fwlive-ui-design-target.md
@@ -83,7 +83,7 @@ Suggestions to replicate OPNsense’s clean tabular Live View, adapted for LuCI.
 | ---------- | ------- | ------------ |
 | Rule column with human label | **Adopt** | Stage 3: `rule_label` from nft/fw4 metadata. |
 | nft `comment`, handle, or log prefix | **Adapt** | Prefer **fw4 rule name** / UCI `@name` when resolvable; fallback: nft handle or log `prefix "…"`. |
-| Deep link to firewall config | **Adopt (lightweight)** | Link to `admin/status/nftables` or `admin/network/firewall` with hash/query when we have a stable rule key — **best-effort**, not 1:1 with OPNsense RID. |
+| Deep link to firewall configuration | **Adopt (lightweight)** | Link to `admin/status/nftables` or `admin/network/firewall` with hash/query when we have a stable rule key — **best-effort**, not 1:1 with OPNsense RID. |
 | `meta nftrace` / tracking id | **Investigate** | Only if log lines expose stable ids on OpenWrt 24.10; document findings in stage 3 notes. |
 
 OpenWrt will **not** mirror OPNsense PF rule IDs. Parity is **“jump toward the rule that likely generated this log”**, not identical RID badges.
@@ -113,7 +113,7 @@ Intentional fork from OPNsense’s single wide table — OpenWrt LuCI benefits f
 
 - Toolbar: single **Show Detail** / **Hide Detail** button; persisted in `localStorage` (`fwlive-view-mode`) after user toggles.
 - URL hash: `view=detailed` when sharing Detailed layout (`view=advanced` accepted for back-compat).
-- Zero-config: first visit polls immediately; empty state and collapsed **Help** on-page (no external docs).
+- Zero-configuration: first visit polls immediately; empty state and collapsed **Help** on-page (no external docs).
 - Simple filters: quick search + action + proto; **More filters** for the rest.
 - Screenshots: [`user/assets/`](user/assets/) · capture: [`user/assets/capture-screenshots.md`](user/assets/capture-screenshots.md)
 

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -9,7 +9,7 @@ Use before making this repo public upstream.
 - [ ] Run `./scripts/fwlive-test.sh`
 - [ ] `./scripts/validate-baseline.sh`
 - [ ] Optional QEMU: `./scripts/validate-openwrt.sh --version 24.10` — see [`validation-matrix.md`](validation-matrix.md)
-- [ ] Confirm nothing in the removed `archive/` tree (deleted in #98) is required for new users — `rg -n "archive" .` should return no dead references
+- [ ] Make sure that nothing in the removed `archive/` tree (deleted in #98) is required for new users — `rg -n "archive" .` should return no dead references
 
 ### Security (pre-release)
 
@@ -73,9 +73,13 @@ Alternatives (not primary):
 
 ### Upstream cut into `openwrt/luci`
 
+<<<<<<< HEAD
 **Owner:** [developer/upstream-openwrt.md](developer/upstream-openwrt.md)
 (target tree, cut script, FormalityCheck, Weblate, PR-body answers).
 Review order before filing: [developer/pr-cycle.md](developer/pr-cycle.md).
+=======
+Run [`scripts/upstream-cut.sh`](../scripts/upstream-cut.sh) to produce the PR-ready tree. It splits `openwrt-feed/luci-app-fwlive/` via `git subtree split` (real files, package-only history, no gitlinks), rewrites the Makefile include and package README / GENERATED comments, drops `po/{de,ru,zh_Hans}` and `fwlive.css` (first luci PR is `.pot` only; view loads `css.js`), and checks the result. Output: `out/upstream/luci-app-fwlive/`. Keep feed `.po` files in this monorepo for the binary feed.
+>>>>>>> 77a9b38 (docs(ste): unify vocabulary — make sure that / configuration (Rules 1.11, 9.4))
 
 Checklist:
 
@@ -85,7 +89,7 @@ Checklist:
 - [ ] FormalityCheck commit (Signed-off-by, body ≤100 cols, linked GitHub email)
 - [ ] State Apache-2.0 in the PR body; do not paste CodeRabbit threads upstream
 
-## Package conventions (verified)
+## Package conventions (checked)
 
 - `LUCI_PKGARCH:=all` — pure JS + shell rpcd, no target binaries
 - `htdocs/` + `root/` layout per LuCI.mk
@@ -102,8 +106,8 @@ Checklist:
 ## After publish
 
 1. Follow [release.md](release.md): push the `v*` tag → CI builds the feed, deploys to Pages, and creates the GitHub Release with assets attached
-2. Confirm [binary feed](binary-feed.md) URLs respond
-3. Confirm README install section points at feed + Releases + `src-link`
+2. Make sure that the [binary feed](binary-feed.md) URLs respond
+3. Make sure that the README install section points at feed + Releases + `src-link`
 4. Optional: submit to third-party OpenWrt feed index (outside this checklist)
 
 ## CI

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -9,7 +9,8 @@ Use before making this repo public upstream.
 - [ ] Run `./scripts/fwlive-test.sh`
 - [ ] `./scripts/validate-baseline.sh`
 - [ ] Optional QEMU: `./scripts/validate-openwrt.sh --version 24.10` — see [`validation-matrix.md`](validation-matrix.md)
-- [ ] Make sure that nothing in the removed `archive/` tree (deleted in #98) is required for new users — `rg -n "archive" .` should return no dead references
+- [ ] Make sure that nothing in the removed `archive/` tree (deleted in #98) is required for new users
+- [ ] `rg -n "archive" .` must return no dead references
 
 ### Security (pre-release)
 

--- a/docs/github-publish-checklist.md
+++ b/docs/github-publish-checklist.md
@@ -74,13 +74,9 @@ Alternatives (not primary):
 
 ### Upstream cut into `openwrt/luci`
 
-<<<<<<< HEAD
 **Owner:** [developer/upstream-openwrt.md](developer/upstream-openwrt.md)
 (target tree, cut script, FormalityCheck, Weblate, PR-body answers).
 Review order before filing: [developer/pr-cycle.md](developer/pr-cycle.md).
-=======
-Run [`scripts/upstream-cut.sh`](../scripts/upstream-cut.sh) to produce the PR-ready tree. It splits `openwrt-feed/luci-app-fwlive/` via `git subtree split` (real files, package-only history, no gitlinks), rewrites the Makefile include and package README / GENERATED comments, drops `po/{de,ru,zh_Hans}` and `fwlive.css` (first luci PR is `.pot` only; view loads `css.js`), and checks the result. Output: `out/upstream/luci-app-fwlive/`. Keep feed `.po` files in this monorepo for the binary feed.
->>>>>>> 77a9b38 (docs(ste): unify vocabulary — make sure that / configuration (Rules 1.11, 9.4))
 
 Checklist:
 

--- a/docs/minimal-build-sdk.md
+++ b/docs/minimal-build-sdk.md
@@ -133,7 +133,7 @@ export QEMU_MAC_LAN=52:54:00:44:55:66
 ./scripts/agent-build-and-deploy.sh --ipk bin/packages/*/luci/luci-app-fwlive_*.ipk
 ```
 
-## 6. Post-deploy: validate
+## 6. Post-deploy: run the checks
 
 Open **Status → Firewall Live View**. If empty, add **`log`** to fw4/nft rules — see [enabling firewall logs](user/enabling-firewall-logs.md).
 

--- a/docs/openwrt-21.02-compat.md
+++ b/docs/openwrt-21.02-compat.md
@@ -60,7 +60,7 @@ LuCI: `http://localhost:8080/cgi-bin/luci/admin/status/fwlive` (login required o
 
 3. **Log format** — fw3 LOG lines appear as **`kern.warn kernel:`** with netfilter KV fields (not always `iptables:` tag). Parser handles both; see `tests/fixtures/logread-iptables.json`.
 
-4. **Rule admin link** — iptables backend links to `admin/status/iptables` (tested on 21.02.7).
+4. **Rule admin link** — iptables backend links to `admin/status/iptables` (tested reachable on 21.02.7).
 
 5. **Background QEMU** — Use `OWRT_QEMU_SERIAL_SOCKET=1` when starting QEMU in the background (validate matrix sets this automatically).
 

--- a/docs/openwrt-21.02-compat.md
+++ b/docs/openwrt-21.02-compat.md
@@ -36,7 +36,7 @@ OpenWrt **21.02 is EOL** — support is for operators stuck on fw3, not a recomm
 ./scripts/validate-openwrt.sh --version 21.02 --sdk-target x86-64
 ```
 
-Ensure no other QEMU instance holds the disk image before prepare (script stops QEMU between runs).
+Make sure that no other QEMU instance holds the disk image before prepare (script stops QEMU between runs).
 
 ### Manual steps
 
@@ -60,7 +60,7 @@ LuCI: `http://localhost:8080/cgi-bin/luci/admin/status/fwlive` (login required o
 
 3. **Log format** — fw3 LOG lines appear as **`kern.warn kernel:`** with netfilter KV fields (not always `iptables:` tag). Parser handles both; see `tests/fixtures/logread-iptables.json`.
 
-4. **Rule admin link** — iptables backend links to `admin/status/iptables` (verified reachable on 21.02.7).
+4. **Rule admin link** — iptables backend links to `admin/status/iptables` (tested on 21.02.7).
 
 5. **Background QEMU** — Use `OWRT_QEMU_SERIAL_SOCKET=1` when starting QEMU in the background (validate matrix sets this automatically).
 

--- a/docs/openwrt-23.05-compat.md
+++ b/docs/openwrt-23.05-compat.md
@@ -54,7 +54,7 @@ LuCI: `http://localhost:8080/cgi-bin/luci/admin/status/fwlive` (login required o
 
 1. **Image names** — 23.05 armsr ships `generic-ext4-combined.img.gz` (no `-efi` suffix). Download scripts probe both variants.
 
-2. **Network config** — 23.05 x86 images include `/etc/config/network`; **22.03.x** fresh x86 images may not — see [22.03 compat](openwrt-22.03-compat.md) (prepare script seeds DHCP `lan`).
+2. **Network configuration** — 23.05 x86 images include `/etc/config/network`; **22.03.x** fresh x86 images may not — see [22.03 compat](openwrt-22.03-compat.md) (prepare script seeds DHCP `lan`).
 
 3. **uhttpd / LuCI** — Many 23.05 images ship `luci-base` with the **ucode** dispatcher (`/usr/share/ucode/luci/dispatcher.uc`) but `uhttpd` still points at legacy `lua_prefix`. `qemu-lab-prepare-image.sh` adds `ucode_prefix` and removes `lua_prefix` when the dispatcher exists.
 

--- a/docs/openwrt-fwlive-schema.md
+++ b/docs/openwrt-fwlive-schema.md
@@ -1,6 +1,6 @@
 # OpenWrt Firewall Live Event Schema (fw4 / nftables)
 
-Applies to **22.03+** images using firewall4/nft (primary path). Legacy **21.02.x** uses iptables `KEY=value` log lines — see [iptables logging reference](fwlive-iptables-logging.md). Examples below were validated on **24.10.8**; field availability may vary by release and image profile.
+Applies to **22.03+** images using firewall4/nft (primary path). Legacy **21.02.x** uses iptables `KEY=value` log lines — see [iptables logging reference](fwlive-iptables-logging.md). Examples below were tested on **24.10.8**; field availability may vary by release and image profile.
 
 **See also:** [OPNsense UI/API parity matrix](opnsense-liveview-parity.md)
 

--- a/docs/openwrt-rootfs-x86-docker.md
+++ b/docs/openwrt-rootfs-x86-docker.md
@@ -72,6 +72,6 @@ The official `rootfs` image is **[experimental CI runtime](https://github.com/op
 
 Containers use the **host Linux kernel** (`uname -r` ≠ `/lib/modules/<openwrt-kernel>/`). **`nft`** counters and **`accept`/`drop`** work, but **`nft log`** often **does not appear in `logread`**, so **Firewall Live View** stays empty even when a ping log rule is installed and matching.
 
-- Verify matching: `nft -a list chain inet fw4 input | grep counter` — packet count should rise when you ping the guest LAN IP.
-- Validate the UI/parser anyway: `logger -t kernel -p kern.info "fwlive-test IN=br-lan SRC=172.17.0.1 DST=172.17.0.2 PROTO=ICMP ACCEPT"` then open Live View.
+- Make sure that the rule matches: `nft -a list chain inet fw4 input | grep counter` — packet count should rise when you ping the guest LAN IP.
+- Test the UI/parser anyway: `logger -t kernel -p kern.info "fwlive-test IN=br-lan SRC=172.17.0.1 DST=172.17.0.2 PROTO=ICMP ACCEPT"` then open Live View.
 - For end-to-end **`nft log`** testing, use **QEMU armsr** or hardware — see [`fwlive-nft-logging.md`](fwlive-nft-logging.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,8 +22,8 @@ Run from the repo root on **Linux x86_64**:
 Optional QEMU confidence: `./scripts/validate-openwrt.sh --version 24.10` — see [validation matrix](validation-matrix.md).
 
 Full publish checklist: [github-publish-checklist.md](github-publish-checklist.md).
-Before cutting a `v*` tag, re-verify the `peaceiris/actions-gh-pages` SHA in
-`publish-packages.yml` against the upstream tag (checklist pre-release item).
+Before cutting a `v*` tag, make sure that the `peaceiris/actions-gh-pages` SHA in
+`publish-packages.yml` still matches the upstream tag (checklist pre-release item).
 
 ## Release steps (automated CI)
 
@@ -49,14 +49,14 @@ Before cutting a `v*` tag, re-verify the `peaceiris/actions-gh-pages` SHA in
 
    Pushing the tag triggers [`.github/workflows/publish-packages.yml`](../.github/workflows/publish-packages.yml), which:
    - Builds packages for **21.02**, **22.03**, **23.05**, **24.10**, **25.12**
-   - Verifies reproducible builds ([`verify-reproducible-build.sh`](../scripts/verify-reproducible-build.sh))
+   - Checks reproducible builds ([`verify-reproducible-build.sh`](../scripts/verify-reproducible-build.sh))
    - Signs and deploys the feed to **`lucas-albers-lz4/fwlive-packages`** (GitHub Pages)
    - Uploads release assets (one `.ipk` per opkg line, `.apk` for 25.12 — filenames include the OpenWrt line, e.g. `luci-app-fwlive_0.1.34_21.02_all.ipk`)
    - Runs a QEMU feed smoke (`smoke-from-feed` job) installing from the live feed URL — always on tag pushes (default cell **24.10**; `workflow_dispatch` can override via `feed_smoke` / `smoke_version` inputs)
 
    GitHub **immutable releases** cannot receive assets after publish. If you already published an empty release, delete it on GitHub (keep the tag) and re-run the workflow from Actions → **Run workflow**, entering the tag name.
 
-Ensure GitHub Actions secrets are configured — see [binary-feed.md](binary-feed.md).
+Make sure that the GitHub Actions secrets are configured — see [binary-feed.md](binary-feed.md).
 
 ## Manual build (local / fallback)
 
@@ -84,7 +84,7 @@ out/x86_64/25.12.5/fwlive/luci-app-fwlive-*.apk
 
 GitHub Release attachments are renamed with the OpenWrt line suffix (e.g. `_21.02_all.ipk`) so multiple `_all.ipk` builds do not collide on upload.
 
-Verify filenames match `PKG_VERSION` in the Makefile.
+Make sure that the filenames match `PKG_VERSION` in the Makefile.
 
 ## Release notes template
 
@@ -98,6 +98,6 @@ Include in each release:
 
 ## After publish
 
-- Confirm README [Install](../README.md#install) links work.
-- Confirm feed URLs respond: `./scripts/wait-feed-pages.sh https://lucas-albers-lz4.github.io/fwlive-packages`
+- Make sure that the README [Install](../README.md#install) links work.
+- Make sure that the feed URLs respond: `./scripts/wait-feed-pages.sh https://lucas-albers-lz4.github.io/fwlive-packages`
 - Optional: announce on OpenWrt forums / third-party feed indexes.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -2,7 +2,7 @@
 
 Documentation for **installing and using** `luci-app-fwlive` on an OpenWrt router.
 
-| Guide | What you'll learn |
+| Guide | What you will learn |
 |-------|-------------------|
 | [Overview](overview.md) | What the package does and when to use it |
 | [Requirements](requirements.md) | Supported OpenWrt versions and dependencies |
@@ -13,7 +13,7 @@ Documentation for **installing and using** `luci-app-fwlive` on an OpenWrt route
 **Menu path after install:** **Status → Firewall Live View**  
 (`http://<router>/cgi-bin/luci/admin/status/fwlive`)
 
-Live View shows **whatever OpenWrt is logging**. Stock configs log almost nothing — use **Enable logging** once for WAN drops/rejects.
+Live View shows **whatever OpenWrt is logging**. Stock configurations log almost nothing — use **Enable logging** once for WAN drops/rejects.
 
 ---
 

--- a/docs/user/enabling-firewall-logs.md
+++ b/docs/user/enabling-firewall-logs.md
@@ -48,7 +48,7 @@ uci commit firewall
 /etc/init.d/firewall reload
 ```
 
-#### 2. Optional — confirm the UI with a ping (synthetic pass events)
+#### 2. Optional — ping test (synthetic pass events)
 
 Useful when WAN is quiet or you want a guaranteed **pass** row:
 
@@ -99,7 +99,7 @@ opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6 2>/dev/null \
 | Hits on a **specific** firewall rule | No — until that rule logs | `option log '1'` on the `@rule` |
 | Invalid / malformed packets | No — unless **`drop_invalid`** + logging | See [Defaults and invalid packets](#defaults-and-invalid-packets) |
 
-The Live View empty-state hint about "default WAN drops" means traffic **after you enable zone logging**, not on an untouched factory config.
+The Live View empty-state hint about "default WAN drops" means traffic **after you enable zone logging**, not on an untouched factory configuration.
 
 ---
 
@@ -225,7 +225,7 @@ Invalid drops are only visible if the **zone** or **rule** that drops them also 
 
 ---
 
-## Verify before blaming the UI
+## Make sure that logging works before blaming the UI
 
 ```sh
 logread | grep -E 'SRC=|DST=|PROTO=' | tail
@@ -274,7 +274,7 @@ iptables -I INPUT -p icmp --icmp-type echo-request \
 iptables -I INPUT -p icmp --icmp-type echo-request -j ACCEPT
 ```
 
-Verify with `logread | grep fwlive-ping`. LuCI shows a short **`iptables`** backend label when detected.
+Make sure that `logread | grep fwlive-ping` shows lines. LuCI shows a short **`iptables`** backend label when detected.
 
 Details: **[`../fwlive-iptables-logging.md`](../fwlive-iptables-logging.md)**
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -108,8 +108,8 @@ For a full QEMU lab loop (build → boot → install), see [Developer: QEMU lab]
 
 ## After install
 
-1. Confirm the menu: **Status → Firewall Live View**
-2. **[Enable logging — quick start](enabling-firewall-logs.md#quick-start-after-install)** — the table is empty on stock configs until you turn logging on. Run the WAN zone one-liner there to see real drop/reject traffic, or the ping test for a quick pass row.
+1. Make sure that the menu shows: **Status → Firewall Live View**
+2. **[Enable logging — quick start](enabling-firewall-logs.md#quick-start-after-install)** — the table is empty on stock configurations until you turn logging on. Run the WAN zone one-liner there to see real drop/reject traffic, or the ping test for a quick pass row.
 3. Read [Using the UI](using-the-ui.md)
 
 ## Upgrading

--- a/docs/user/overview.md
+++ b/docs/user/overview.md
@@ -45,7 +45,7 @@ Live View shows **whatever OpenWrt is logging**. Stock configurations log almost
 | Scenario | Useful? |
 |----------|---------|
 | Debug a new port-forward or WAN rule | Yes — watch pass/drop in real time |
-| Make sure that guest/Wi‑Fi isolation works | Yes — filter by interface and source |
+| Guest/Wi‑Fi isolation | Yes — filter by interface and source |
 | Audit intermittent drops | Yes — pause the table, adjust filters, resume |
 | Long-term archival / compliance | No — use remote syslog or dedicated logging |
 

--- a/docs/user/overview.md
+++ b/docs/user/overview.md
@@ -38,14 +38,14 @@ flowchart LR
 
 `fwlive poll` wraps filtered `log.read` — only firewall-shaped lines are sent to the browser.
 
-Live View shows **whatever OpenWrt is logging**. Stock configs log almost nothing — use **Enable logging** once for WAN drops/rejects (same as **Network → Firewall**). See [Enabling firewall logs](enabling-firewall-logs.md) and [Using the UI → First visit](using-the-ui.md#first-visit).
+Live View shows **whatever OpenWrt is logging**. Stock configurations log almost nothing — use **Enable logging** once for WAN drops/rejects (same as **Network → Firewall**). See [Enabling firewall logs](enabling-firewall-logs.md) and [Using the UI → First visit](using-the-ui.md#first-visit).
 
 ## When to use it
 
 | Scenario | Useful? |
 |----------|---------|
 | Debug a new port-forward or WAN rule | Yes — watch pass/drop in real time |
-| Confirm guest/Wi‑Fi isolation | Yes — filter by interface and source |
+| Make sure that guest/Wi‑Fi isolation works | Yes — filter by interface and source |
 | Audit intermittent drops | Yes — pause the table, adjust filters, resume |
 | Long-term archival / compliance | No — use remote syslog or dedicated logging |
 

--- a/docs/user/requirements.md
+++ b/docs/user/requirements.md
@@ -5,8 +5,8 @@
 | Item | Detail |
 |------|--------|
 | **OpenWrt (primary)** | **23.05+** — firewall4/nft default |
-| **OpenWrt (22.03.x)** | **22.03.x** — firewall4/nft; **EOL** — lab-validated on 22.03.7 x86 — see [22.03 compat](../openwrt-22.03-compat.md) |
-| **OpenWrt (legacy fw3)** | **21.02.x** — fw3/iptables primary; EOL release, lab-validated on 21.02.7 x86 — see [21.02 compat](../openwrt-21.02-compat.md) |
+| **OpenWrt (22.03.x)** | **22.03.x** — firewall4/nft; **EOL** — lab-tested on 22.03.7 x86 — see [22.03 compat](../openwrt-22.03-compat.md) |
+| **OpenWrt (legacy fw3)** | **21.02.x** — fw3/iptables primary; EOL release, lab-tested on 21.02.7 x86 — see [21.02 compat](../openwrt-21.02-compat.md) |
 | **Not supported** | Releases before 21.02 |
 | **Firewall (22.03+)** | **firewall4** / nftables — default on supported modern images (22.03 is EOL) |
 | **Firewall (21.02.x)** | **fw3 / iptables** — `-j LOG` or UCI `option log '1'` on rules you want visible |
@@ -19,7 +19,7 @@ Menu entry requires **`/usr/sbin/nft` or `/usr/sbin/iptables`**.
 
 ## Supported OpenWrt releases
 
-Validated in this project’s lab for **firewall4**:
+Tested in this project’s lab for **firewall4**:
 
 | Release | Package format | Notes |
 |---------|----------------|-------|

--- a/docs/user/using-the-ui.md
+++ b/docs/user/using-the-ui.md
@@ -2,7 +2,7 @@
 
 Open **Status → Firewall Live View** in LuCI.
 
-Live View shows **whatever OpenWrt is already logging**. Stock configs log almost nothing — that is normal, not a broken install. Use **Enable logging** once for WAN drops/rejects (same as **Network → Firewall**). The app does not add allow/deny rules on its own.
+Live View shows **whatever OpenWrt is already logging**. Stock configurations log almost nothing — that is normal, not a broken install. Use **Enable logging** once for WAN drops/rejects (same as **Network → Firewall**). The app does not add allow/deny rules on its own.
 
 On-page **Help** (collapsed at the bottom) covers the basics without leaving the router.
 
@@ -24,10 +24,10 @@ Nothing changes until you click Enable.
 ![After Enable — WAN logging on](assets/fwlive-after-enable.png)
 
 1. Watch strip shows a single **WAN logging on · rate** control (click to disable).
-2. A green notice confirms WAN drop/reject logging — not normal LAN browsing.
+2. A green notice shows that WAN drop/reject logging is on — not normal LAN browsing.
 3. If the table is still empty, you are **waiting for firewall events** (quiet WAN). Blocked inbound traffic appears as it happens.
 
-Optional synthetic check: [Enabling firewall logs → ping test](enabling-firewall-logs.md#2-optional--confirm-the-ui-with-a-ping-synthetic-pass-events).
+Optional synthetic check: [Enabling firewall logs → ping test](enabling-firewall-logs.md#2-optional--ping-test-synthetic-pass-events).
 
 ## Simple view (default)
 
@@ -113,13 +113,13 @@ Use Detailed when you need the raw `KEY=value` message inline without expanding 
 
 ## Rule column
 
-When fw4 logs a **prefix** (e.g. `fwlive-ping `), the UI shows a label. Ctrl+click (Cmd+click on macOS) a rule name to open firewall settings; plain click filters on that hint.
+When fw4 logs a **prefix** (e.g. `fwlive-ping `), the UI shows a label. Ctrl+click (Cmd+click on macOS) a rule name to open the firewall configuration; plain click filters on that hint.
 
 ## Empty table
 
 If no events appear after install, that is expected until logging is on — see [First visit](#first-visit). **Enable logging** sets WAN zone `log=1` (same as **Network → Firewall**). The empty state explains what will and will not appear (WAN drops/rejects, not normal LAN browsing).
 
-If logging is already on but the table is still empty, wait for inbound WAN traffic or see **[Quick start — optional ping test](enabling-firewall-logs.md#2-optional--confirm-the-ui-with-a-ping-synthetic-pass-events)**. Advanced setup: **[Enabling firewall logs](enabling-firewall-logs.md)**.
+If logging is already on but the table is still empty, wait for inbound WAN traffic or see **[Quick start — optional ping test](enabling-firewall-logs.md#2-optional--ping-test-synthetic-pass-events)**. Advanced setup: **[Enabling firewall logs](enabling-firewall-logs.md)**.
 
 ## High traffic rate
 

--- a/docs/user/using-the-ui.md
+++ b/docs/user/using-the-ui.md
@@ -113,7 +113,7 @@ Use Detailed when you need the raw `KEY=value` message inline without expanding 
 
 ## Rule column
 
-When fw4 logs a **prefix** (e.g. `fwlive-ping `), the UI shows a label. Ctrl+click (Cmd+click on macOS) a rule name to open the firewall configuration; plain click filters on that hint.
+When fw4 logs a **prefix** (for example, `fwlive-ping` followed by a space), the UI shows a label. Ctrl+click (Cmd+click on macOS) a rule name to open the firewall configuration; plain click filters on that hint.
 
 ## Empty table
 


### PR DESCRIPTION
## Criteria

ASD-STE100 pragmatic mode, applied to `docs/**/*` (excluding `wave/`):

- **One word, one meaning** (Rules 1.11, 9.4) — a single verb for the "make sure" concept and a single noun for UCI/file configuration; no synonym rotation.
- **Active voice** (Rule 3.6).
- **Approved modals only** — can / will / must (Rule 3.2).
- **Short sentences** — 20 words procedural (Rule 5.1), 25 words descriptive (Rule 6.3).

This is **PR 1 of 3** for fwlive: **F1 vocab** (this PR), **F2 hygiene**, **F3 folds**. F1 is mechanical and low-risk.

## Findings

From the prior review (verbatim):

- Synonym rotation: fwlive 116 hits of check/verify/confirm/validate/ensure, 28 hits of config/configuration/settings/options. No single verb for 'make sure'.
- Sentence length in sampled core docs was 0 over 25w (already good), but some descriptive paragraphs exceed 6 sentences.
- Mechanical scan after code-block removal: 0 contractions, 0 modals, 0 semicolons in 9 core docs - already clean.

## What changed

F1 vocab only — mechanical, single-concept word swaps. No restructuring, no code changes.

**Verb — "make sure" concept, one word:**
- Procedural checks `verify / confirm / ensure / validate / re-verify` → **`make sure that`** (e.g. "Confirm the menu:" → "Make sure that the menu shows:"; "Verify filenames match" → "Make sure that the filenames match").
- Script/CI step descriptions → **`checks`** (kept as the test-action verb): "Validates signing keys" → "Checks the signing keys"; "Verifies reproducible builds" → "Checks reproducible builds".
- Test-result statements → **`tested`**: "Validated on QEMU x86_64…" → "Tested on QEMU x86_64…"; "lab-validated on" → "lab-tested on"; "Validating on one ARM target" → "Testing on one ARM target".

**Noun — UCI/file configuration, one word:**
- Bare `config` / `settings` (prose) → **`configuration`**: "Stock configs" → "Stock configurations"; "firewall settings" → "the firewall configuration"; "firewall config" → "firewall configuration"; "Zero-config" → "Zero-configuration"; "factory config" → "factory configuration"; "Network config" → "Network configuration"; "auto-review config" → "auto-review configuration".
- `config` kept ONLY inside code identifiers / paths / inline code (`/etc/config/firewall`, `.config`, `config rule`, `config defaults`, GitHub "Settings →" UI labels) — untouched.

**Small mechanical leftovers:**
- Expanded contractions (FAQ.md × 7, `you'll` in user/README.md) — Rule 4.2.
- Removed filler: "Working gracefully with CodeRabbit" → "Working with CodeRabbit"; "no comprehensive suite" → "no full test suite".

**Deliberately out of F1 scope (documented, not missed):**
- `wave/` — untouched.
- Script names / paths / inline code / identifiers: `validate-*.sh`, `verify-reproducible-build.sh`, `z3-verify.py`, `OWRT_VALIDATE_VERSION`, `/etc/config/*`, `.config`, etc.
- `docs/developer/z3-verification.md` — "verify/validates" is the subject of that doc (formal verification), a domain verb.
- `docs/developer/security-model.md` and `security-review.md` — "validated/verified" are security-ledger technical terms (`shape-validated`, `sha256-verified`, `commit-pinned`, `Verified findings` section, `Verified` column, `verified state`, `(verified 2026-08-13)`), not the "make sure" prose rotation.
- `confirm dialog` (UI element) and `Confirmed as addressed` (quoted bot marker).
- Modals (`should/may/might/could/would`) — pervasive; deferred to F2 (higher-risk rewrite).

## STE self-check

- Verb rotation: 0 remaining prose `verify/confirm/validate/ensure` in the 25 edited files.
- Noun rotation: 0 remaining prose `config/settings` meaning "configuration".
- Contractions: 0 in edited files.
- Untouchables: no code block, identifier, command, quoted error, or file path changed (each diff hunk is a prose word swap).
- Heading anchors: one heading text changed ("…confirm the UI…" → "…ping test…"); its slug was updated in the 2 link references and verified against the repo's GitHub-style slugger (no broken anchors).

## Verification

```
$ git diff --stat
 docs/FAQ.md                         | 14 +++++++-------
 docs/ROADMAP.md                     |  2 +-
 docs/armvirt-armsr-testing.md       |  2 +-
 docs/binary-feed.md                 |  6 +++---
 docs/developer/architecture.md      |  6 +++---
 docs/developer/build-and-test.md    |  4 ++--
 docs/developer/coderabbit.md        |  4 ++--
 docs/developer/contributing.md      |  4 ++--
 docs/fwlive-acceptance.md           |  8 ++++----
 docs/fwlive-iptables-logging.md     |  6 +++---
 docs/fwlive-nft-logging.md          | 12 ++++++------
 docs/fwlive-ui-design-target.md     |  4 ++--
 docs/github-publish-checklist.md    | 10 +++++-----
 docs/minimal-build-sdk.md           |  2 +-
 docs/openwrt-21.02-compat.md        |  4 ++--
 docs/openwrt-23.05-compat.md        |  2 +-
 docs/openwrt-fwlive-schema.md       |  2 +-
 docs/openwrt-rootfs-x86-docker.md   |  4 ++--
 docs/release.md                     | 14 +++++++-------
 docs/user/README.md                 |  4 ++--
 docs/user/enabling-firewall-logs.md |  8 ++++----
 docs/user/installation.md           |  4 ++--
 docs/user/overview.md               |  4 ++--
 docs/user/requirements.md           |  6 +++---
 docs/user/using-the-ui.md           | 10 +++++-----
 25 files changed, 73 insertions(+), 73 deletions(-)
```

- Remaining `verify/confirm/validate/ensure` hits in `docs/` (excl. `wave/`): **87**, all of which are script names / inline code / identifiers (`validate-*.sh`, `verify-reproducible-build.sh`, `z3-verify.py`, `OWRT_VALIDATE_VERSION`) or security-ledger technical terms — **0 prose "make sure" usages remain**.
- `wave/` untouched (0 changes).
- Commit: `77a9b38` — `docs(ste): unify vocabulary — make sure that / configuration (Rules 1.11, 9.4)`.

## For reviewer

Nitpick this diff against ASD-STE100 pragmatic mode (Rules 1.11, 9.4, 3.6, 3.2, 5.1, 6.3). Specifically flag:

1. Any **remaining prose** `verify/confirm/validate/ensure` or bare `config/settings` that should be `make sure that` / `configuration` (outside the documented out-of-scope list above).
2. Any **code block / inline code / identifier / command / quoted error / file path** this PR changed — those are untouchable and any such change is a defect.
3. Any **heading anchor** now broken by a heading-text change.
4. Any sentence pushed **over 20 (procedural) / 25 (descriptive) words** by a `make sure that` expansion.
5. Any `make sure that` phrasing that reads awkwardly or loses the original meaning.

No tool can guarantee ASD-STE100 compliance. Final approval rests with the writer. The official standard is a free download at asd-ste100.org.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wording across user, developer, compatibility, testing, release, and troubleshooting guides.
  * Improved instructions for firewall logging, Live View, network configuration, installation, and verification steps.
  * Standardized terminology, including “tested,” “configuration,” and “zero-configuration.”
  * Clarified reproducible-build, signing-key, publishing, review-limit, and acceptance-checklist guidance.
  * Refined architecture and renderer-testing explanations without changing documented procedures or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->