### PR TITLE
docs: luci vs fwlive maintenance model

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -63,7 +63,7 @@ Documentation for **building, testing, and extending** `luci-app-fwlive` and the
 |-------|----------|
 | Publish checklist | [`../github-publish-checklist.md`](../github-publish-checklist.md) |
 | Agent PR cycle (luna → Bugbot → human → file → CodeRabbit) | [pr-cycle.md](pr-cycle.md) |
-| Upstream to `openwrt/luci` | [upstream-openwrt.md](upstream-openwrt.md) |
+| Upstream to `openwrt/luci` (incl. [maintenance model](upstream-openwrt.md#maintenance-model)) | [upstream-openwrt.md](upstream-openwrt.md) |
 | CodeRabbit protocol | [coderabbit.md](coderabbit.md) |
 
 ## User documentation

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -63,7 +63,7 @@ Documentation for **building, testing, and extending** `luci-app-fwlive` and the
 |-------|----------|
 | Publish checklist | [`../github-publish-checklist.md`](../github-publish-checklist.md) |
 | Agent PR cycle (luna → Bugbot → human → file → CodeRabbit) | [pr-cycle.md](pr-cycle.md) |
-| Upstream to `openwrt/luci` (incl. [maintenance model](upstream-openwrt.md#maintenance-model)) | [upstream-openwrt.md](upstream-openwrt.md) |
+| Upstream to `openwrt/luci` (see [Maintenance model](upstream-openwrt.md#maintenance-model)) | [upstream-openwrt.md](upstream-openwrt.md) |
 | CodeRabbit protocol | [coderabbit.md](coderabbit.md) |
 
 ## User documentation

--- a/docs/developer/upstream-openwrt.md
+++ b/docs/developer/upstream-openwrt.md
@@ -5,59 +5,55 @@ upstream PR. Publish checklist pointer:
 [`../github-publish-checklist.md`](../github-publish-checklist.md).
 Agent review order before filing: [pr-cycle.md](pr-cycle.md).
 
-This monorepo stays the development home. The luci PR is a **copy**, not a
-move. The signed binary / `src-link` feed stays for non-snapshot users.
+This monorepo is the development home.
+The luci PR is a **copy**, not a move.
+The signed binary feed and `src-link` stay for users who do not use snapshots.
 
 ## Maintenance model
 
-Short answers for LuCI maintainers and anyone browsing the in-tree copy.
-Package README links here.
+This section answers questions from LuCI maintainers.
+The package README has a link to this section.
 
 ### Which tree wins
 
 | Tree | Role |
 |------|------|
-| **[lucas-albers-lz4/fwlive](https://github.com/lucas-albers-lz4/fwlive)** | Canonical source — develop, test, release, and cut from here |
-| **`openwrt/luci` `applications/luci-app-fwlive/`** | Periodic **snapshot** for snapshot images / the luci feed |
-| **Signed binary feed** | Parallel install path for non-snapshot users — not a second source of truth |
+| **[lucas-albers-lz4/fwlive](https://github.com/lucas-albers-lz4/fwlive)** | Primary source. Develop, test, release, and cut from this tree. |
+| **`openwrt/luci` `applications/luci-app-fwlive/`** | Snapshot for OpenWrt snapshot images and the luci feed. |
+| **Signed binary feed** | Second install path for users who do not use snapshots. Not a second source of truth. |
 
-On conflict, **this monorepo wins**. The next `./scripts/upstream-cut.sh` into
-luci replaces the previous luci copy (code + `.pot`). Do not treat the luci
-tree as a second development home.
+If the two trees disagree, **this monorepo wins**.
+The next run of `./scripts/upstream-cut.sh` replaces the luci copy (code and `.pot`).
+Do not use the luci tree as a second place to develop the app.
 
 ### Generated / snapshot files
 
-Several shipped files are **snapshots**, not hand-edited LuCI sources. Headers
-say so after the cut (e.g. `fwlive-is-firewall-event.sh`, `css.js`).
-`APP_VERSION` in `constants.js` stays lockstep with `PKG_VERSION`. Fix
-classifier / shared classify in the monorepo (`CLASSIFY_SPEC` +
-`./scripts/gen-all.sh`), then re-cut. An in-tree edit of those artifacts will
-be overwritten on the next snapshot.
+Some shipped files are **snapshots**. They are not hand-edited LuCI sources.
+After the cut, their headers say this (for example `fwlive-is-firewall-event.sh` and `css.js`).
+Keep `APP_VERSION` in `constants.js` equal to `PKG_VERSION`.
+To change the classifier, edit `CLASSIFY_SPEC` in this monorepo, run `./scripts/gen-all.sh`, then cut again.
+If you edit those files only in luci, the next snapshot will overwrite your change.
 
 ### Keeping luci current
 
-Commitment: re-cut **deltas** into `openwrt/luci` when shipping fixes or
-releases (same FormalityCheck path as the first PR). After Weblate owns
-`po/<lang>/`, re-cuts must **never** clobber those locales — code + `.pot`
-only ([After merge](#after-merge-upstream)).
+When we ship a fix or a release, we cut the change into `openwrt/luci` again.
+Use the same FormalityCheck path as the first PR.
+After Weblate owns `po/<lang>/`, a re-cut must **not** replace those locale files.
+Re-cut only code and `.pot` ([After merge](#after-merge-upstream)).
 
-This is intentional dual maintenance with a single winner, not the
-ambiguous two-homes pattern that bit packages like `luci-app-https-dns-proxy`.
-Drive-by fixes belong in fwlive (or as a note forwarded upstream), not as
-long-lived patches only in luci.
+We keep two trees on purpose, with one winner.
+We do not use two equal homes (see `luci-app-https-dns-proxy` as a bad example).
+Send fixes to fwlive. Do not leave long-lived patches only in luci.
 
 ### Why not `PKG_SOURCE`
 
-A tarball / `PKG_SOURCE` package was considered and **declined**:
+We looked at a `PKG_SOURCE` / tarball package. We **do not** use that design:
 
-- LuCI applications normally live **in-tree** under `applications/`
-- After merge, **Weblate** owns `po/<lang>/` in luci; a fetch-from-GitHub
-  flow still needs periodic bumps and does not remove “two places”
-- Snapshot / image builders expect a plain tree, not a network fetch at
-  package build time
+- LuCI apps usually live **in the tree** under `applications/`
+- After merge, **Weblate** owns `po/<lang>/` in luci. A GitHub download still needs version bumps and still has two places to update
+- Snapshot and image builders expect a plain tree. They must not fetch from the network when they build the package
 
-In-tree snapshot + explicit “fwlive wins” policy matches LuCI conventions
-better than an out-of-tree tarball for a first-party app.
+An in-tree snapshot with a clear “fwlive wins” rule fits LuCI practice better than an out-of-tree tarball.
 
 ## Where it lands
 
@@ -168,8 +164,8 @@ paste review threads upstream.
 | `PKG_VERSION` | Keep in the cut (lockstep with `APP_VERSION`) |
 | License | State Apache-2.0 in the PR body. `PKG_LICENSE` is already set; do not add `PKG_LICENSE_FILES` (peer LuCI apps) |
 | Out-of-tree | New in-tree app, not an LLM redirect heuristic; feed stays |
-| Generated files | Snapshots from this repo — see [Maintenance model](#maintenance-model) |
-| Dual tree / `PKG_SOURCE` | fwlive wins; in-tree snapshot kept; `PKG_SOURCE` declined — [Maintenance model](#maintenance-model) |
+| Generated files | Snapshots from this repo. See [Maintenance model](#maintenance-model). |
+| Dual tree / `PKG_SOURCE` | fwlive wins. Keep the in-tree snapshot. Do not use `PKG_SOURCE`. See [Maintenance model](#maintenance-model). |
 
 ## After merge (upstream)
 

--- a/docs/developer/upstream-openwrt.md
+++ b/docs/developer/upstream-openwrt.md
@@ -8,6 +8,57 @@ Agent review order before filing: [pr-cycle.md](pr-cycle.md).
 This monorepo stays the development home. The luci PR is a **copy**, not a
 move. The signed binary / `src-link` feed stays for non-snapshot users.
 
+## Maintenance model
+
+Short answers for LuCI maintainers and anyone browsing the in-tree copy.
+Package README links here.
+
+### Which tree wins
+
+| Tree | Role |
+|------|------|
+| **[lucas-albers-lz4/fwlive](https://github.com/lucas-albers-lz4/fwlive)** | Canonical source — develop, test, release, and cut from here |
+| **`openwrt/luci` `applications/luci-app-fwlive/`** | Periodic **snapshot** for snapshot images / the luci feed |
+| **Signed binary feed** | Parallel install path for non-snapshot users — not a second source of truth |
+
+On conflict, **this monorepo wins**. The next `./scripts/upstream-cut.sh` into
+luci replaces the previous luci copy (code + `.pot`). Do not treat the luci
+tree as a second development home.
+
+### Generated / snapshot files
+
+Several shipped files are **snapshots**, not hand-edited LuCI sources. Headers
+say so after the cut (e.g. `fwlive-is-firewall-event.sh`, `css.js`).
+`APP_VERSION` in `constants.js` stays lockstep with `PKG_VERSION`. Fix
+classifier / shared classify in the monorepo (`CLASSIFY_SPEC` +
+`./scripts/gen-all.sh`), then re-cut. An in-tree edit of those artifacts will
+be overwritten on the next snapshot.
+
+### Keeping luci current
+
+Commitment: re-cut **deltas** into `openwrt/luci` when shipping fixes or
+releases (same FormalityCheck path as the first PR). After Weblate owns
+`po/<lang>/`, re-cuts must **never** clobber those locales — code + `.pot`
+only ([After merge](#after-merge-upstream)).
+
+This is intentional dual maintenance with a single winner, not the
+ambiguous two-homes pattern that bit packages like `luci-app-https-dns-proxy`.
+Drive-by fixes belong in fwlive (or as a note forwarded upstream), not as
+long-lived patches only in luci.
+
+### Why not `PKG_SOURCE`
+
+A tarball / `PKG_SOURCE` package was considered and **declined**:
+
+- LuCI applications normally live **in-tree** under `applications/`
+- After merge, **Weblate** owns `po/<lang>/` in luci; a fetch-from-GitHub
+  flow still needs periodic bumps and does not remove “two places”
+- Snapshot / image builders expect a plain tree, not a network fetch at
+  package build time
+
+In-tree snapshot + explicit “fwlive wins” policy matches LuCI conventions
+better than an out-of-tree tarball for a first-party app.
+
 ## Where it lands
 
 | Place | Role | First PR? |
@@ -117,7 +168,8 @@ paste review threads upstream.
 | `PKG_VERSION` | Keep in the cut (lockstep with `APP_VERSION`) |
 | License | State Apache-2.0 in the PR body. `PKG_LICENSE` is already set; do not add `PKG_LICENSE_FILES` (peer LuCI apps) |
 | Out-of-tree | New in-tree app, not an LLM redirect heuristic; feed stays |
-| Generated files | Snapshots from this repo |
+| Generated files | Snapshots from this repo — see [Maintenance model](#maintenance-model) |
+| Dual tree / `PKG_SOURCE` | fwlive wins; in-tree snapshot kept; `PKG_SOURCE` declined — [Maintenance model](#maintenance-model) |
 
 ## After merge (upstream)
 

--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -39,9 +39,9 @@ No `luasrc/` — modern JS-only app.
 
 ## Maintenance
 
-Development home is [lucas-albers-lz4/fwlive](https://github.com/lucas-albers-lz4/fwlive).
-The copy in `openwrt/luci` is a snapshot. Which tree wins, re-cut cadence,
-generated files, and why not `PKG_SOURCE`:
+The development home is [lucas-albers-lz4/fwlive](https://github.com/lucas-albers-lz4/fwlive).
+The copy in `openwrt/luci` is a snapshot.
+For which tree wins, when we re-cut, generated files, and why we do not use `PKG_SOURCE`, see
 [Maintenance model](../../docs/developer/upstream-openwrt.md#maintenance-model).
 
 ## Documentation

--- a/openwrt-feed/luci-app-fwlive/README.md
+++ b/openwrt-feed/luci-app-fwlive/README.md
@@ -40,14 +40,9 @@ No `luasrc/` — modern JS-only app.
 ## Maintenance
 
 Development home is [lucas-albers-lz4/fwlive](https://github.com/lucas-albers-lz4/fwlive).
-The copy in `openwrt/luci` is a snapshot. On conflict, the next snapshot from
-that repository replaces the luci copy — land fixes upstream of this tree
-first.
-
-A `PKG_SOURCE` tarball package was considered and declined: LuCI applications
-are in-tree under `applications/`, Weblate owns `po/<lang>/` after merge, and a
-tarball would still leave a copy to update on every release. The signed binary
-feed stays for non-snapshot users.
+The copy in `openwrt/luci` is a snapshot. Which tree wins, re-cut cadence,
+generated files, and why not `PKG_SOURCE`:
+[Maintenance model](../../docs/developer/upstream-openwrt.md#maintenance-model).
 
 ## Documentation
 

--- a/scripts/upstream-cut.sh
+++ b/scripts/upstream-cut.sh
@@ -81,6 +81,7 @@ fi
 sed -i \
 	-e 's|\[`\.\./\.\./docs/user/installation\.md`\](\.\./\.\./docs/user/installation\.md)|[installation guide]('"$GITHUB_BLOB"'/docs/user/installation.md)|' \
 	-e 's|\[`\.\./\.\./docs/developer/README\.md`\](\.\./\.\./docs/developer/README.md)|[developer documentation]('"$GITHUB_BLOB"'/docs/developer/README.md)|' \
+	-e 's|\[Maintenance model\](\.\./\.\./docs/developer/upstream-openwrt\.md#maintenance-model)|[Maintenance model]('"$GITHUB_BLOB"'/docs/developer/upstream-openwrt.md#maintenance-model)|' \
 	-e 's|Parser/filter module (mirror of repo `core/fwlive-log.js`)|Parser/filter module (`CLASSIFY_SPEC` + LuCI helpers)|' \
 	"$OUT/README.md"
 


### PR DESCRIPTION
## Summary
- Add an anchorable [Maintenance model](docs/developer/upstream-openwrt.md#maintenance-model) section (which tree wins, generated snapshots, re-cut cadence, why not `PKG_SOURCE`).
- Point the package README at it; teach `upstream-cut.sh` to rewrite the link to the GitHub blob URL for the luci tree.

## Test plan
- [x] `./scripts/upstream-cut.sh` — cut README Maintenance link becomes `.../upstream-openwrt.md#maintenance-model`
- [ ] Merge, then re-cut luci#8992 README so reviewers can click through

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the maintenance model for upstream OpenWrt content, including source-of-truth guidance and the role of generated snapshots.
  * Added guidance for generated files, change synchronization, translation ownership, and package source handling.
  * Consolidated feed documentation around the dedicated maintenance model and linked related policies.
* **Chores**
  * Updated automated upstream exports to preserve valid links to maintenance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->