### PR TITLE
test: Wave B view contract + mocked Playwright harness (#240)

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Link check (internal markdown links + external URLs)
         run: ./scripts/fwlive-linkcheck.sh
 
+  # Tier 2 mocked LuCI view smoke — required check (add test-view-mock to branch protection).
   test-view-mock:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -26,7 +26,6 @@ jobs:
 
   test-view-mock:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6

--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -24,6 +24,20 @@ jobs:
       - name: Link check (internal markdown links + external URLs)
         run: ./scripts/fwlive-linkcheck.sh
 
+  test-view-mock:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
+        with:
+          node-version: '22'
+      - run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Mocked view smoke (Tier 2)
+        run: npm run test:view
+
   zizmor:
     runs-on: ubuntu-latest
     env:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "./scripts/fwlive-test.sh",
     "test:links": "./scripts/fwlive-linkcheck.sh",
-    "test:ui": "node scripts/capture-fwlive-screenshots.mjs"
+    "test:ui": "node scripts/capture-fwlive-screenshots.mjs",
+    "test:view": "node tests/fwlive-view-smoke.mjs"
   },
   "devDependencies": {
     "playwright": "1.60.0"

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -59,6 +59,12 @@ echo "== fwlive theme tint helpers ==" >&2
 echo "== fwlive extracted modules smoke ==" >&2
 "$NODE" tests/fwlive-modules-smoke.test.js
 
+echo "== fwlive view poll contract (#233 / #240) =="
+"$NODE" tests/fwlive-view-poll-error.test.js
+
+echo "== fwlive view poll guard (#240) =="
+"$NODE" tests/fwlive-view-poll-guard.test.js
+
 echo "== fwlive LuCI-accurate E() harness (#149) ==" >&2
 "$NODE" tests/fwlive-e-harness.test.js
 

--- a/scripts/serve-view-harness.mjs
+++ b/scripts/serve-view-harness.mjs
@@ -2,7 +2,7 @@
 /**
  * Static server for mocked LuCI view harness (Tier 2 / #240 Wave B2).
  *
- * Loopback-only by default. Refuses path escape via `..` or symlinks (#249).
+ * Loopback-only by default. Refuses path escape via `..`, symlinks, or `.git`.
  *
  *   node scripts/serve-view-harness.mjs
  *   FWLIVE_HARNESS_PORT=8765 node scripts/serve-view-harness.mjs
@@ -42,9 +42,22 @@ const MIME = {
 	'.svg': 'image/svg+xml'
 };
 
-/** Resolve URL to a real file under ROOT; null if missing, escaped, or .git. */
+function isDeniedGitPath(real) {
+	const rel = path.relative(ROOT_REAL, real);
+	if (!rel || rel.startsWith('..'))
+		return true;
+	return rel.split(path.sep).includes('.git');
+}
+
+/** Resolve URL to a real file under ROOT; null if missing, escaped, or denied. */
 function safePath(urlPath) {
-	const decoded = decodeURIComponent((urlPath || '').split('?')[0]);
+	let decoded;
+	try {
+		decoded = decodeURIComponent((urlPath || '').split('?')[0]);
+	} catch (e) {
+		return null;
+	}
+
 	const rel = decoded.replace(/^\/+/, '');
 	if (!rel || rel.split(/[/\\]/).includes('..'))
 		return null;
@@ -66,39 +79,53 @@ function safePath(urlPath) {
 
 	if (!real.startsWith(ROOT_REAL + path.sep) && real !== ROOT_REAL)
 		return null;
+	if (isDeniedGitPath(real))
+		return null;
 
 	return real;
 }
 
 const server = http.createServer((req, res) => {
-	let urlPath = req.url || '/';
-	if (urlPath === '/')
-		urlPath = '/tests/fixtures/luci-view-harness.html';
-
-	const abs = safePath(urlPath);
-	if (!abs) {
-		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-		res.end('not found');
-		return;
-	}
-
-	let st;
 	try {
-		st = fs.statSync(abs);
-	} catch (e) {
-		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-		res.end('not found');
-		return;
-	}
-	if (st.isDirectory()) {
-		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-		res.end('not found');
-		return;
-	}
+		let urlPath = req.url || '/';
+		if (urlPath === '/')
+			urlPath = '/tests/fixtures/luci-view-harness.html';
 
-	const ext = path.extname(abs);
-	res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
-	fs.createReadStream(abs).pipe(res);
+		const abs = safePath(urlPath);
+		if (!abs) {
+			res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+			res.end('not found');
+			return;
+		}
+
+		let st;
+		try {
+			st = fs.statSync(abs);
+		} catch (e) {
+			res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+			res.end('not found');
+			return;
+		}
+		if (st.isDirectory()) {
+			res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+			res.end('not found');
+			return;
+		}
+
+		const ext = path.extname(abs);
+		res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+		const stream = fs.createReadStream(abs);
+		stream.on('error', () => {
+			if (!res.headersSent)
+				res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+			res.end('read error');
+		});
+		stream.pipe(res);
+	} catch (e) {
+		if (!res.headersSent)
+			res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+		res.end('server error');
+	}
 });
 
 server.listen(PORT, HOST, () => {

--- a/scripts/serve-view-harness.mjs
+++ b/scripts/serve-view-harness.mjs
@@ -2,6 +2,8 @@
 /**
  * Static server for mocked LuCI view harness (Tier 2 / #240 Wave B2).
  *
+ * Loopback-only by default. Refuses path escape via `..` or symlinks (#249).
+ *
  *   node scripts/serve-view-harness.mjs
  *   FWLIVE_HARNESS_PORT=8765 node scripts/serve-view-harness.mjs
  */
@@ -11,8 +13,25 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_REAL = fs.realpathSync(ROOT);
 const PORT = Number(process.env.FWLIVE_HARNESS_PORT || 8765);
-const HOST = process.env.FWLIVE_HARNESS_HOST || '127.0.0.1';
+const HOST_RAW = process.env.FWLIVE_HARNESS_HOST || '127.0.0.1';
+
+const LOOPBACK = new Set(['127.0.0.1', '::1', 'localhost']);
+
+function assertLoopbackHost(host) {
+	const h = String(host || '').toLowerCase();
+	if (!LOOPBACK.has(h)) {
+		console.error(
+			`serve-view-harness: refusing non-loopback bind "${host}" ` +
+			'(set FWLIVE_HARNESS_HOST to 127.0.0.1 or ::1)'
+		);
+		process.exit(1);
+	}
+	return host === 'localhost' ? '127.0.0.1' : host;
+}
+
+const HOST = assertLoopbackHost(HOST_RAW);
 
 const MIME = {
 	'.html': 'text/html; charset=utf-8',
@@ -23,13 +42,32 @@ const MIME = {
 	'.svg': 'image/svg+xml'
 };
 
+/** Resolve URL to a real file under ROOT; null if missing, escaped, or .git. */
 function safePath(urlPath) {
-	const decoded = decodeURIComponent(urlPath.split('?')[0]);
+	const decoded = decodeURIComponent((urlPath || '').split('?')[0]);
 	const rel = decoded.replace(/^\/+/, '');
+	if (!rel || rel.split(/[/\\]/).includes('..'))
+		return null;
+	if (rel === '.git' || rel.startsWith('.git/') || rel.startsWith('.git' + path.sep))
+		return null;
+
 	const abs = path.resolve(ROOT, rel);
 	if (!abs.startsWith(ROOT + path.sep) && abs !== ROOT)
 		return null;
-	return abs;
+
+	let real;
+	try {
+		if (!fs.existsSync(abs))
+			return null;
+		real = fs.realpathSync(abs);
+	} catch (e) {
+		return null;
+	}
+
+	if (!real.startsWith(ROOT_REAL + path.sep) && real !== ROOT_REAL)
+		return null;
+
+	return real;
 }
 
 const server = http.createServer((req, res) => {
@@ -38,7 +76,21 @@ const server = http.createServer((req, res) => {
 		urlPath = '/tests/fixtures/luci-view-harness.html';
 
 	const abs = safePath(urlPath);
-	if (!abs || !fs.existsSync(abs) || fs.statSync(abs).isDirectory()) {
+	if (!abs) {
+		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+		res.end('not found');
+		return;
+	}
+
+	let st;
+	try {
+		st = fs.statSync(abs);
+	} catch (e) {
+		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+		res.end('not found');
+		return;
+	}
+	if (st.isDirectory()) {
 		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
 		res.end('not found');
 		return;

--- a/scripts/serve-view-harness.mjs
+++ b/scripts/serve-view-harness.mjs
@@ -2,7 +2,7 @@
 /**
  * Static server for mocked LuCI view harness (Tier 2 / #240 Wave B2).
  *
- * Loopback-only by default. Refuses path escape via `..`, symlinks, or `.git`.
+ * Loopback-only. Serves only allowlisted prefixes under fixed roots (#249 / CodeQL).
  *
  *   node scripts/serve-view-harness.mjs
  *   FWLIVE_HARNESS_PORT=8765 node scripts/serve-view-harness.mjs
@@ -13,11 +13,31 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const ROOT_REAL = fs.realpathSync(ROOT);
 const PORT = Number(process.env.FWLIVE_HARNESS_PORT || 8765);
 const HOST_RAW = process.env.FWLIVE_HARNESS_HOST || '127.0.0.1';
 
 const LOOPBACK = new Set(['127.0.0.1', '::1', 'localhost']);
+
+/** Fixed roots — URL must match prefix; path segments validated before join. */
+const ALLOWED_ROOTS = [
+	{
+		prefix: '/tests/fixtures/',
+		root: path.join(ROOT, 'tests', 'fixtures')
+	},
+	{
+		prefix: '/openwrt-feed/luci-app-fwlive/htdocs/luci-static/',
+		root: path.join(ROOT, 'openwrt-feed', 'luci-app-fwlive', 'htdocs', 'luci-static')
+	}
+];
+
+const MIME = {
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'text/javascript; charset=utf-8',
+	'.css': 'text/css; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.png': 'image/png',
+	'.svg': 'image/svg+xml'
+};
 
 function assertLoopbackHost(host) {
 	const h = String(host || '').toLowerCase();
@@ -33,65 +53,73 @@ function assertLoopbackHost(host) {
 
 const HOST = assertLoopbackHost(HOST_RAW);
 
-const MIME = {
-	'.html': 'text/html; charset=utf-8',
-	'.js': 'text/javascript; charset=utf-8',
-	'.css': 'text/css; charset=utf-8',
-	'.json': 'application/json; charset=utf-8',
-	'.png': 'image/png',
-	'.svg': 'image/svg+xml'
-};
+function isSafeSegment(seg) {
+	return seg.length > 0 && seg !== '.' && seg !== '..' &&
+		seg !== '.git' && /^[a-zA-Z0-9._-]+$/.test(seg);
+}
 
-function isDeniedGitPath(real) {
-	const rel = path.relative(ROOT_REAL, real);
+function isDeniedGitPath(rootReal, real) {
+	const rel = path.relative(rootReal, real);
 	if (!rel || rel.startsWith('..'))
 		return true;
 	return rel.split(path.sep).includes('.git');
 }
 
-/** Resolve URL to a real file under ROOT; null if missing, escaped, or denied. */
-function safePath(urlPath) {
-	let decoded;
+/** Map request URL to a real file under an allowlisted root, or null. */
+function resolveAllowedFile(urlPath) {
+	let pathname;
 	try {
-		decoded = decodeURIComponent((urlPath || '').split('?')[0]);
+		pathname = decodeURIComponent(String(urlPath || '').split('?')[0]);
 	} catch (e) {
 		return null;
 	}
 
-	const rel = decoded.replace(/^\/+/, '');
-	if (!rel || rel.split(/[/\\]/).includes('..'))
-		return null;
-	if (rel === '.git' || rel.startsWith('.git/') || rel.startsWith('.git' + path.sep))
-		return null;
+	if (pathname === '/' || pathname === '')
+		pathname = '/tests/fixtures/luci-view-harness.html';
 
-	const abs = path.resolve(ROOT, rel);
-	if (!abs.startsWith(ROOT + path.sep) && abs !== ROOT)
-		return null;
+	for (const entry of ALLOWED_ROOTS) {
+		if (!pathname.startsWith(entry.prefix))
+			continue;
 
-	let real;
-	try {
-		if (!fs.existsSync(abs))
+		const suffix = pathname.slice(entry.prefix.length);
+		if (!suffix)
 			return null;
-		real = fs.realpathSync(abs);
-	} catch (e) {
-		return null;
+
+		const segments = suffix.split('/').filter(Boolean);
+		if (!segments.length || !segments.every(isSafeSegment))
+			return null;
+
+		let rootReal;
+		try {
+			rootReal = fs.realpathSync(entry.root);
+		} catch (e) {
+			return null;
+		}
+
+		const abs = path.join(rootReal, ...segments);
+		let real;
+		try {
+			if (!fs.existsSync(abs))
+				return null;
+			real = fs.realpathSync(abs);
+		} catch (e) {
+			return null;
+		}
+
+		if (!real.startsWith(rootReal + path.sep) && real !== rootReal)
+			return null;
+		if (isDeniedGitPath(rootReal, real))
+			return null;
+
+		return real;
 	}
 
-	if (!real.startsWith(ROOT_REAL + path.sep) && real !== ROOT_REAL)
-		return null;
-	if (isDeniedGitPath(real))
-		return null;
-
-	return real;
+	return null;
 }
 
 const server = http.createServer((req, res) => {
 	try {
-		let urlPath = req.url || '/';
-		if (urlPath === '/')
-			urlPath = '/tests/fixtures/luci-view-harness.html';
-
-		const abs = safePath(urlPath);
+		const abs = resolveAllowedFile(req.url);
 		if (!abs) {
 			res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
 			res.end('not found');

--- a/scripts/serve-view-harness.mjs
+++ b/scripts/serve-view-harness.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Static server for mocked LuCI view harness (Tier 2 / #240 Wave B2).
+ *
+ *   node scripts/serve-view-harness.mjs
+ *   FWLIVE_HARNESS_PORT=8765 node scripts/serve-view-harness.mjs
+ */
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PORT = Number(process.env.FWLIVE_HARNESS_PORT || 8765);
+const HOST = process.env.FWLIVE_HARNESS_HOST || '127.0.0.1';
+
+const MIME = {
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'text/javascript; charset=utf-8',
+	'.css': 'text/css; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.png': 'image/png',
+	'.svg': 'image/svg+xml'
+};
+
+function safePath(urlPath) {
+	const decoded = decodeURIComponent(urlPath.split('?')[0]);
+	const rel = decoded.replace(/^\/+/, '');
+	const abs = path.resolve(ROOT, rel);
+	if (!abs.startsWith(ROOT + path.sep) && abs !== ROOT)
+		return null;
+	return abs;
+}
+
+const server = http.createServer((req, res) => {
+	let urlPath = req.url || '/';
+	if (urlPath === '/')
+		urlPath = '/tests/fixtures/luci-view-harness.html';
+
+	const abs = safePath(urlPath);
+	if (!abs || !fs.existsSync(abs) || fs.statSync(abs).isDirectory()) {
+		res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+		res.end('not found');
+		return;
+	}
+
+	const ext = path.extname(abs);
+	res.writeHead(200, { 'Content-Type': MIME[ext] || 'application/octet-stream' });
+	fs.createReadStream(abs).pipe(res);
+});
+
+server.listen(PORT, HOST, () => {
+	process.stdout.write(`fwlive view harness http://${HOST}:${PORT}/\n`);
+});
+
+function shutdown() {
+	server.close(() => process.exit(0));
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/tests/fixtures/luci-dom-shim.js
+++ b/tests/fixtures/luci-dom-shim.js
@@ -1,0 +1,93 @@
+/**
+ * Browser LuCI E() shim — real DOM, ported from tests/lib/luci-e-harness.js.
+ */
+(function(global) {
+	'use strict';
+
+	const dom = {
+		elem(e) {
+			return e != null && typeof e === 'object' && 'nodeType' in e;
+		},
+		parse(s) {
+			try {
+				const tpl = document.createElement('template');
+				tpl.innerHTML = s.trim();
+				return tpl.content.firstChild;
+			} catch (e) {
+				return null;
+			}
+		},
+		append(node, children) {
+			if (!this.elem(node))
+				return null;
+			if (Array.isArray(children)) {
+				for (let i = 0; i < children.length; i++) {
+					if (this.elem(children[i]))
+						node.appendChild(children[i]);
+					else if (children[i] !== null && children[i] !== undefined)
+						node.appendChild(document.createTextNode(String(children[i])));
+				}
+				return node.lastChild;
+			}
+			if (typeof children === 'function')
+				return this.append(node, children(node));
+			if (this.elem(children))
+				return node.appendChild(children);
+			if (children !== null && children !== undefined) {
+				node.innerHTML = String(children);
+				return node.lastChild;
+			}
+			return null;
+		},
+		attr(node, key, val) {
+			if (!this.elem(node))
+				return null;
+			let attr = null;
+			if (typeof key === 'object' && key !== null)
+				attr = key;
+			else if (typeof key === 'string')
+				attr = {}, attr[key] = val;
+			for (const k in attr) {
+				if (!Object.prototype.hasOwnProperty.call(attr, k) || attr[k] == null)
+					continue;
+				switch (typeof attr[k]) {
+				case 'function':
+					node.addEventListener(k, attr[k]);
+					break;
+				case 'object':
+					node.setAttribute(k, JSON.stringify(attr[k]));
+					break;
+				default:
+					node.setAttribute(k, attr[k]);
+				}
+			}
+		},
+		create() {
+			const html = arguments[0];
+			let attr = arguments[1];
+			let data = arguments[2];
+			let elem;
+			if (!(attr instanceof Object) || Array.isArray(attr))
+				data = attr, attr = null;
+			if (Array.isArray(html)) {
+				elem = document.createDocumentFragment();
+				for (let i = 0; i < html.length; i++)
+					elem.appendChild(this.create(html[i]));
+			} else if (this.elem(html)) {
+				elem = html;
+			} else if (typeof html === 'string' && html.charCodeAt(0) === 60) {
+				elem = this.parse(html);
+			} else {
+				elem = document.createElement(html);
+			}
+			if (!elem)
+				return null;
+			this.attr(elem, attr);
+			this.append(elem, data);
+			return elem;
+		}
+	};
+
+	global.E = dom.create.bind(dom);
+	global.LuciDom = dom;
+})(window);

--- a/tests/fixtures/luci-view-boot.js
+++ b/tests/fixtures/luci-view-boot.js
@@ -1,5 +1,6 @@
 /**
  * Mocked LuCI harness boot for view/status/fwlive.js (Tier 2 / #240 Wave B2).
+ * Honors rpc.declare `expect` unwrap like LuCI (#249 / #243).
  */
 (function() {
 	'use strict';
@@ -37,6 +38,17 @@
 		{ id: 3, time: 1704067202, msg: 'fw4: IN=wan OUT= SRC=192.0.2.3 DST=192.0.2.4 PROTO=UDP SPT=53 DPT=53' }
 	];
 
+	const NAME_MAP = {
+		'192.0.2.1': 'src-host',
+		'192.0.2.2': 'dst-host',
+		'203.0.113.5': 'attacker',
+		'192.168.1.1': 'router',
+		'192.0.2.3': 'udp-src',
+		'192.0.2.4': 'udp-dst'
+	};
+
+	window.fwliveResolveCalls = [];
+
 	const rpcMocks = {
 		'fwlive.poll': function() {
 			return { log: CANNED_LOGS.slice() };
@@ -44,8 +56,16 @@
 		'fwlive.rules': function() {
 			return { rules: { 'wan-lan': 'Allow LAN', 'block-wan': '!fw4: Block WAN' } };
 		},
-		'fwlive.resolve': function() {
-			return { names: {} };
+		'fwlive.resolve': function(opts) {
+			const addrs = (opts && opts.addresses) || [];
+			window.fwliveResolveCalls.push(addrs.slice());
+			const names = {};
+			for (let i = 0; i < addrs.length; i++) {
+				const ip = addrs[i];
+				if (NAME_MAP[ip])
+					names[ip] = NAME_MAP[ip];
+			}
+			return { names: names };
 		},
 		'fwlive.logging_status': function() {
 			return {
@@ -70,14 +90,37 @@
 		rpcMocks['fwlive.poll'] = fn;
 	};
 
+	/**
+	 * LuCI rpc.declare expect unwrap:
+	 * - expect: { names: {} } → reply.names
+	 * - expect: { '': shape } → whole reply
+	 * - no expect → whole reply
+	 */
+	function applyExpect(reply, expect) {
+		if (!expect || typeof expect !== 'object')
+			return reply;
+		const keys = Object.keys(expect);
+		if (keys.length === 1 && keys[0] === '')
+			return reply;
+		if (keys.length === 1) {
+			const k = keys[0];
+			if (reply && typeof reply === 'object' && Object.prototype.hasOwnProperty.call(reply, k))
+				return reply[k];
+			return expect[k];
+		}
+		return reply;
+	}
+
 	const poll = { add: function() {}, remove: function() {} };
 	const view = { extend: function(desc) { return desc; } };
 	const rpc = {
 		declare: function(cfg) {
 			const key = cfg.object + '.' + cfg.method;
+			const expect = cfg.expect;
 			return function() {
 				const mock = rpcMocks[key];
-				return Promise.resolve(mock ? mock.apply(null, arguments) : {});
+				const raw = mock ? mock.apply(null, arguments) : {};
+				return Promise.resolve(applyExpect(raw, expect));
 			};
 		}
 	};

--- a/tests/fixtures/luci-view-boot.js
+++ b/tests/fixtures/luci-view-boot.js
@@ -87,7 +87,9 @@
 	};
 
 	window.setFwlivePollMock = function(fn) {
+		const prev = rpcMocks['fwlive.poll'];
 		rpcMocks['fwlive.poll'] = fn;
+		return prev;
 	};
 
 	const poll = {

--- a/tests/fixtures/luci-view-boot.js
+++ b/tests/fixtures/luci-view-boot.js
@@ -1,0 +1,148 @@
+/**
+ * Mocked LuCI harness boot for view/status/fwlive.js (Tier 2 / #240 Wave B2).
+ */
+(function() {
+	'use strict';
+
+	const RES = '/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources';
+	const baseclass = { extend: function(desc) { return desc; } };
+
+	function gettext(s) {
+		const out = Object(String(s));
+		out.format = function() {
+			let i = 0;
+			const args = arguments;
+			return String(out).replace(/%s|%d/g, function() {
+				return String(args[i++]);
+			});
+		};
+		return out;
+	}
+
+	if (typeof String.prototype.format !== 'function') {
+		String.prototype.format = function() {
+			let i = 0;
+			const args = arguments;
+			return String(this).replace(/%s|%d/g, function() {
+				return String(args[i++]);
+			});
+		};
+	}
+
+	window._ = gettext;
+
+	const CANNED_LOGS = [
+		{ id: 1, time: 1704067200, msg: 'fw4: IN=wan OUT= SRC=192.0.2.1 DST=192.0.2.2 PROTO=TCP SPT=1234 DPT=443' },
+		{ id: 2, time: 1704067201, msg: 'iptables: DROP IN=wan OUT= SRC=203.0.113.5 DST=192.168.1.1 PROTO=TCP DPT=22' },
+		{ id: 3, time: 1704067202, msg: 'fw4: IN=wan OUT= SRC=192.0.2.3 DST=192.0.2.4 PROTO=UDP SPT=53 DPT=53' }
+	];
+
+	const rpcMocks = {
+		'fwlive.poll': function() {
+			return { log: CANNED_LOGS.slice() };
+		},
+		'fwlive.rules': function() {
+			return { rules: { 'wan-lan': 'Allow LAN', 'block-wan': '!fw4: Block WAN' } };
+		},
+		'fwlive.resolve': function() {
+			return { names: {} };
+		},
+		'fwlive.logging_status': function() {
+			return {
+				wan_zone: 'wan',
+				wan_log: false,
+				wan_log_limit: 10,
+				nf_log_ipv4: true,
+				nf_log_ipv6: false,
+				ready: true,
+				blockers: []
+			};
+		},
+		'fwlive.enable_wan_logging': function() {
+			return { ok: true, changed: true, wan_zone: 'wan' };
+		},
+		'fwlive.disable_wan_logging': function() {
+			return { ok: true, changed: true, wan_zone: 'wan' };
+		}
+	};
+
+	window.setFwlivePollMock = function(fn) {
+		rpcMocks['fwlive.poll'] = fn;
+	};
+
+	const poll = { add: function() {}, remove: function() {} };
+	const view = { extend: function(desc) { return desc; } };
+	const rpc = {
+		declare: function(cfg) {
+			const key = cfg.object + '.' + cfg.method;
+			return function() {
+				const mock = rpcMocks[key];
+				return Promise.resolve(mock ? mock.apply(null, arguments) : {});
+			};
+		}
+	};
+
+	async function loadModule(url, depNames, depValues) {
+		const src = await fetch(url).then(function(r) {
+			if (!r.ok)
+				throw new Error('fetch failed: ' + url + ' (' + r.status + ')');
+			return r.text();
+		});
+		const body = src
+			.replace(/^'use strict';\s*/m, '')
+			.replace(/^\/\*[\s\S]*?\*\/\s*/m, '')
+			.replace(/^'require [^']+';[^\n]*\n/gm, '');
+		const fn = new Function('baseclass', ...depNames, body);
+		return fn(baseclass, ...depValues);
+	}
+
+	async function boot() {
+		const log = await loadModule(RES + '/fwlive/log.js', [], []);
+		const constants = await loadModule(RES + '/fwlive/constants.js', [], []);
+		const css = await loadModule(RES + '/fwlive/css.js', [], []);
+		const tint = await loadModule(RES + '/fwlive/tint.js', [], []);
+		const links = await loadModule(RES + '/fwlive/links.js', ['log'], [log]);
+		const buffer = await loadModule(RES + '/fwlive/buffer.js', [], []);
+		const hostname = await loadModule(RES + '/fwlive/hostname.js', [], []);
+		const chips = await loadModule(RES + '/fwlive/chips.js', ['log'], [log]);
+		const proto = await loadModule(RES + '/fwlive/proto.js', ['document'], [document]);
+		const table = await loadModule(RES + '/fwlive/table.js', ['log', 'links'], [log, links]);
+		const logging = await loadModule(RES + '/fwlive/logging.js', ['log', 'links', 'E', '_'], [log, links, E, gettext]);
+
+		const viewSrc = await fetch(RES + '/view/status/fwlive.js').then(function(r) {
+			return r.text();
+		});
+		const viewBody = viewSrc
+			.replace(/^'use strict';\s*/m, '')
+			.replace(/^\/\*[\s\S]*?\*\/\s*/m, '')
+			.replace(/^'require [^']+';[^\n]*\n/gm, '');
+		const viewFn = new Function(
+			'view', 'poll', 'rpc', 'log', 'constants', 'css', 'tint', 'chips', 'logging',
+			'table', 'buffer', 'hostname', 'proto', 'E', '_', 'document', 'window', 'localStorage',
+			viewBody
+		);
+		const viewDesc = viewFn(
+			view, poll, rpc, log, constants, css, tint, chips, logging, table, buffer, hostname, proto,
+			E, gettext, document, window, localStorage
+		);
+
+		const mount = document.getElementById('fwlive-app');
+		const root = viewDesc.render();
+		mount.appendChild(root);
+		viewDesc.addFooter();
+		await viewDesc.load();
+		viewDesc.renderRows(true);
+
+		window.fwliveView = viewDesc;
+		window.dispatchEvent(new Event('fwlive-harness-ready'));
+	}
+
+	boot().catch(function(err) {
+		const el = document.getElementById('fwlive-boot-error');
+		if (el) {
+			el.style.display = 'block';
+			el.textContent = String(err && err.stack ? err.stack : err);
+		}
+		throw err;
+	});
+})();

--- a/tests/fixtures/luci-view-boot.js
+++ b/tests/fixtures/luci-view-boot.js
@@ -120,9 +120,13 @@
 			const key = cfg.object + '.' + cfg.method;
 			const expect = cfg.expect;
 			return function() {
-				const mock = rpcMocks[key];
-				const raw = mock ? mock.apply(null, arguments) : {};
-				return Promise.resolve(FwliveRpcExpect.applyExpect(raw, expect));
+				const args = arguments;
+				return Promise.resolve().then(function() {
+					const mock = rpcMocks[key];
+					return mock ? mock.apply(null, args) : {};
+				}).then(function(raw) {
+					return FwliveRpcExpect.applyExpect(raw, expect);
+				});
 			};
 		}
 	};

--- a/tests/fixtures/luci-view-boot.js
+++ b/tests/fixtures/luci-view-boot.js
@@ -90,28 +90,30 @@
 		rpcMocks['fwlive.poll'] = fn;
 	};
 
-	/**
-	 * LuCI rpc.declare expect unwrap:
-	 * - expect: { names: {} } → reply.names
-	 * - expect: { '': shape } → whole reply
-	 * - no expect → whole reply
-	 */
-	function applyExpect(reply, expect) {
-		if (!expect || typeof expect !== 'object')
-			return reply;
-		const keys = Object.keys(expect);
-		if (keys.length === 1 && keys[0] === '')
-			return reply;
-		if (keys.length === 1) {
-			const k = keys[0];
-			if (reply && typeof reply === 'object' && Object.prototype.hasOwnProperty.call(reply, k))
-				return reply[k];
-			return expect[k];
+	const poll = {
+		_entries: [],
+		_timer: null,
+		add: function(fn, intervalSec) {
+			this._entries.push({ fn: fn, intervalSec: intervalSec || 1 });
+			if (this._timer)
+				return;
+			/* Slow tick so smoke stays deterministic; exercises poll.add wiring. */
+			this._timer = setInterval(function() {
+				for (let i = 0; i < poll._entries.length; i++) {
+					const entry = poll._entries[i];
+					if (typeof entry.fn === 'function')
+						entry.fn();
+				}
+			}, 5000);
+		},
+		remove: function(fn) {
+			this._entries = this._entries.filter(function(e) { return e.fn !== fn; });
+			if (!this._entries.length && this._timer) {
+				clearInterval(this._timer);
+				this._timer = null;
+			}
 		}
-		return reply;
-	}
-
-	const poll = { add: function() {}, remove: function() {} };
+	};
 	const view = { extend: function(desc) { return desc; } };
 	const rpc = {
 		declare: function(cfg) {
@@ -120,7 +122,7 @@
 			return function() {
 				const mock = rpcMocks[key];
 				const raw = mock ? mock.apply(null, arguments) : {};
-				return Promise.resolve(applyExpect(raw, expect));
+				return Promise.resolve(FwliveRpcExpect.applyExpect(raw, expect));
 			};
 		}
 	};

--- a/tests/fixtures/luci-view-harness.html
+++ b/tests/fixtures/luci-view-harness.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>fwlive view harness</title>
+	<style>
+		body { font-family: system-ui, sans-serif; margin: 16px; }
+		#fwlive-boot-error { display: none; color: #b45309; white-space: pre-wrap; }
+	</style>
+</head>
+<body>
+	<div id="fwlive-boot-error"></div>
+	<div id="fwlive-app"></div>
+	<script src="/tests/fixtures/luci-dom-shim.js"></script>
+	<script src="/tests/fixtures/luci-view-boot.js"></script>
+</body>
+</html>

--- a/tests/fixtures/luci-view-harness.html
+++ b/tests/fixtures/luci-view-harness.html
@@ -12,6 +12,7 @@
 	<div id="fwlive-boot-error"></div>
 	<div id="fwlive-app"></div>
 	<script src="/tests/fixtures/luci-dom-shim.js"></script>
+	<script src="/tests/fixtures/rpc-expect.js"></script>
 	<script src="/tests/fixtures/luci-view-boot.js"></script>
 </body>
 </html>

--- a/tests/fixtures/rpc-expect.js
+++ b/tests/fixtures/rpc-expect.js
@@ -1,0 +1,40 @@
+/**
+ * LuCI rpc.declare expect unwrap for browser harness (LuCI parity).
+ */
+(function(global) {
+	'use strict';
+
+	function typeTag(v) {
+		return Object.prototype.toString.call(v);
+	}
+
+	function applyExpect(reply, expect) {
+		if (!expect || typeof expect !== 'object')
+			return reply;
+		const keys = Object.keys(expect);
+		if (keys.length !== 1)
+			return reply;
+
+		const k = keys[0];
+		const def = expect[k];
+
+		if (k === '') {
+			if (reply != null && typeTag(reply) === typeTag(def))
+				return reply;
+			return def;
+		}
+
+		let val;
+		if (reply != null && typeof reply === 'object' && Object.prototype.hasOwnProperty.call(reply, k))
+			val = reply[k];
+		else
+			val = def;
+
+		if (typeTag(val) !== typeTag(def))
+			val = def;
+
+		return val;
+	}
+
+	global.FwliveRpcExpect = { applyExpect: applyExpect };
+})(window);

--- a/tests/fwlive-view-poll-error.test.js
+++ b/tests/fwlive-view-poll-error.test.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * View poll contract (#233 / #240 Tier 1.4): reply.error must reach lastPollError + status banner.
+ */
+
+const assert = require('node:assert/strict');
+const { loadFwliveView } = require('./lib/load-fwlive-view');
+
+const SAMPLE_ROW = {
+	id: 1,
+	time: 1704067200,
+	msg: 'fw4: IN=wan OUT= SRC=192.0.2.1 DST=192.0.2.2 PROTO=TCP SPT=1234 DPT=443'
+};
+
+function fail(msg) {
+	console.error(msg);
+	process.exit(1);
+}
+
+async function testPollErrorField() {
+	const h = loadFwliveView({
+		rpcMocks: {
+			'fwlive.poll': async function() {
+				return { log: [], error: 'filter_failed' };
+			}
+		}
+	});
+	const view = h.view;
+
+	await view.fetchEntries();
+	assert.strictEqual(view.lastPollError, true, 'reply.error must set lastPollError');
+
+	view.updateStatus();
+	const status = h.document.getElementById('fwlive-status');
+	assert.ok(status, 'fwlive-status must exist after render');
+	assert.match(status.textContent, /Connection lost/i,
+		'error reply must show connection-lost banner');
+	console.log('fwlive-view poll-error: reply.error banner OK');
+}
+
+async function testPollHappyPath() {
+	const h = loadFwliveView({
+		rpcMocks: {
+			'fwlive.poll': async function() {
+				return { log: [SAMPLE_ROW] };
+			}
+		}
+	});
+	const view = h.view;
+
+	await view.fetchEntries();
+	assert.strictEqual(view.lastPollError, false, 'happy poll must clear lastPollError');
+	assert.ok(view.entries.length >= 1, 'happy poll must populate entries');
+	console.log('fwlive-view poll-error: happy path OK');
+}
+
+async function testPollBadShape() {
+	for (const bad of [null, [], { log: null }]) {
+		const h = loadFwliveView({
+			rpcMocks: {
+				'fwlive.poll': async function() { return bad; }
+			}
+		});
+		await h.view.fetchEntries();
+		assert.strictEqual(h.view.lastPollError, true,
+			'bad poll shape must set lastPollError: ' + JSON.stringify(bad));
+	}
+	console.log('fwlive-view poll-error: bad shape OK');
+}
+
+async function testPollTransportThrow() {
+	const h = loadFwliveView({
+		rpcMocks: {
+			'fwlive.poll': async function() {
+				throw new Error('network down');
+			}
+		}
+	});
+	await h.view.fetchEntries();
+	assert.strictEqual(h.view.lastPollError, true, 'transport throw must set lastPollError');
+	console.log('fwlive-view poll-error: transport throw OK');
+}
+
+(async function main() {
+	try {
+		await testPollErrorField();
+		await testPollHappyPath();
+		await testPollBadShape();
+		await testPollTransportThrow();
+		console.log('fwlive-view poll-error tests passed');
+	} catch (e) {
+		fail(e && e.stack ? e.stack : String(e));
+	}
+})();

--- a/tests/fwlive-view-poll-guard.test.js
+++ b/tests/fwlive-view-poll-guard.test.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * pollDataInFlight guard (#240 Tier 1.7): overlapping pollData() is a no-op.
+ */
+
+const assert = require('node:assert/strict');
+const { loadFwliveView } = require('./lib/load-fwlive-view');
+
+function fail(msg) {
+	console.error(msg);
+	process.exit(1);
+}
+
+function deferredPoll(reply) {
+	let resolveFn;
+	const promise = new Promise(function(resolve) {
+		resolveFn = resolve;
+	});
+	let calls = 0;
+	const mock = async function() {
+		calls++;
+		await promise;
+		return reply || { log: [] };
+	};
+	mock.calls = function() { return calls; };
+	mock.release = function() { resolveFn(); };
+	return mock;
+}
+
+async function testPollDataInFlightGuard() {
+	const pollMock = deferredPoll({ log: [] });
+	const h = loadFwliveView({
+		rpcMocks: {
+			'fwlive.poll': pollMock,
+			'fwlive.resolve': async function() { return { names: {} }; }
+		}
+	});
+	const view = h.view;
+	view.paused = true;
+
+	const first = view.pollData();
+	assert.strictEqual(pollMock.calls(), 1, 'first pollData must invoke poll once');
+
+	view.pollData();
+	assert.strictEqual(pollMock.calls(), 1, 'second pollData while in-flight must not invoke poll');
+
+	pollMock.release();
+	await first;
+
+	view.pollData();
+	await new Promise(function(r) { setTimeout(r, 10); });
+	assert.strictEqual(pollMock.calls(), 2, 'poll after first completes may proceed');
+	console.log('fwlive-view poll-guard: in-flight guard OK');
+}
+
+(async function main() {
+	try {
+		await testPollDataInFlightGuard();
+		console.log('fwlive-view poll-guard tests passed');
+	} catch (e) {
+		fail(e && e.stack ? e.stack : String(e));
+	}
+})();

--- a/tests/fwlive-view-smoke.mjs
+++ b/tests/fwlive-view-smoke.mjs
@@ -12,7 +12,8 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PORT = Number(process.env.FWLIVE_HARNESS_PORT || 8765);
-const BASE = process.env.FWLIVE_HARNESS_URL || `http://127.0.0.1:${PORT}`;
+const EXTERNAL_URL = process.env.FWLIVE_HARNESS_URL || '';
+const BASE = EXTERNAL_URL || `http://127.0.0.1:${PORT}`;
 
 async function waitForHarness(page) {
 	await page.goto(`${BASE}/tests/fixtures/luci-view-harness.html`, {
@@ -169,17 +170,27 @@ async function testHostnamesToggle(page) {
 }
 
 async function testPollErrorBanner(page) {
-	await page.evaluate(() => {
-		window.setFwlivePollMock(function() {
+	await page.evaluate(async () => {
+		window.__fwlivePrevPollMock = window.setFwlivePollMock(function() {
 			return { log: [], error: 'filter_failed' };
 		});
+		await window.fwliveView.fetchEntries();
+		window.fwliveView.updateStatus();
 	});
-	await page.evaluate(() => window.fwliveView.fetchEntries().then(() => window.fwliveView.updateStatus()));
-	await page.waitForFunction(() => {
-		const el = document.getElementById('fwlive-status');
-		return el && /Connection lost/i.test(el.textContent || '');
-	}, { timeout: 10000 });
-	console.log('OK: poll error banner (#233)');
+	try {
+		await page.waitForFunction(() => {
+			const el = document.getElementById('fwlive-status');
+			return el && /Connection lost/i.test(el.textContent || '');
+		}, { timeout: 10000 });
+		console.log('OK: poll error banner (#233)');
+	} finally {
+		await page.evaluate(() => {
+			if (typeof window.__fwlivePrevPollMock !== 'undefined') {
+				window.setFwlivePollMock(window.__fwlivePrevPollMock);
+				delete window.__fwlivePrevPollMock;
+			}
+		});
+	}
 }
 
 async function runSmoke(browser) {
@@ -299,7 +310,8 @@ async function mainDirect() {
 	}
 }
 
-const direct = process.argv.includes('--no-server');
+/* --no-server or FWLIVE_HARNESS_URL: use an already-running harness (no local spawn). */
+const direct = process.argv.includes('--no-server') || !!EXTERNAL_URL;
 (direct ? mainDirect() : mainWithServer()).catch((e) => {
 	console.error(e);
 	process.exit(1);

--- a/tests/fwlive-view-smoke.mjs
+++ b/tests/fwlive-view-smoke.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
  * Mocked LuCI view Playwright smoke (Tier 2 / #240 Wave B2) — no QEMU.
+ * Hardens pageerror / cleanup / hostname resolve assertions (#249).
  *
  *   npm run test:view
  */
@@ -112,14 +113,46 @@ async function testSegmentToggles(page) {
 }
 
 async function testHostnamesToggle(page) {
+	await clearFilters(page);
+	/* Simple view so filteredRows() still has the canned log IPs. */
+	const simple = page.locator('#fwlive-view-simple');
+	if (await simple.count())
+		await simple.click();
+
+	await page.evaluate(() => {
+		window.fwliveResolveCalls = [];
+		const v = window.fwliveView;
+		if (v.hostnameCache)
+			v.hostnameCache.clear();
+		if (v.hostnameFailed)
+			v.hostnameFailed.clear();
+		v.resolveInFlight = false;
+	});
+
 	const cb = page.locator('#fwlive-show-hostnames');
+	if (await cb.isChecked())
+		await cb.uncheck();
 	const genBefore = await page.evaluate(() => window.fwliveView.resolveGeneration);
 	await cb.check();
-	await page.waitForTimeout(200);
+
+	await page.waitForFunction(() => {
+		const v = window.fwliveView;
+		return v &&
+			window.fwliveResolveCalls.length > 0 &&
+			v.hostnameCache &&
+			v.hostnameCache.has('192.0.2.1') &&
+			v.hostnameCache.get('192.0.2.1') === 'src-host';
+	}, { timeout: 10000 });
+
 	const genAfter = await page.evaluate(() => window.fwliveView.resolveGeneration);
 	if (genAfter <= genBefore)
 		throw new Error('hostnames toggle must bump resolveGeneration');
-	console.log('OK: hostnames toggle generation bump');
+
+	const calls = await page.evaluate(() => window.fwliveResolveCalls);
+	if (!calls.length || !calls[0].includes('192.0.2.1'))
+		throw new Error('resolve RPC must be called with row IPs, got: ' + JSON.stringify(calls));
+
+	console.log('OK: hostnames resolve called and names applied');
 }
 
 async function testPollErrorBanner(page) {
@@ -136,67 +169,125 @@ async function testPollErrorBanner(page) {
 	console.log('OK: poll error banner (#233)');
 }
 
-async function main() {
-	const browser = await chromium.launch({ headless: true });
+async function runSmoke(browser) {
+	const pageErrors = [];
 	const page = await browser.newPage();
-	page.on('pageerror', (e) => console.error('pageerror:', e.message));
+	page.on('pageerror', (e) => {
+		pageErrors.push(e.message);
+		console.error('pageerror:', e.message);
+	});
 
-	await waitForHarness(page);
-	await testInitialRender(page);
-	await testPauseResume(page);
-	await testDisplayDrawer(page);
-	await testProtoCustomWins(page);
-	await testChipInvert(page);
-	await testSegmentToggles(page);
-	await testHostnamesToggle(page);
-	await testPollErrorBanner(page);
+	try {
+		await waitForHarness(page);
+		await testInitialRender(page);
+		await testPauseResume(page);
+		await testDisplayDrawer(page);
+		await testProtoCustomWins(page);
+		await testChipInvert(page);
+		await testSegmentToggles(page);
+		await testHostnamesToggle(page);
+		await testPollErrorBanner(page);
 
-	console.log('fwlive view smoke OK (mocked harness)');
-	await browser.close();
+		if (pageErrors.length)
+			throw new Error('pageerror(s) during smoke: ' + pageErrors.join('; '));
+
+		console.log('fwlive view smoke OK (mocked harness)');
+	} finally {
+		await page.close().catch(() => {});
+	}
 }
 
 function spawnHarnessServer() {
 	return spawn(process.execPath, ['scripts/serve-view-harness.mjs'], {
 		cwd: ROOT,
-		env: { ...process.env, FWLIVE_HARNESS_PORT: String(PORT) },
+		env: {
+			...process.env,
+			FWLIVE_HARNESS_PORT: String(PORT),
+			FWLIVE_HARNESS_HOST: '127.0.0.1'
+		},
 		stdio: ['ignore', 'pipe', 'pipe']
 	});
 }
 
 function waitForServerReady(child) {
 	return new Promise((resolve, reject) => {
-		const timer = setTimeout(() => reject(new Error('harness server start timeout')), 15000);
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (!settled) {
+				settled = true;
+				reject(new Error('harness server start timeout'));
+			}
+		}, 15000);
 		child.stdout.on('data', (chunk) => {
-			if (/fwlive view harness/.test(String(chunk))) {
+			if (/fwlive view harness/.test(String(chunk)) && !settled) {
+				settled = true;
 				clearTimeout(timer);
 				resolve();
 			}
 		});
-		child.on('error', reject);
+		child.stderr.on('data', (chunk) => {
+			process.stderr.write(chunk);
+		});
+		child.on('error', (err) => {
+			if (!settled) {
+				settled = true;
+				clearTimeout(timer);
+				reject(err);
+			}
+		});
 		child.on('exit', (code) => {
-			clearTimeout(timer);
-			reject(new Error('harness server exited early: ' + code));
+			if (!settled) {
+				settled = true;
+				clearTimeout(timer);
+				reject(new Error('harness server exited early: ' + code));
+			}
 		});
 	});
 }
 
-const direct = process.argv.includes('--no-server');
-if (direct) {
-	main().catch((e) => {
-		console.error(e);
-		process.exit(1);
-	});
-} else {
-	const child = spawnHarnessServer();
-	waitForServerReady(child)
-		.then(() => main())
-		.then(() => {
-			child.kill('SIGTERM');
-			process.exit(0);
-		})
-		.catch((e) => {
-			console.error(e);
-			child.kill('SIGTERM');
-			process.exit(1);
+function stopChild(child) {
+	if (!child || child.killed || child.exitCode != null)
+		return Promise.resolve();
+	return new Promise((resolve) => {
+		const t = setTimeout(() => {
+			try { child.kill('SIGKILL'); } catch (e) { /* ignore */ }
+			resolve();
+		}, 3000);
+		child.once('exit', () => {
+			clearTimeout(t);
+			resolve();
 		});
+		try { child.kill('SIGTERM'); } catch (e) { clearTimeout(t); resolve(); }
+	});
 }
+
+async function mainWithServer() {
+	const child = spawnHarnessServer();
+	let browser;
+	try {
+		await waitForServerReady(child);
+		browser = await chromium.launch({ headless: true });
+		await runSmoke(browser);
+	} finally {
+		if (browser)
+			await browser.close().catch(() => {});
+		await stopChild(child);
+	}
+}
+
+async function mainDirect() {
+	let browser;
+	try {
+		browser = await chromium.launch({ headless: true });
+		await runSmoke(browser);
+	} finally {
+		if (browser)
+			await browser.close().catch(() => {});
+	}
+}
+
+const direct = process.argv.includes('--no-server');
+(direct ? mainDirect() : mainWithServer()).catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/tests/fwlive-view-smoke.mjs
+++ b/tests/fwlive-view-smoke.mjs
@@ -57,8 +57,14 @@ async function testDisplayDrawer(page) {
 async function clearFilters(page) {
 	await page.locator('#fwlive-proto').selectOption('');
 	await page.locator('#fwlive-proto-custom').fill('');
-	await page.locator('a.fwlive-chip-clear').first().click().catch(() => {});
-	await page.waitForTimeout(200);
+	await page.locator('#fwlive-action').selectOption('');
+	await page.locator('#fwlive-q').fill('');
+	const clearAll = page.locator('a.fwlive-chip-clear');
+	if (await clearAll.count())
+		await clearAll.first().click();
+	await page.waitForFunction(() => document.querySelectorAll('.fwlive-chip').length === 0, {
+		timeout: 5000
+	});
 }
 
 async function testProtoCustomWins(page) {
@@ -70,7 +76,11 @@ async function testProtoCustomWins(page) {
 		throw new Error(`expected TCP chip, got: ${chip}`);
 
 	await page.locator('#fwlive-proto-custom').fill('esp');
-	await page.waitForTimeout(400);
+	await page.waitForFunction(() => {
+		const sel = document.getElementById('fwlive-proto');
+		const chip = document.querySelector('.fwlive-chip-label');
+		return sel && sel.value === '' && chip && /esp/i.test(chip.textContent || '');
+	}, { timeout: 5000 });
 	const sel = await page.locator('#fwlive-proto').inputValue();
 	chip = await page.locator('.fwlive-chip-label').first().textContent();
 	if (sel !== '')
@@ -86,7 +96,10 @@ async function testChipInvert(page) {
 	await page.waitForSelector('.fwlive-chip', { timeout: 5000 });
 	const before = await page.locator('.fwlive-chip-label').first().textContent();
 	await page.locator('.fwlive-chip-invert').first().click();
-	await page.waitForTimeout(300);
+	await page.waitForFunction(() => {
+		const chip = document.querySelector('.fwlive-chip-label');
+		return chip && /not pass/i.test(chip.textContent || '');
+	}, { timeout: 5000 });
 	const after = await page.locator('.fwlive-chip-label').first().textContent();
 	if (before === after || !/not pass/i.test(after || ''))
 		throw new Error(`chip invert failed: ${before} -> ${after}`);

--- a/tests/fwlive-view-smoke.mjs
+++ b/tests/fwlive-view-smoke.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Mocked LuCI view Playwright smoke (Tier 2 / #240 Wave B2) — no QEMU.
+ *
+ *   npm run test:view
+ */
+import { chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PORT = Number(process.env.FWLIVE_HARNESS_PORT || 8765);
+const BASE = process.env.FWLIVE_HARNESS_URL || `http://127.0.0.1:${PORT}`;
+
+async function waitForHarness(page) {
+	await page.goto(`${BASE}/tests/fixtures/luci-view-harness.html`, {
+		waitUntil: 'domcontentloaded',
+		timeout: 30000
+	});
+	await page.waitForFunction(() => window.fwliveView != null, { timeout: 30000 });
+	await page.waitForSelector('#fwlive-table tbody tr', { timeout: 30000 });
+}
+
+async function testInitialRender(page) {
+	const rows = await page.locator('#fwlive-table tbody tr').count();
+	if (rows < 1)
+		throw new Error('expected at least one table row after initial render');
+	console.log('OK: initial render');
+}
+
+async function testPauseResume(page) {
+	const pauseBtn = page.locator('#fwlive-pause');
+	await pauseBtn.click();
+	await page.waitForFunction(() => {
+		const map = document.querySelector('.fwlive-map');
+		return map && map.classList.contains('fwlive-watch-paused');
+	}, { timeout: 10000 });
+	await pauseBtn.click();
+	await page.waitForFunction(() => {
+		const map = document.querySelector('.fwlive-map');
+		return map && !map.classList.contains('fwlive-watch-paused');
+	}, { timeout: 10000 });
+	console.log('OK: pause/resume toggle');
+}
+
+async function testDisplayDrawer(page) {
+	await page.waitForSelector('#fwlive-display-drawer', { timeout: 10000 });
+	await page.waitForSelector('#fwlive-limit', { timeout: 10000 });
+	const visible = await page.locator('#fwlive-display-drawer').isVisible();
+	if (!visible)
+		throw new Error('display drawer must be visible');
+	console.log('OK: display drawer');
+}
+
+async function clearFilters(page) {
+	await page.locator('#fwlive-proto').selectOption('');
+	await page.locator('#fwlive-proto-custom').fill('');
+	await page.locator('a.fwlive-chip-clear').first().click().catch(() => {});
+	await page.waitForTimeout(200);
+}
+
+async function testProtoCustomWins(page) {
+	await clearFilters(page);
+	await page.locator('#fwlive-proto').selectOption('TCP');
+	await page.waitForSelector('.fwlive-chip', { timeout: 5000 });
+	let chip = await page.locator('.fwlive-chip-label').first().textContent();
+	if (!/TCP/i.test(chip || ''))
+		throw new Error(`expected TCP chip, got: ${chip}`);
+
+	await page.locator('#fwlive-proto-custom').fill('esp');
+	await page.waitForTimeout(400);
+	const sel = await page.locator('#fwlive-proto').inputValue();
+	chip = await page.locator('.fwlive-chip-label').first().textContent();
+	if (sel !== '')
+		throw new Error(`expected select cleared when typing custom, got select=${sel}`);
+	if (!/esp/i.test(chip || ''))
+		throw new Error(`expected esp chip from custom input, got: ${chip}`);
+	console.log('OK: proto custom wins');
+}
+
+async function testChipInvert(page) {
+	await clearFilters(page);
+	await page.locator('a.fwlive-filter-link', { hasText: /^pass$/i }).first().click();
+	await page.waitForSelector('.fwlive-chip', { timeout: 5000 });
+	const before = await page.locator('.fwlive-chip-label').first().textContent();
+	await page.locator('.fwlive-chip-invert').first().click();
+	await page.waitForTimeout(300);
+	const after = await page.locator('.fwlive-chip-label').first().textContent();
+	if (before === after || !/not pass/i.test(after || ''))
+		throw new Error(`chip invert failed: ${before} -> ${after}`);
+	console.log('OK: chip invert');
+}
+
+async function testSegmentToggles(page) {
+	const detail = page.locator('#fwlive-view-detail');
+	await detail.click();
+	await page.waitForFunction(() => {
+		const el = document.getElementById('fwlive-view-detail');
+		return el && el.getAttribute('aria-pressed') === 'true';
+	}, { timeout: 5000 });
+
+	const oneline = page.locator('#fwlive-msg-oneline');
+	if (await oneline.count()) {
+		await oneline.click();
+		await page.waitForFunction(() => {
+			const el = document.getElementById('fwlive-msg-oneline');
+			return el && el.getAttribute('aria-pressed') === 'true';
+		}, { timeout: 5000 });
+	}
+	console.log('OK: segment aria-pressed toggles');
+}
+
+async function testHostnamesToggle(page) {
+	const cb = page.locator('#fwlive-show-hostnames');
+	const genBefore = await page.evaluate(() => window.fwliveView.resolveGeneration);
+	await cb.check();
+	await page.waitForTimeout(200);
+	const genAfter = await page.evaluate(() => window.fwliveView.resolveGeneration);
+	if (genAfter <= genBefore)
+		throw new Error('hostnames toggle must bump resolveGeneration');
+	console.log('OK: hostnames toggle generation bump');
+}
+
+async function testPollErrorBanner(page) {
+	await page.evaluate(() => {
+		window.setFwlivePollMock(function() {
+			return { log: [], error: 'filter_failed' };
+		});
+	});
+	await page.evaluate(() => window.fwliveView.fetchEntries().then(() => window.fwliveView.updateStatus()));
+	await page.waitForFunction(() => {
+		const el = document.getElementById('fwlive-status');
+		return el && /Connection lost/i.test(el.textContent || '');
+	}, { timeout: 10000 });
+	console.log('OK: poll error banner (#233)');
+}
+
+async function main() {
+	const browser = await chromium.launch({ headless: true });
+	const page = await browser.newPage();
+	page.on('pageerror', (e) => console.error('pageerror:', e.message));
+
+	await waitForHarness(page);
+	await testInitialRender(page);
+	await testPauseResume(page);
+	await testDisplayDrawer(page);
+	await testProtoCustomWins(page);
+	await testChipInvert(page);
+	await testSegmentToggles(page);
+	await testHostnamesToggle(page);
+	await testPollErrorBanner(page);
+
+	console.log('fwlive view smoke OK (mocked harness)');
+	await browser.close();
+}
+
+function spawnHarnessServer() {
+	return spawn(process.execPath, ['scripts/serve-view-harness.mjs'], {
+		cwd: ROOT,
+		env: { ...process.env, FWLIVE_HARNESS_PORT: String(PORT) },
+		stdio: ['ignore', 'pipe', 'pipe']
+	});
+}
+
+function waitForServerReady(child) {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error('harness server start timeout')), 15000);
+		child.stdout.on('data', (chunk) => {
+			if (/fwlive view harness/.test(String(chunk))) {
+				clearTimeout(timer);
+				resolve();
+			}
+		});
+		child.on('error', reject);
+		child.on('exit', (code) => {
+			clearTimeout(timer);
+			reject(new Error('harness server exited early: ' + code));
+		});
+	});
+}
+
+const direct = process.argv.includes('--no-server');
+if (direct) {
+	main().catch((e) => {
+		console.error(e);
+		process.exit(1);
+	});
+} else {
+	const child = spawnHarnessServer();
+	waitForServerReady(child)
+		.then(() => main())
+		.then(() => {
+			child.kill('SIGTERM');
+			process.exit(0);
+		})
+		.catch((e) => {
+			console.error(e);
+			child.kill('SIGTERM');
+			process.exit(1);
+		});
+}

--- a/tests/lib/load-fwlive-view.js
+++ b/tests/lib/load-fwlive-view.js
@@ -96,6 +96,21 @@ function defaultRpcReply(key) {
 	}
 }
 
+function applyExpect(reply, expect) {
+	if (!expect || typeof expect !== 'object')
+		return reply;
+	const keys = Object.keys(expect);
+	if (keys.length === 1 && keys[0] === '')
+		return reply;
+	if (keys.length === 1) {
+		const k = keys[0];
+		if (reply && typeof reply === 'object' && Object.prototype.hasOwnProperty.call(reply, k))
+			return reply[k];
+		return expect[k];
+	}
+	return reply;
+}
+
 function loadFwliveView(options) {
 	options = options || {};
 	const rpcMocks = Object.assign(Object.create(null), options.rpcMocks || {});
@@ -133,12 +148,16 @@ function loadFwliveView(options) {
 	const rpc = {
 		declare: function(cfg) {
 			const key = cfg.object + '.' + cfg.method;
+			const expect = cfg.expect;
 			return async function() {
+				let raw;
 				if (rpcMocks[key])
-					return rpcMocks[key].apply(null, arguments);
-				if (typeof options.defaultRpc === 'function')
-					return options.defaultRpc(key, arguments);
-				return defaultRpcReply(key);
+					raw = await rpcMocks[key].apply(null, arguments);
+				else if (typeof options.defaultRpc === 'function')
+					raw = await options.defaultRpc(key, arguments);
+				else
+					raw = defaultRpcReply(key);
+				return applyExpect(raw, expect);
 			};
 		}
 	};

--- a/tests/lib/load-fwlive-view.js
+++ b/tests/lib/load-fwlive-view.js
@@ -7,6 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const { loadFwliveModule, fakeGettext } = require('./load-fwlive-module');
+const { applyExpect } = require('./rpc-expect');
 const luciE = require('./luci-e-harness');
 
 const ROOT = path.join(__dirname, '..', '..');
@@ -94,21 +95,6 @@ function defaultRpcReply(key) {
 	default:
 		return {};
 	}
-}
-
-function applyExpect(reply, expect) {
-	if (!expect || typeof expect !== 'object')
-		return reply;
-	const keys = Object.keys(expect);
-	if (keys.length === 1 && keys[0] === '')
-		return reply;
-	if (keys.length === 1) {
-		const k = keys[0];
-		if (reply && typeof reply === 'object' && Object.prototype.hasOwnProperty.call(reply, k))
-			return reply[k];
-		return expect[k];
-	}
-	return reply;
 }
 
 function loadFwliveView(options) {

--- a/tests/lib/load-fwlive-view.js
+++ b/tests/lib/load-fwlive-view.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * Load view/status/fwlive.js under Node with stubbed rpc/poll/view and real fwlive modules.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { loadFwliveModule, fakeGettext } = require('./load-fwlive-module');
+const luciE = require('./luci-e-harness');
+
+const ROOT = path.join(__dirname, '..', '..');
+const VIEW_PATH = path.join(
+	ROOT,
+	'openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js'
+);
+
+class HarnessElement extends luciE.Element {
+	constructor(tagName) {
+		super(tagName);
+		this.className = '';
+		this.textContent = '';
+		this.style = { display: '' };
+	}
+
+	setAttribute(key, value) {
+		super.setAttribute(key, value);
+		if (key === 'id')
+			this._id = String(value);
+	}
+}
+
+function createHarnessDocument() {
+	const idMap = Object.create(null);
+
+	const document = {
+		createElement(tagName) {
+			const el = new HarnessElement(tagName);
+			el.setAttribute = function(key, value) {
+				HarnessElement.prototype.setAttribute.call(this, key, value);
+				if (key === 'id')
+					idMap[value] = this;
+			}.bind(el);
+			return el;
+		},
+		createTextNode(text) {
+			return new luciE.TextNode(text);
+		},
+		createDocumentFragment() {
+			return new luciE.DocumentFragment();
+		},
+		getElementById(id) {
+			return idMap[id] || null;
+		},
+		body: {
+			appendChild(node) {
+				indexElementIds(node, idMap);
+			}
+		}
+	};
+
+	return { document: document, idMap: idMap };
+}
+
+function indexElementIds(node, idMap) {
+	if (!node)
+		return;
+	if (node._attrs && node._attrs.id)
+		idMap[node._attrs.id] = node;
+	if (node._id)
+		idMap[node._id] = node;
+	for (let i = 0; i < (node.childNodes || []).length; i++)
+		indexElementIds(node.childNodes[i], idMap);
+}
+
+function defaultRpcReply(key) {
+	switch (key) {
+	case 'fwlive.rules':
+		return { rules: {} };
+	case 'fwlive.resolve':
+		return { names: {} };
+	case 'fwlive.logging_status':
+		return {
+			wan_zone: null,
+			wan_log: false,
+			wan_log_limit: null,
+			nf_log_ipv4: false,
+			nf_log_ipv6: false,
+			ready: true,
+			blockers: []
+		};
+	case 'fwlive.poll':
+		return { log: [] };
+	default:
+		return {};
+	}
+}
+
+function loadFwliveView(options) {
+	options = options || {};
+	const rpcMocks = Object.assign(Object.create(null), options.rpcMocks || {});
+	const storage = Object.assign(Object.create(null), options.storage || {});
+
+	const harness = options.document
+		? { document: options.document, idMap: Object.create(null) }
+		: createHarnessDocument();
+	const document = harness.document;
+
+	const log = loadFwliveModule('log');
+	const constants = loadFwliveModule('constants');
+	const css = loadFwliveModule('css');
+	const tint = loadFwliveModule('tint');
+	const chips = loadFwliveModule('chips', { log: log });
+	const links = loadFwliveModule('links', { log: log });
+	const logging = loadFwliveModule('logging', {
+		log: log,
+		links: links,
+		E: luciE.E,
+		_: fakeGettext
+	});
+	const table = loadFwliveModule('table', { log: log, links: links });
+	const buffer = loadFwliveModule('buffer');
+	const hostname = loadFwliveModule('hostname');
+	const proto = loadFwliveModule('proto', { document: document });
+
+	const poll = {
+		add: function() {},
+		remove: function() {}
+	};
+	const view = {
+		extend: function(desc) { return desc; }
+	};
+	const rpc = {
+		declare: function(cfg) {
+			const key = cfg.object + '.' + cfg.method;
+			return async function() {
+				if (rpcMocks[key])
+					return rpcMocks[key].apply(null, arguments);
+				if (typeof options.defaultRpc === 'function')
+					return options.defaultRpc(key, arguments);
+				return defaultRpcReply(key);
+			};
+		}
+	};
+
+	const localStorage = {
+		getItem: function(k) {
+			return Object.prototype.hasOwnProperty.call(storage, k) ? storage[k] : null;
+		},
+		setItem: function(k, v) {
+			storage[k] = String(v);
+		},
+		removeItem: function(k) {
+			delete storage[k];
+		}
+	};
+
+	const src = fs.readFileSync(VIEW_PATH, 'utf8');
+	const body = src
+		.replace(/^'use strict';\s*/m, '')
+		.replace(/^\/\*[\s\S]*?\*\/\s*/m, '')
+		.replace(/^'require [^']+';[^\n]*\n/gm, '');
+
+	const fn = new Function(
+		'view', 'poll', 'rpc', 'log', 'constants', 'css', 'tint', 'chips', 'logging',
+		'table', 'buffer', 'hostname', 'proto', 'E', '_', 'document', 'window', 'localStorage',
+		body
+	);
+
+	const viewDesc = fn(
+		view, poll, rpc, log, constants, css, tint, chips, logging, table, buffer, hostname, proto,
+		luciE.E, fakeGettext, document, { addEventListener: function() {} }, localStorage
+	);
+
+	if (viewDesc.render) {
+		const root = viewDesc.render();
+		indexElementIds(root, harness.idMap);
+		if (document.body && document.body.appendChild)
+			document.body.appendChild(root);
+	}
+
+	return {
+		view: viewDesc,
+		document: document,
+		rpcMocks: rpcMocks,
+		setRpcMock: function(key, fn) {
+			rpcMocks[key] = fn;
+		}
+	};
+}
+
+module.exports = {
+	VIEW_PATH: VIEW_PATH,
+	createHarnessDocument: createHarnessDocument,
+	loadFwliveView: loadFwliveView
+};

--- a/tests/lib/rpc-expect.js
+++ b/tests/lib/rpc-expect.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * LuCI rpc.declare expect unwrap for Node harness tests.
+ * Coerces wrong-type values to the expect default (LuCI parity).
+ */
+
+function typeTag(v) {
+	return Object.prototype.toString.call(v);
+}
+
+function applyExpect(reply, expect) {
+	if (!expect || typeof expect !== 'object')
+		return reply;
+	const keys = Object.keys(expect);
+	if (keys.length !== 1)
+		return reply;
+
+	const k = keys[0];
+	const def = expect[k];
+
+	if (k === '') {
+		if (reply != null && typeTag(reply) === typeTag(def))
+			return reply;
+		return def;
+	}
+
+	let val;
+	if (reply != null && typeof reply === 'object' && Object.prototype.hasOwnProperty.call(reply, k))
+		val = reply[k];
+	else
+		val = def;
+
+	if (typeTag(val) !== typeTag(def))
+		val = def;
+
+	return val;
+}
+
+module.exports = {
+	applyExpect: applyExpect,
+	typeTag: typeTag
+};


### PR DESCRIPTION
## Summary
- **B1:** Node view contract tests for poll `error` banner (#233) and `pollDataInFlight` guard, wired into `fwlive-test.sh`
- **B2:** Mocked LuCI Playwright harness (`npm run test:view`) with required CI job `test-view-mock`
- **#249:** Luna review fixes — expect unwrap, loopback harness, pageerror fail, finally cleanup, hostname resolve assertions

Depends on #241 (A2 / #239) already merged to master.

Fixes #249.

## Test plan
- [x] `./scripts/fwlive-test.sh` (includes new view unit tests)
- [x] `npm run test:view` (mocked harness, no QEMU)
- [ ] CI `test-view-mock` job green on PR

Closes Wave B items from #240. Wave C remains deferred on that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for Firewall Live View rendering, controls, filters, hostname resolution, polling safeguards, and error handling.
  * Added validation for malformed responses, connection-loss indicators, and recovery after polling failures.
  * Added required CI checks to run mocked view smoke tests automatically.
  * Improved test reliability with a dedicated local harness for browser-based view testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->