### PR TITLE
fix(lab): require opt-in for insecure SSH in agent-build-and-deploy (#261)

### DIFF
--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,7 +1,7 @@
 # Security review state
 
-> **Status:** 40 controls in force; 0 open findings.
-> **Last review:** 2026-08-31 (upstream-review remaining).
+> **Status:** 41 controls in force; 0 open findings.
+> **Last review:** 2026-09-03 (lab deploy SSH host-key default).
 > **Open:** none.
 > **Next:** re-check pins before each `v*` tag; close the 4 honest gaps in the lab.
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. For coverage beyond that script, follow [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md). Values current as of this PR.
@@ -67,12 +67,14 @@ should carry a note saying what would raise it.
 | Package/install surface (Makefiles, prerm, feed layout) | 2026-08-23 | Read | No ACL or path regressions |
 | Build inputs (`feeds.lock`, `package-lock.json`) | 2026-08-23 | Read | Pins intact |
 | Dev tooling (`.cursor/mcp.json`) | 2026-08-23 | Read + fix | #205: unpinned `@playwright/mcp@latest` removed; UI tests use pinned `playwright` devDep |
+| Lab deploy helper (`scripts/agent-build-and-deploy.sh`) | 2026-09-03 | Read + fix | #261: SSH host-key verification ON by default; `ALLOW_INSECURE_SSH=1` / `--lab-only` opt-in with warning |
 
 ## Controls in force
 
 | Control | Proof class | Where |
 |---------|-------------|-------|
 | Sessions never receive `ubus log.*` | `host` | `tests/fwlive-rpcd-security.test.js` |
+| Lab `.ipk` deploy keeps SSH host-key verification unless explicitly opted in | `manual` | `scripts/agent-build-and-deploy.sh` — default empty `SSH_OPTS`; `ALLOW_INSECURE_SSH=1` or `--lab-only` required for `StrictHostKeyChecking=no` (#261) |
 | Read and write ACL scopes stay separate | `host` | same |
 | Caller line count validated and clamped | `host` | rpcd `__selftest` |
 | Poll line-count clamp rejects over-long digit strings before numeric compare (no silenced `test` overflow) and maps `0`→50 | `host` | rpcd `poll_clamp_lines` helper + `__selftest` (over-long, zero, 2001, 500) — defence-in-depth for read-ACL reachable `poll` |

--- a/scripts/agent-build-and-deploy.sh
+++ b/scripts/agent-build-and-deploy.sh
@@ -9,8 +9,10 @@
 #
 #   OPENWRT_HOST=192.168.1.1 ./scripts/agent-build-and-deploy.sh --ipk path/to.ipk
 #
-#   ./scripts/agent-build-and-deploy.sh --legacy-hostfwd --ipk out/luci-app-fwlive_*.ipk
+#   ./scripts/agent-build-and-deploy.sh --legacy-hostfwd --lab-only --ipk out/luci-app-fwlive_*.ipk
 #
+# Host-key verification is ON by default. QEMU/ephemeral guests need an explicit
+# opt-in: ALLOW_INSECURE_SSH=1 or --lab-only (prints a warning).
 set -euo pipefail
 
 LEASES_FILE="${DHCPD_LEASES:-/var/db/dhcpd_leases}"
@@ -19,9 +21,12 @@ OPENWRT_SSH_PORT="${OPENWRT_SSH_PORT:-22}"
 OPENWRT_USER="${OPENWRT_USER:-root}"
 OPENWRT_HOST="${OPENWRT_HOST:-}"
 LEGACY_HOSTFWD=0
+LAB_ONLY=0
 IPK_PATH=""
 SKIP_CURL=0
-SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+# Default: normal host-key verification. Opt in to lab insecure SSH via
+# ALLOW_INSECURE_SSH=1 or --lab-only (see apply_ssh_opts).
+SSH_OPTS=()
 
 apply_legacy_defaults() {
 	if [[ "$LEGACY_HOSTFWD" -ne 1 ]]; then
@@ -31,10 +36,23 @@ apply_legacy_defaults() {
 	OPENWRT_SSH_PORT="${OPENWRT_SSH_LEGACY_PORT:-2222}"
 }
 
+apply_ssh_opts() {
+	local insecure=0
+	if [[ "${ALLOW_INSECURE_SSH:-0}" == "1" || "$LAB_ONLY" -eq 1 ]]; then
+		insecure=1
+	fi
+	if [[ "$insecure" -eq 1 ]]; then
+		SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+		echo "warn: insecure SSH enabled (StrictHostKeyChecking=no) — lab/QEMU only; MITM can swap the uploaded .ipk" >&2
+	else
+		SSH_OPTS=()
+	fi
+}
+
 die() { echo "error: $*" >&2; exit 1; }
 
 usage() {
-	sed -n '1,20p' "$0" | tail -n +2
+	sed -n '1,25p' "$0" | tail -n +2
 	exit "${1:-0}"
 }
 
@@ -93,6 +111,7 @@ while [[ $# -gt 0 ]]; do
 	case "$1" in
 		-h|--help) usage 0 ;;
 		--legacy-hostfwd) LEGACY_HOSTFWD=1 ;;
+		--lab-only) LAB_ONLY=1 ;;
 		--ipk) shift; [[ $# -gt 0 ]] || die "--ipk needs a path"; IPK_PATH="$1" ;;
 		--skip-curl) SKIP_CURL=1 ;;
 		*) die "unknown arg: $1 (try --help)" ;;
@@ -104,6 +123,7 @@ done
 [[ -f "$IPK_PATH" ]] || die "ipk not found: $IPK_PATH"
 
 apply_legacy_defaults
+apply_ssh_opts
 
 HOST="$(resolve_host)"
 REMOTE_IPK="/tmp/luci-app-fwlive.ipk"


### PR DESCRIPTION
## Summary
- Default SSH host-key verification ON in the lab deploy helper
- Opt in via `ALLOW_INSECURE_SSH=1` or `--lab-only` (warns at use)
- Record control in security-review.md

Closes #261

## Test plan
- [x] `bash -n scripts/agent-build-and-deploy.sh`
- [ ] Manual: without opt-in, known_hosts mismatch fails; with `--lab-only`, warns and proceeds