### PR TITLE
fix(logging): B-1 canonical WAN zone identity for uci changes

### DIFF
--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,7 +1,7 @@
 # Security review state
 
-> **Status:** 41 controls in force; 0 open findings.
-> **Last review:** 2026-09-03 (lab deploy SSH host-key default).
+> **Status:** 42 controls in force; 0 open findings.
+> **Last review:** 2026-09-03 (B-1 canonical WAN zone identity for staged uci changes).
 > **Open:** none.
 > **Next:** re-check pins before each `v*` tag; close the 4 honest gaps in the lab.
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. For coverage beyond that script, follow [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md). Values current as of this PR.
@@ -59,7 +59,7 @@ should carry a note saying what would raise it.
 | Shell helpers — injection and quoting | 2026-08-13 | Read | #177: no log data reaches a command string |
 | Shell helpers — **file modes and lock ownership** | 2026-08-31 | Reproduced | #204 symlink reject + #232 BusyBox-safe dir check (`[ -O ]` + `find -perm`, no `stat -c`); Parts E/F in `fwlive-logging-lock.test.sh`; lock 0600 (Part D) |
 | Shell helpers — **uninstall baseline restore (`prerm`)** | 2026-08-22 | Read + host test | `/etc/fwlive/wan-log-baseline`; restore only on `remove` |
-| Shell helpers — **UCI commit scope and zone grammar** | 2026-08-13 | Host test | #177: pending-delta refuse; named/anonymous/non-zone lookups |
+| Shell helpers — **UCI commit scope and zone grammar** | 2026-09-03 | Host test + Fable | #177 pending-delta; #241 cfg↔@zone; **B-1** canonical `uci -X` identity (duplicate wan no longer under-matches); `tests/fwlive-logging.test.sh` |
 | Release pipeline — secrets and key handling | 2026-08-18 | Reproduced | #177 key-mode re-run; R7 pin-before-mount + `--network none` ([#179](https://github.com/lucas-albers-lz4/fwlive/issues/179)); 2026-08-18 hardening parity + R7 wrapper fix |
 | Release pipeline — fetch pinning | 2026-08-18 | Read + host test | #177 fetch-pin gate; R7 digest pin-cache (`tests/sdk-matrix-digests.test.sh`); 2026-08-18 wrapper-export + exact-cache-key |
 | Workflow inputs into `run:` bodies | 2026-08-23 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY`; 2026-08-18: dispatch tag validated (control chars, shape, real-tag + HEAD identity) before repo scripts |
@@ -107,6 +107,7 @@ should carry a note saying what would raise it.
 | SDK feed cache key is exact (no `restore-keys` prefix fallback) | `manual` | same workflow — stale feed pins cannot be restored on cache miss |
 | SDK cache dirs owned by buildbot (1000:1000), owner-write + group/other read-traverse; enforced fail-closed pre-build (skipped only when CI pre-chowned both trees, roots AND nested entries; scan errors fail closed) | `host` | `tests/sdk-matrix-cache-owner.test.sh` — #208 (v0.1.36 chown regression) |
 | WAN toggle changes only the zone `log` bit | `host` | `tests/fwlive-logging.test.sh` — pending-delta refuse; named + anonymous zone lookup |
+| WAN zone identity for staged `uci changes` uses canonical cfg ids (`uci -X`), not class-match on `name=wan` | `host` | `uci_canonical_firewall_section` + `wan_firewall_zone_same`; B-1 duplicate-wan foreign `.log` stays foreign (`tests/fwlive-logging.test.sh`) |
 | Uninstall restores WAN `log` from pre-first-enable baseline | `host` | `tests/fwlive-logging.test.sh` — baseline snapshot/restore; `scripts/qemu-logging-uninstall-smoke.sh` (`lab`) |
 | The WAN logging lock cannot be held by an unprivileged user | `host` | `tests/fwlive-logging-lock.test.sh` Part D — create+tighten to 0600 |
 | Lock path rejects symlinks before truncate/chmod/chown | `host` | `tests/fwlive-logging-lock.test.sh` Part E — #204 |
@@ -126,6 +127,7 @@ should carry a note saying what would raise it.
 
 | ID | Severity | Issue | Summary | Verified |
 |----|----------|-------|---------|----------|
+| B-1 | Low | `wan_firewall_zone_same` class-matched any `name=wan` zone | Canonical `uci -X` cfg id compare; duplicate wan `.log` stays foreign | 2026-09-03 |
 | [#204](https://github.com/lucas-albers-lz4/fwlive/issues/204) | Low | Predictable lock path opened O_TRUNC without symlink check | Lock under `/etc/fwlive/`; `acquire_wan_log_lock` rejects `-L` before create/tighten/open; Part E | 2026-08-23 — security-audit PR |
 | [#205](https://github.com/lucas-albers-lz4/fwlive/issues/205) | Low | Unpinned `@playwright/mcp@latest` in `.cursor/mcp.json` | MCP entry removed; tests use pinned `playwright@1.60.0` | 2026-08-23 — security-audit PR |
 | [#190](https://github.com/lucas-albers-lz4/fwlive/issues/190) | Low | `is_resolvable_address` hostname-shaped tokens | Strict IPv4/IPv6 validation + selftest cases | merged 2026-08-21 |
@@ -374,3 +376,11 @@ links to this ledger for review state.
 **Scope.** `wan_log_lock_dir_safe` used `stat -c '%u'/'%a'`, which default OpenWrt BusyBox omits (`STAT=n` / `FEATURE_STAT_FORMAT=n`). Fail-closed then made Enable/Disable WAN logging dead on a stock image.
 
 **Fix.** `[ -O ]` for euid ownership; `find -prune \( -perm -020 -o -perm -002 \)` for group/other write. No `stat`. Part F in `fwlive-logging-lock.test.sh` shadows `stat` on `PATH`.
+
+### 2026-09-03 — B-1 canonical WAN zone identity
+
+**Scope.** Fable Stage-2 review of hand-parsed `uci changes` grammar for WAN log commit scope (`wan_firewall_zone_same`).
+
+**Finding.** Class-match on `name=wan` + type `zone` treated any two wan zones as the same section, so a foreign staged `firewall.<dup>.log=` line could ride `uci commit firewall` (Low; admin + duplicate-zone misconfiguration).
+
+**Fix.** `uci_canonical_firewall_section` via `uci -X show`; identity is equal canonical cfg ids. Host test: duplicate wan foreign `.log` stays foreign; `@zone[N]`↔cfg bridge preserved.

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -143,17 +143,27 @@ wan_zone_log_value() {
 	uci -q get "firewall.${zone}.log" 2>/dev/null
 }
 
+# Resolve a firewall section id to its canonical cfgXXXX form (issue B-1 /
+# multi-model audit). `uci -X show` disables @type[N] aliases so @zone[0] and
+# cfgXXXX for the same anonymous section compare equal. Empty on failure.
+uci_canonical_firewall_section() {
+	_sid="$1"
+	[ -n "$_sid" ] || return 1
+	uci -q -X show "firewall.${_sid}" 2>/dev/null \
+		| sed -n '1s/^firewall\.\([^=.]*\)=.*/\1/p'
+}
+
 # True when two firewall section ids refer to the same WAN zone (issue #239).
+# Compare canonical cfg ids — do NOT treat every name=wan zone as identical
+# (duplicate wan sections would under-match foreign .log deltas as ours).
 wan_firewall_zone_same() {
 	_a="$1"
 	_b="$2"
 	[ -n "$_a" ] && [ -n "$_b" ] || return 1
 	[ "$_a" = "$_b" ] && return 0
-	_na=$(uci -q get "firewall.${_a}.name" 2>/dev/null) || return 1
-	_nb=$(uci -q get "firewall.${_b}.name" 2>/dev/null) || return 1
-	_ta=$(uci -q get "firewall.${_a}" 2>/dev/null) || return 1
-	_tb=$(uci -q get "firewall.${_b}" 2>/dev/null) || return 1
-	[ "$_na" = "wan" ] && [ "$_nb" = "wan" ] && [ "$_ta" = "zone" ] && [ "$_tb" = "zone" ]
+	_ca=$(uci_canonical_firewall_section "$_a") || return 1
+	_cb=$(uci_canonical_firewall_section "$_b") || return 1
+	[ -n "$_ca" ] && [ -n "$_cb" ] && [ "$_ca" = "$_cb" ]
 }
 
 wan_log_staged_line_section() {

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -637,6 +637,9 @@ uci() {
 		'-q show firewall')
 			printf "firewall.@zone[0]=zone\nfirewall.@zone[0].name='wan'\n"
 			;;
+		'-q -X show firewall.@zone[0]'|'-q -X show firewall.cfg03dc81')
+			printf "firewall.cfg03dc81=zone\n"
+			;;
 		'-q get firewall.@zone[0]')
 			printf 'zone\n'
 			;;
@@ -693,10 +696,22 @@ ok "wan_log_staged_line_section parses all uci changes forms"
 
 uci() {
 	case "$*" in
+		'-q -X show firewall.@zone[1]'|'-q -X show firewall.cfg03dc81')
+			printf "firewall.cfg03dc81=zone\n"
+			;;
+		'-q -X show firewall.cfg01aaaa')
+			printf "firewall.cfg01aaaa=zone\n"
+			;;
 		'-q get firewall.@zone[1].name'|'-q get firewall.cfg03dc81.name')
 			printf 'wan\n'
 			;;
 		'-q get firewall.@zone[1]'|'-q get firewall.cfg03dc81')
+			printf 'zone\n'
+			;;
+		'-q get firewall.cfg01aaaa.name')
+			printf 'lan\n'
+			;;
+		'-q get firewall.cfg01aaaa')
 			printf 'zone\n'
 			;;
 		*) return 1 ;;
@@ -729,6 +744,38 @@ _ours=$(wan_log_count_our_staged_lines '@zone[1]' "$_staged")
 [ "$_ours" = "1" ] || die "count_our_staged_lines expected 1, got '$_ours'"
 unset -f uci
 ok "wan_log staged-line helpers classify cfg id vs foreign lines"
+
+# B-1: duplicate name=wan zones must NOT be treated as the same section.
+uci() {
+	case "$*" in
+		'-q -X show firewall.@zone[0]')
+			printf "firewall.cfgWAN1=zone\n"
+			;;
+		'-q -X show firewall.cfgWAN1')
+			printf "firewall.cfgWAN1=zone\n"
+			;;
+		'-q -X show firewall.cfgDUP')
+			printf "firewall.cfgDUP=zone\n"
+			;;
+		*) return 1 ;;
+	esac
+}
+wan_firewall_zone_same '@zone[0]' 'cfgWAN1' \
+	|| die "B-1: @zone[0] and its cfg id must still match"
+wan_firewall_zone_same '@zone[0]' 'cfgDUP' \
+	&& die "B-1: duplicate wan cfgDUP must NOT match @zone[0]"
+_staged_dup="firewall.cfgWAN1.log='1'
+firewall.cfgDUP.log='0'"
+_foreign_dup=$(wan_log_foreign_staged_lines '@zone[0]' "$_staged_dup")
+case "$_foreign_dup" in
+	*'firewall.cfgDUP.log'*) ;;
+	*) die "B-1: foreign_staged_lines must keep duplicate wan .log as foreign, got: $_foreign_dup" ;;
+esac
+case "$_foreign_dup" in
+	*cfgWAN1*) die "B-1: our cfgWAN1.log must not be foreign: $_foreign_dup" ;;
+esac
+unset -f uci
+ok "B-1 duplicate wan zones stay distinct for commit-scope"
 
 sh "$RPCD" __selftest >/dev/null || die "rpcd __selftest"
 ok "rpcd __selftest"

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -746,6 +746,7 @@ unset -f uci
 ok "wan_log staged-line helpers classify cfg id vs foreign lines"
 
 # B-1: duplicate name=wan zones must NOT be treated as the same section.
+# Stub name/type probes too so a class-match revert would fail this test (Grok).
 uci() {
 	case "$*" in
 		'-q -X show firewall.@zone[0]')
@@ -756,6 +757,12 @@ uci() {
 			;;
 		'-q -X show firewall.cfgDUP')
 			printf "firewall.cfgDUP=zone\n"
+			;;
+		'-q get firewall.@zone[0].name'|'-q get firewall.cfgWAN1.name'|'-q get firewall.cfgDUP.name')
+			printf 'wan\n'
+			;;
+		'-q get firewall.@zone[0]'|'-q get firewall.cfgWAN1'|'-q get firewall.cfgDUP')
+			printf 'zone\n'
 			;;
 		*) return 1 ;;
 	esac


### PR DESCRIPTION
## Summary
- `wan_firewall_zone_same` compared zones by class (`name=wan` + type `zone`), so a **duplicate** wan section’s staged `.log=` line could be treated as “ours” and ride `uci commit firewall` (Low; admin + misconfiguration).
- Identity now uses canonical cfg ids via `uci -X show` (`uci_canonical_firewall_section`).
- Host test covers duplicate-wan foreign `.log` staying foreign while `@zone[N]`↔cfg bridge still works.

## Test plan
- [x] `bash tests/fwlive-logging.test.sh` (includes B-1 case)
- [ ] `./scripts/fwlive-test.sh` in CI
- [ ] Luna + Bugbot on branch before Ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WAN firewall change detection by consistently matching canonical firewall section identities.
  * Correctly handles duplicate WAN zones and staged changes represented by different section identifiers.
  * Prevents unrelated firewall sections and properties from being incorrectly included.

* **Tests**
  * Added regression coverage for anonymous and generated firewall section identifiers.
  * Expanded validation for commit-scope and staged-log change handling.

* **Documentation**
  * Updated the security review ledger with the resolved finding and associated verification controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->