### PR TITLE
fix(ui,shell): round-3 hygiene — non-sticky rules error, timeout_missing blocker

### DIFF
--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -112,6 +112,8 @@ should carry a note saying what would raise it.
 | Rules map prefers `!fw4:` labels over earlier cosmetics for the same prefix (UCI still first-wins) | `host` | labeled-then-unlabeled passes; `tests/fwlive-rules-map.test.js` `testFw4LabeledBeatsCosmetic` |
 | `iptables-save` / `ip6tables-save` bounded by `IPTABLES_TIMEOUT`; rules map key/byte capped | `host` | `testIptablesSaveTimeout`, `testRulesMapKeyBound` |
 | mktemp-skip on rules map surfaces `error:mktemp_failed` | `host` | `testNoMktempGracefulDegradation` |
+| `timeout` absent surfaces `timeout_missing` blocker (fail-closed `run_with_timeout` diagnosability) | `host` | `fwlive-logging.sh` `collect_logging_blockers` → `logging_status` `blockers` (`command -v timeout` probe, POSIX) |
+| Rules-map degradation (`rules_truncated`/`mktemp_failed`/`rules_unavailable`) surfaces in `#fwlive-backend` span, not the live counter / paused class | `host` | `view/status/fwlive.js` `updateBackendUi` (backend label + ` · ` + error via `_()`), `updateStatus` always reaches counter branch; `lastPollError` precedence unchanged |
 
 ## Open findings
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -503,7 +503,6 @@ return view.extend({
 			this.lastRulesError = 'rules_unavailable';
 		}
 		this.updateBackendUi();
-		this.updateStatus();
 	},
 
 	backendDisplayLabel() {
@@ -520,8 +519,20 @@ return view.extend({
 			map.setAttribute('data-backend', this.firewallBackend || 'unknown');
 
 		const label = document.getElementById('fwlive-backend');
-		if (label)
-			label.textContent = this.backendDisplayLabel();
+		if (label) {
+			let text = this.backendDisplayLabel();
+			if (this.lastRulesError) {
+				let err = '';
+				if (this.lastRulesError === 'rules_truncated')
+					err = _('Rule labels incomplete — map truncated');
+				else if (this.lastRulesError === 'mktemp_failed')
+					err = _('Rule labels unavailable — temp file failed');
+				else
+					err = _('Rule labels unavailable');
+				text = text ? text + ' \u00b7 ' + err : err;
+			}
+			label.textContent = text;
+		}
 
 		this.updateEmptyStateUi();
 	},
@@ -925,17 +936,6 @@ return view.extend({
 		if (this.lastPollError) {
 			status.className = 'fwlive-status fwlive-status-error';
 			status.textContent = _('Connection lost — retrying…') + suffix;
-			return;
-		}
-
-		if (this.lastRulesError) {
-			status.className = 'fwlive-status fwlive-status-error';
-			if (this.lastRulesError === 'rules_truncated')
-				status.textContent = _('Rule labels incomplete — map truncated') + suffix;
-			else if (this.lastRulesError === 'mktemp_failed')
-				status.textContent = _('Rule labels unavailable — temp file failed') + suffix;
-			else
-				status.textContent = _('Rule labels unavailable') + suffix;
 			return;
 		}
 

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -382,6 +382,8 @@ collect_logging_blockers() {
 	[ -n "$zone" ] || logging_blockers_append 'no_wan_zone'
 	check_nf_log_ipv4 || logging_blockers_append 'nf_log_ipv4_missing'
 	check_nf_log_ipv6 || logging_blockers_append 'nf_log_ipv6_missing'
+	# rpcd/fwlive run_with_timeout fail-closes to 127 without timeout (#229): surface as blocker.
+	command -v timeout >/dev/null 2>&1 || logging_blockers_append 'timeout_missing'
 
 	[ -n "$LOGGING_BLOCKERS" ] || return 0
 	return 1

--- a/scripts/upstream-cut.sh
+++ b/scripts/upstream-cut.sh
@@ -62,10 +62,12 @@ sed -i 's|include $(TOPDIR)/feeds/luci/luci.mk|include ../../luci.mk|' \
 # Keep the SPDX line; real luci apps start clean from there.
 sed -i '/^# Wire feed first/,/^$/d' "$OUT/Makefile"
 
-# SOURCE_DATE_EPOCH is already exported by OpenWrt toplevel.mk; the block is
-# a no-op in luci and the comment cites docker-sdk.sh (monorepo-only) (#224).
+# Master keeps SOURCE_DATE_EPOCH block (reproducible-build flow exports it);
+# only the luci-shaped copy drops it — already exported by OpenWrt toplevel.mk,
+# no-op in luci and comment cites monorepo-only docker-sdk.sh (#224).
 sed -i '/^# Reproducible build: honor SOURCE_DATE_EPOCH/,/^endif$/d' "$OUT/Makefile"
 # The delete leaves a double blank before PKG_LICENSE; squeeze to one (#246).
+# Master keeps the block intentionally; only the copy is squeezed.
 sed -i '/^PKG_RELEASE:=/{n;/^$/{n;/^$/d;};}' "$OUT/Makefile"
 
 # First luci PR: .pot only. Empty locale dirs still make luci.mk emit empty


### PR DESCRIPTION
fix(ui,shell): round-3 hygiene — non-sticky rules error, timeout_missing blocker

Three findings from the openwrt/luci#8992 round-3 review (fwlive #250, #251,
#252), plus the commit-hygiene notes.

Sticky lastRulesError no longer consumes the live counter (#250)
----------------------------------------------------------------
`updateStatus()` early-returned on `lastRulesError`, which is set exactly once
in `loadRulesMap()` (run once from `load()`) and never cleared — so the first
`rules_truncated` / `mktemp_failed` occurrence replaced the live match counter
and the paused class for the whole session, even though log capture kept
working. Unlike `lastPollError`, which resets after every successful poll.

The rules-map degradation now surfaces in the `#fwlive-backend` span next to
the title (backend label + " · " + the existing translated error), which
already carried persistent backend state, and `updateStatus()` always reaches
the counter branch. `lastPollError` precedence is unchanged. All three messages
reuse the existing `.pot` msgids — no new translation strings.

Also removed the dead `updateStatus()` call at the end of `loadRulesMap()`:
`load()` runs before `render()`, so the status element does not exist yet and
the call returned at its first guard. The status readout is driven by the
poll/click paths, which call `updateStatus()` with the element present.

timeout_missing blocker surfaces the fail-closed path (#251)
------------------------------------------------------------
`run_with_timeout` returns 127 when the `timeout` binary is absent (fail-closed,
#229). On slimmed builds without `timeout` that degraded silently: backend
detection fell through to `unknown`, the rules map returned no error field, and
`resolve` stayed empty — indistinguishable from "no PTR record".

`collect_logging_blockers` now appends a `timeout_missing` blocker via the
existing blockers channel (surfaced through `logging_status`), alongside
`nf_log_ipv4_missing`. No behaviour change when `timeout` is present (stock
images; `BUSYBOX_DEFAULT_TIMEOUT=y`).

upstream-cut.sh: verify-only (#252)
-----------------------------------
The `SOURCE_DATE_EPOCH` strip + double-blank squeeze already exist in the cut
script (#224/#246). Master's Makefile keeps the block intentionally
(`verify-reproducible-build.sh` exports it); only the luci-shaped copy drops
it. Comments amplified to state that; no logic change.

security-review.md updated with the two new controls.

## Test plan
- [ ] `./scripts/fwlive-test.sh` green (all suites incl. rules-map, logging-lock)
- [ ] `./scripts/fwlive-shellcheck.sh` green
- [ ] Functional: `timeout_missing` present in `logging_status` when `timeout`
      absent (stubbed), absent when present — verified both shells
- [ ] UI: rules-map degradation shown in backend span; live counter + paused
      class survive a `rules_truncated` state

Closes #250
Closes #251
Closes #252
Refs #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend status now clearly displays rule-loading errors, including truncated rules and temporary-file failures.
  * Missing timeout support is reported as a blocking issue to prevent unsafe operation.

* **Bug Fixes**
  * Rule errors no longer incorrectly alter live counters or paused-state styling.
  * Removed an unnecessary status refresh after rule loading.

* **Documentation**
  * Updated export-script comments to reflect current Makefile cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->