### PR TITLE
docs(security): multi-model VVAH audit playbook + honest-gap scripts

### DIFF
--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -16,19 +16,100 @@ A pass owes the ledger a coverage-map update, a proof class for every control it
 touches, and its non-findings — see
 [security-review.md § Review procedure](../../../docs/developer/security-review.md#review-procedure).
 
+## Multi-model pass (VVAH-style)
+
+Token-efficient asymmetric loop shared with sibling OpenWrt packages (e.g.
+usrmanage). Cheap/deterministic work first; Fable 5.1 only for narrow judgment.
+Do not invent a new procedure in chat — follow this section.
+
+### Phase order
+
+1. **Close open issues / prove honest gaps** (ledger `Next:` / cannot-prove /
+   prove-next) before a broad re-read.
+2. **Delta** since the last coverage-map dates (touched surfaces only).
+3. **Full-pass gate** — only if criteria below fire; otherwise record deferral.
+
+### Stages and models
+
+| Stage | Job | Model | Token rule |
+|-------|-----|-------|------------|
+| 0 Static seed | Repo greps (below), shellcheck/smoke, key `git check-ignore`, action SHA pin spot-check | Deterministic | Zero LLM |
+| 1 Prep & triage | Job packets from ledger + diff | Grok (map) + Luna (polish) | Cheap |
+| 2 Audit & reason | Multi-step chains; Engineer Mode; fix sketch beside each finding | Fable 5.1 medium (high only for root/XSS chains) | Premium, narrow |
+| 3 Execute & fix | Patches, tests, ledger | Composer | Bulk output |
+| Validation panel | Mechanism real? severity calibrated? duplicate of accepted residual? | Luna + Grok (severity) | Cheap gate before filing |
+
+**Maker-never-grader:** Fable must not bulk-write patches. Composer must not
+invent new trust boundaries (edit the model doc only when a finding falsifies
+it). Luna/Grok score candidates before `gh` advisory/issue.
+
+**Engineer Mode (Fable stub):** You are reviewing production code for structural
+security flaws. For each finding: mechanism, location, blast radius, severity
+per the calibration table, and a concrete fix sketch. Do not role-play an
+attacker sandbox or request exploit payloads. Scope is exactly the attached job
+packet checklist — not "find any security issue."
+
+**Static cache block (identical on every Fable call):** one-line threat model +
+invariants from
+[`security-model.md`](../../../docs/developer/security-model.md) + ACL method
+table + severity calibration below.
+
+### Job-packet template
+
+Ephemeral (chat or scratch dir — do not commit noise):
+
+- Files / short diff summary
+- Cached threat-model block (above)
+- Checklist (surface-specific)
+- Prior non-findings for that surface from the ledger
+- Expected proof class on exit (`host` / `lab` / `manual`)
+
+### Full-pass gate
+
+Run a full surface re-pass only if one of:
+
+- A gap failed and suggests a **class** bug (fix-the-class sweep)
+- Delta Fable finds high/medium with blast radius beyond touched files
+- A root-reachable control is still only `manual` with no raise path
+- Pre-`v*` tag and pin checklist is stale
+
+Otherwise update coverage-map dates for surfaces examined, record non-findings,
+and set ledger `Next:` to the deferral reason.
+
+### Cross-repo class memory (Stage 0 checklist)
+
+Not a Fable dump — grep/confirm mechanically:
+
+- Temp mode loss after `mv` / normalize rewrite
+- Unswept pin neighbors (one helper pinned, sibling not)
+- Hand-parsed platform formats narrower than `uci`/`fw4`/`nslookup`
+- R7: digest-pin before secret mount + `--network none` on signing containers
+- Workflow `${{ }}` interpolated into `run:` bodies
+
+### fwlive bindings
+
+| Binding | Value |
+|---------|-------|
+| Threat model | [`docs/developer/security-model.md`](../../../docs/developer/security-model.md) |
+| Ledger | [`docs/developer/security-review.md`](../../../docs/developer/security-review.md) |
+| Host gate | `./scripts/fwlive-test.sh`, `./scripts/fwlive-shellcheck.sh` |
+| Lab / honest-gap smokes | `./scripts/qemu-smoke-fwlive.sh`, `./scripts/qemu-security-gaps-smoke.sh` |
+| Highest-yield surface | Frontend `E()` / log XSS (Steps 1–2 below) |
+| Honest gaps | Ledger § What this pass could not prove |
+
 ## Order of work
 
-Highest yield first. The frontend is where the exploitable bugs live; the
-backend has held up under audit.
+Highest yield first when running a **full** surface pass. Prefer the multi-model
+phase order above for routine audits.
 
 ```
+- [ ] 0. Multi-model: open issues / honest gaps → delta → gate
 - [ ] 1. Frontend rendering sinks (E() string children)
 - [ ] 2. Untrusted-input trace (log fields, PTR, URL hash, UCI)
 - [ ] 3. rpcd plugin + ACL scope
 - [ ] 4. Shell helpers (injection, quoting)
 - [ ] 5. Release pipeline (secrets, pinning, temp paths)
 ```
-
 ## Verified facts — do not re-derive
 
 The facts themselves live in the security model; this section only records **how

--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -12,23 +12,23 @@ for the trust boundaries and invariants, and
 for what has already been checked, with what proof, and what is open. This file
 is the *how*.
 
-A pass owes the ledger a coverage-map update, a proof class for every control it
-touches, and its non-findings — see
+After a pass, update the coverage map in the ledger. Record a proof class for
+every control the pass touches. Record the non-findings — see
 [security-review.md § Review procedure](../../../docs/developer/security-review.md#review-procedure).
 
 ## Multi-model pass (VVAH-style)
 
-Token-efficient asymmetric loop shared with sibling OpenWrt packages (e.g.
-usrmanage). Cheap/deterministic work first; reserve a **frontier reasoner**
-only for narrow judgment. Do not invent a new procedure in chat — follow this
-section.
+Sibling OpenWrt packages (for example usrmanage) share this loop. Do cheap,
+deterministic work first. Reserve a **frontier reasoner** for narrow judgment
+only. Do not invent a new procedure in chat — follow this section.
 
 ### Phase order
 
 1. **Close open issues / prove honest gaps** (ledger `Next:` / cannot-prove /
    prove-next) before a broad re-read.
 2. **Delta** since the last coverage-map dates (touched surfaces only).
-3. **Full-pass gate** — only if criteria below fire; otherwise record deferral.
+3. **Full-pass gate** — run it only if one of the criteria below is true.
+   Otherwise record the deferral.
 
 ### Frontier reasoner profiles
 
@@ -38,7 +38,7 @@ round.
 | Profile | Stage 2 (reason) | Stage 1 helpers | Validation panel | Notes |
 |---------|------------------|-----------------|------------------|-------|
 | **Fable** (default when available) | Claude Fable 5.1 — medium effort; high only for root/XSS chains | Grok (map) + Luna (polish) | Luna + Grok (severity) | Strong on multi-step OpenWrt/LuCI chains |
-| **GLM** (alternate review process) | GLM-5.3 at **max thinking** | Luna + GLM-5.3 Flash **or** DeepSeek V4 Flash | Luna + the same flash helper (severity) | Use when the orchestrator runs GLM instead of Fable; max thinking is required — medium/low under-reasons on ACL/commit-scope |
+| **GLM** (alternate review process) | GLM-5.3 at **max thinking** | Luna + GLM-5.3 Flash **or** DeepSeek V4 Flash | Luna + the same flash helper (pairwise) | Use when the orchestrator runs GLM instead of Fable. Use max thinking. Medium or low thinking does not reason enough about ACL and commit scope. |
 
 Composer remains Stage 3 (patches) under both profiles. Doc-only PRs do not
 need a frontier reasoner — Luna (+ optional Grok for cross-repo wording) is
@@ -54,10 +54,10 @@ enough.
 | 3 Execute & fix | Patches, tests, ledger | Composer | Bulk output |
 | Validation panel | Mechanism real? severity calibrated? duplicate of accepted residual? | Profile validation pair | Cheap gate before filing |
 
-**Maker-never-grader:** The Stage-2 reasoner must not bulk-write patches.
-Composer must not invent new trust boundaries (edit the model doc only when a
-finding falsifies it). Validation-panel models score candidates before `gh`
-advisory/issue.
+**Keep review and patching separate:** The Stage-2 reasoner must not write
+patches in bulk. Composer must not invent new trust boundaries. Edit the model
+doc only when a finding falsifies it. Validation-panel models score candidates
+before `gh` advisory/issue.
 
 **Engineer Mode (Stage-2 stub):** You are reviewing production code for
 structural security flaws. For each finding: mechanism, location, blast radius,
@@ -72,7 +72,7 @@ table + severity calibration below.
 
 ### Job-packet template
 
-Ephemeral (chat or scratch dir — do not commit noise):
+Ephemeral (chat or scratch dir — do not commit these files):
 
 - Files / short diff summary
 - Cached threat-model block (above)
@@ -85,16 +85,18 @@ Ephemeral (chat or scratch dir — do not commit noise):
 Run a full surface re-pass only if one of:
 
 - A gap failed and suggests a **class** bug (fix-the-class sweep)
-- Delta Stage-2 reasoner finds high/medium with blast radius beyond touched files
+- The Stage-2 reasoner finds a high or medium issue whose blast radius goes
+  beyond the touched files
 - A root-reachable control is still only `manual` with no raise path
-- Pre-`v*` tag and pin checklist is stale
+- You are about to cut a `v*` tag, and the pin checklist is stale
 
-Otherwise update coverage-map dates for surfaces examined, record non-findings,
-and set ledger `Next:` to the deferral reason.
+Otherwise update coverage-map dates for surfaces examined. Record non-findings.
+Set ledger `Next:` to the deferral reason.
 
 ### Cross-repo class memory (Stage 0 checklist)
 
-Not a Stage-2 dump — grep/confirm mechanically:
+Make sure that each item below is true. Use grep. Do not send this list to
+Stage 2:
 
 - Temp mode loss after `mv` / normalize rewrite
 - Unswept pin neighbors (one helper pinned, sibling not)
@@ -115,7 +117,7 @@ Not a Stage-2 dump — grep/confirm mechanically:
 
 ## Order of work
 
-Highest yield first when running a **full** surface pass. Prefer the multi-model
+Highest yield first when running a **full** surface pass. Use the multi-model
 phase order above for routine audits.
 
 ```

--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -299,14 +299,14 @@ spaces after colons will match nothing and look like a failure:
 gh api /repos/{owner}/{repo}/security-advisories --jq '.[] | "\(.ghsa_id) \(.state)"'
 ```
 
-## Known-good — do not re-litigate without new evidence
+## Accepted items — do not reopen without new evidence
 
 Invariants 2–7 in [`security-model.md`](../../../docs/developer/security-model.md)
 were each audited and found correctly implemented, as was the
 `__rulesmap_iptables` fixed-path guard.
 
 Re-examine them only with new evidence — a code change in the area, or a concrete
-bypass. Spending the pass re-reading known-good shell is the main way an audit
+bypass. Spending the pass re-reading accepted shell is the main way an audit
 runs out of time before reaching the frontend.
 
 **Two entries were removed from this list on 2026-08-12**, and the reason

--- a/.cursor/skills/security-audit/SKILL.md
+++ b/.cursor/skills/security-audit/SKILL.md
@@ -19,8 +19,9 @@ touches, and its non-findings — see
 ## Multi-model pass (VVAH-style)
 
 Token-efficient asymmetric loop shared with sibling OpenWrt packages (e.g.
-usrmanage). Cheap/deterministic work first; Fable 5.1 only for narrow judgment.
-Do not invent a new procedure in chat — follow this section.
+usrmanage). Cheap/deterministic work first; reserve a **frontier reasoner**
+only for narrow judgment. Do not invent a new procedure in chat — follow this
+section.
 
 ### Phase order
 
@@ -29,27 +30,42 @@ Do not invent a new procedure in chat — follow this section.
 2. **Delta** since the last coverage-map dates (touched surfaces only).
 3. **Full-pass gate** — only if criteria below fire; otherwise record deferral.
 
+### Frontier reasoner profiles
+
+Pick **one** Stage-2 reasoner for the pass. Do not mix both in the same packet
+round.
+
+| Profile | Stage 2 (reason) | Stage 1 helpers | Validation panel | Notes |
+|---------|------------------|-----------------|------------------|-------|
+| **Fable** (default when available) | Claude Fable 5.1 — medium effort; high only for root/XSS chains | Grok (map) + Luna (polish) | Luna + Grok (severity) | Strong on multi-step OpenWrt/LuCI chains |
+| **GLM** (alternate review process) | GLM-5.3 at **max thinking** | Luna + GLM-5.3 Flash **or** DeepSeek V4 Flash | Luna + the same flash helper (severity) | Use when the orchestrator runs GLM instead of Fable; max thinking is required — medium/low under-reasons on ACL/commit-scope |
+
+Composer remains Stage 3 (patches) under both profiles. Doc-only PRs do not
+need a frontier reasoner — Luna (+ optional Grok for cross-repo wording) is
+enough.
+
 ### Stages and models
 
-| Stage | Job | Model | Token rule |
-|-------|-----|-------|------------|
+| Stage | Job | Model (see profile above) | Token rule |
+|-------|-----|---------------------------|------------|
 | 0 Static seed | Repo greps (below), shellcheck/smoke, key `git check-ignore`, action SHA pin spot-check | Deterministic | Zero LLM |
-| 1 Prep & triage | Job packets from ledger + diff | Grok (map) + Luna (polish) | Cheap |
-| 2 Audit & reason | Multi-step chains; Engineer Mode; fix sketch beside each finding | Fable 5.1 medium (high only for root/XSS chains) | Premium, narrow |
+| 1 Prep & triage | Job packets from ledger + diff | Profile helpers | Cheap |
+| 2 Audit & reason | Multi-step chains; Engineer Mode; fix sketch beside each finding | Profile frontier reasoner | Premium, narrow |
 | 3 Execute & fix | Patches, tests, ledger | Composer | Bulk output |
-| Validation panel | Mechanism real? severity calibrated? duplicate of accepted residual? | Luna + Grok (severity) | Cheap gate before filing |
+| Validation panel | Mechanism real? severity calibrated? duplicate of accepted residual? | Profile validation pair | Cheap gate before filing |
 
-**Maker-never-grader:** Fable must not bulk-write patches. Composer must not
-invent new trust boundaries (edit the model doc only when a finding falsifies
-it). Luna/Grok score candidates before `gh` advisory/issue.
+**Maker-never-grader:** The Stage-2 reasoner must not bulk-write patches.
+Composer must not invent new trust boundaries (edit the model doc only when a
+finding falsifies it). Validation-panel models score candidates before `gh`
+advisory/issue.
 
-**Engineer Mode (Fable stub):** You are reviewing production code for structural
-security flaws. For each finding: mechanism, location, blast radius, severity
-per the calibration table, and a concrete fix sketch. Do not role-play an
-attacker sandbox or request exploit payloads. Scope is exactly the attached job
-packet checklist — not "find any security issue."
+**Engineer Mode (Stage-2 stub):** You are reviewing production code for
+structural security flaws. For each finding: mechanism, location, blast radius,
+severity per the calibration table, and a concrete fix sketch. Do not role-play
+an attacker sandbox or request exploit payloads. Scope is exactly the attached
+job packet checklist — not "find any security issue."
 
-**Static cache block (identical on every Fable call):** one-line threat model +
+**Static cache block (identical on every Stage-2 call):** one-line threat model +
 invariants from
 [`security-model.md`](../../../docs/developer/security-model.md) + ACL method
 table + severity calibration below.
@@ -69,7 +85,7 @@ Ephemeral (chat or scratch dir — do not commit noise):
 Run a full surface re-pass only if one of:
 
 - A gap failed and suggests a **class** bug (fix-the-class sweep)
-- Delta Fable finds high/medium with blast radius beyond touched files
+- Delta Stage-2 reasoner finds high/medium with blast radius beyond touched files
 - A root-reachable control is still only `manual` with no raise path
 - Pre-`v*` tag and pin checklist is stale
 
@@ -78,7 +94,7 @@ and set ledger `Next:` to the deferral reason.
 
 ### Cross-repo class memory (Stage 0 checklist)
 
-Not a Fable dump — grep/confirm mechanically:
+Not a Stage-2 dump — grep/confirm mechanically:
 
 - Temp mode loss after `mv` / normalize rewrite
 - Unswept pin neighbors (one helper pinned, sibling not)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Shipped surface: `openwrt-feed/luci-app-fwlive/`. Rules live in the linked owner
 - Sessions MUST NOT get `ubus log.read`. Keep read/write ACL scopes separate.
 - `PKG_VERSION` MUST match `APP_VERSION` (bump both in lockstep; see [release.md](docs/release.md)).
 - Renderer tests do not render — a green run is not XSS proof. [build-and-test.md](docs/developer/build-and-test.md)
-- rpcd / ACL / shell helpers / release pipeline: update [security-review.md](docs/developer/security-review.md) in the same PR; audit via `.cursor/skills/security-audit`.
+- rpcd / ACL / shell helpers / release pipeline: update [security-review.md](docs/developer/security-review.md) in the same PR; audit via `.cursor/skills/security-audit` (multi-model VVAH-style section + surface steps).
 - Releases: bump `PKG_VERSION`/`APP_VERSION`, fold CHANGELOG, tag `v0.1.N` — CI builds the signed feed + release assets. [release.md](docs/release.md)
 - Vulnerabilities go to a private advisory ([SECURITY.md](SECURITY.md)), not a public issue.
 - Agent PRs: luna (or grok) + Bugbot on the branch, **human review**, then file vs master, then CodeRabbit — not CI-green alone. [pr-cycle.md](docs/developer/pr-cycle.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Shipped surface: `openwrt-feed/luci-app-fwlive/`. Rules live in the linked owner
 - Sessions MUST NOT get `ubus log.read`. Keep read/write ACL scopes separate.
 - `PKG_VERSION` MUST match `APP_VERSION` (bump both in lockstep; see [release.md](docs/release.md)).
 - Renderer tests do not render — a green run is not XSS proof. [build-and-test.md](docs/developer/build-and-test.md)
-- rpcd / ACL / shell helpers / release pipeline: update [security-review.md](docs/developer/security-review.md) in the same PR; audit via `.cursor/skills/security-audit` (multi-model VVAH-style section + surface steps).
+- rpcd / ACL / shell helpers / release pipeline: update [security-review.md](docs/developer/security-review.md) in the same PR; audit via `.cursor/skills/security-audit` (see Multi-model pass and the surface steps).
 - Releases: bump `PKG_VERSION`/`APP_VERSION`, fold CHANGELOG, tag `v0.1.N` — CI builds the signed feed + release assets. [release.md](docs/release.md)
 - Vulnerabilities go to a private advisory ([SECURITY.md](SECURITY.md)), not a public issue.
 - Agent PRs: luna (or grok) + Bugbot on the branch, **human review**, then file vs master, then CodeRabbit — not CI-green alone. [pr-cycle.md](docs/developer/pr-cycle.md)

--- a/docs/developer/coderabbit.md
+++ b/docs/developer/coderabbit.md
@@ -30,6 +30,36 @@ CodeRabbit, that is separate — do not paste this repo’s review threads.
   - `@coderabbitai full review` — full re-review from scratch
   - `@coderabbitai pause` / `@coderabbitai resume` — stop / restart auto-reviews
     (auto-pause kicks in after many reviewed commits)
+  - `@coderabbitai rate limit` — quota status only (does **not** consume a review)
+
+## Efficient trigger path (prefer this)
+
+Goal: **one review slot per stable head**, not a fixed one-hour sleep.
+
+1. **Finish the branch first** (luna + Bugbot + human + CI green on the
+   rebased head). Stay in draft while pushing.
+2. **Pre-flight quota** — comment `@coderabbitai rate limit` on the draft.
+   If allowance is `0`, wait until the bot’s refresh window (or the plan’s
+   rolling hour) before the next step. Do **not** mark Ready just to “use
+   up” an empty slot.
+3. **One trigger only** — when quota is available, either:
+   - `gh pr ready` (preferred; starts auto-review), **or**
+   - `@coderabbitai review` while still draft  
+   **Never both** on the same head — that can burn two slots for one diff.
+4. **Poll for completion, don’t wall-clock guess.** Record trigger time + head
+   SHA. Watch until either:
+   - a new `COMMENTED` review from `coderabbitai[bot]` with matching
+     `commit_id` (round done), or
+   - a rate-limit issue comment / `Review rate limited` check (terminal —
+     head was **not** reviewed).
+5. **If rate-limited after Ready** — leave the PR Ready (do not bounce
+   draft↔ready). When quota refreshes, post **one**
+   `@coderabbitai review` for that same head. No fixed “wait an hour then
+   hope”; use the bot’s rate-limit text / next `@coderabbitai rate limit`.
+6. **Fixes** — collect the full round, batch into **one** push, then wait for
+   the incremental round (or `@coderabbitai review` if auto-review is paused /
+   limited). Repeat until the latest round has no actionable `CONFIRMED`
+   findings.
 
 ## The 4 rules
 
@@ -71,8 +101,12 @@ CodeRabbit, that is separate — do not paste this repo’s review threads.
 
 When an agent drives the fix loop:
 
-- Trigger the review, then **poll** — do not time-box with a guess. Check
-  `pulls/<n>/reviews` for a new submission before starting any fix.
+- **Quota before Ready** — `@coderabbitai rate limit` first; only then
+  `gh pr ready` (or a single manual review). Never Ready + manual review on
+  the same SHA.
+- Trigger the review, then **poll** — do not time-box with a guess (“wait an
+  hour”). Check `pulls/<n>/reviews` for a new submission, and issue comments /
+  checks for rate-limit, before starting any fix.
 - Do not auto-push per-finding as the bot posts comments. Collect the full
   round, fix in one batch, push once.
 - After the push, re-fetch `pulls/<n>/reviews` + `pulls/<n>/comments` and diff
@@ -80,5 +114,7 @@ When an agent drives the fix loop:
   with refined findings, not just `Addressed` markers on old ones.
 - Rate limits are plan-specific rolling allowances (e.g. Free 1/hr, Pro 5/hr,
   Pro+ 10/hr — check the plan's limits). They apply to automatic and manual
-  triggers alike; check remaining quota with `@coderabbitai rate limit` and
-  prefer batching over `@coderabbitai review` spam.
+  triggers alike; prefer batching over `@coderabbitai review` spam.
+- On rate-limit: stay Ready, sleep until the reported refresh (or re-check
+  `@coderabbitai rate limit`), then one `@coderabbitai review` — do not flip
+  draft state to “retry” auto-review.

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -119,8 +119,11 @@ The `uci set` touches only bit 0 of the WAN zone `log` value, and UCI is rolled
 back if the firewall reload fails. Before `uci set` / commit, the toggle refuses
 when `uci changes firewall` is non-empty (`firewall_changes_pending`) so a
 package-wide commit cannot publish unrelated staged deltas
-([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)). Zone lookup
-accepts both anonymous `@zone[N]` and named sections.
+([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)).
+`uci commit firewall` remains package-wide: two privileged writers can still
+publish each other's already-staged changes in a race ([#191](https://github.com/lucas-albers-lz4/fwlive/issues/191)
+residual — accepted). Zone lookup accepts both anonymous `@zone[N]` and named
+sections.
 
 Serialization of the toggle uses a lock file created/tightened to `0600` so
 unprivileged UIDs cannot take `LOCK_EX` ([#167](https://github.com/lucas-albers-lz4/fwlive/issues/167)).

--- a/docs/developer/security-model.md
+++ b/docs/developer/security-model.md
@@ -120,7 +120,7 @@ back if the firewall reload fails. Before `uci set` / commit, the toggle refuses
 when `uci changes firewall` is non-empty (`firewall_changes_pending`) so a
 package-wide commit cannot publish unrelated staged deltas
 ([#168](https://github.com/lucas-albers-lz4/fwlive/issues/168)).
-`uci commit firewall` remains package-wide: two privileged writers can still
+`uci commit firewall` remains package-wide. Two privileged writers can still
 publish each other's already-staged changes in a race ([#191](https://github.com/lucas-albers-lz4/fwlive/issues/191)
 residual — accepted). Zone lookup accepts both anonymous `@zone[N]` and named
 sections.

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,6 +1,6 @@
 # Security review state
 
-> **Status:** 43 controls in force; 0 open findings.
+> **Status:** 45 controls in force; 0 open findings.
 > **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
 > **Open:** none.
 > **Next:** On the next `v*` tag, re-check pins and run full docker usign (gap 4). The full surface re-pass is deferred — the gate criteria are not met (skill § Multi-model pass / full-pass gate). Lab gaps 1–3 ran as smoke tests on 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green). The gap 2 flock residual is unchanged.

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -98,7 +98,7 @@ should carry a note saying what would raise it.
 | Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` — `peaceiris/actions-gh-pages@84c30a85c…` = `v4.1.0` (verified 2026-08-13); CodeQL alert 7 closed as **fixed**; re-check before each `v*` tag ([#178](https://github.com/lucas-albers-lz4/fwlive/issues/178)) |
 | SDK image digest-pinned at first **secret-touching** pull | `host` | `sdk_matrix_pull_and_pin` in `validate-feed-keys.sh`; `feed_publish_apply_sdk_pin` before opkg/apk sign; `tests/sdk-matrix-digests.test.sh` |
 | Signing-secret containers have no network | `host` | `docker run --network none` on validate usign check and opkg/apk sign steps (Compose v2 has no `--network` on `compose run`); same test |
-| Signing secrets stay 0600 through validate-feed-keys rewrite prefix (decode/normalize/chmod) | `host` | `tests/validate-feed-keys-mode.test.sh` — mirrors validate path without SDK pull; full docker usign sign on next `v*` still prove-next |
+| Signing secrets stay 0600 through validate-feed-keys rewrite prefix (decode/normalize/chmod) | `host` | `tests/validate-feed-keys-mode.test.sh` — calls shared `feed_keys_validate_*_rewrite_prefix` (same helpers as `validate-feed-keys.sh`) including a base64 decode rewrite; full docker usign sign on next `v*` still prove-next |
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
@@ -160,7 +160,7 @@ path: `tests/validate-feed-keys-mode.test.sh` (gap 4 prefix; wired into
 | `resolve` really returns within its budget on a loaded router | lab smoke 2026-09-04 (responsiveness only; not blackhole-DNS budget proof) | Flood returned in 1s under `RESOLVE_SLACK_SEC=8` |
 | The rpcd script timeout actually bounds a blocked `flock` waiter | lab smoke 2026-09-04; BusyBox has no `flock -w` (**accepted residual** — client timed out, residual holds) | Host-side timeout fired; does not promote residual to cleared |
 | Pre-stage `firewall_changes_pending` refuse on a live device | lab smoke 2026-09-04 (**accepted residual** for package-commit publish of foreign staging — see above) | Foreign staging refused; foreign delta neither committed nor dropped |
-| Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + decode/normalize/chmod mirror of `validate-feed-keys.sh` (no SDK pull). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
+| Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + shared `feed_keys_validate_*_rewrite_prefix` (decode/normalize/chmod; base64 branch). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
 
 ## Review procedure
 

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -68,7 +68,7 @@ should carry a note saying what would raise it.
 | Build inputs (`feeds.lock`, `package-lock.json`) | 2026-08-23 | Read | Pins intact |
 | Dev tooling (`.cursor/mcp.json`) | 2026-08-23 | Read + fix | #205: unpinned `@playwright/mcp@latest` removed; UI tests use pinned `playwright` devDep |
 | Lab deploy helper (`scripts/agent-build-and-deploy.sh`) | 2026-09-03 | Read + fix | #261: SSH host-key verification ON by default; `ALLOW_INSECURE_SSH=1` / `--lab-only` opt-in with warning |
-| Lab honest-gap smokes | 2026-09-03 | Scripts landed | `scripts/qemu-security-gaps-smoke.sh` (gaps 1–3; QEMU not run this pass); `tests/validate-feed-keys-mode.test.sh` (gap 4 validate-prefix → `host`) |
+| Lab honest-gap smokes | 2026-09-04 | Lab smoke | `scripts/qemu-security-gaps-smoke.sh` gaps 1–3 green 2026-09-04; gap-2 BusyBox `flock` (no `-w`) accepted residual; `tests/validate-feed-keys-mode.test.sh` (gap 4 validate-prefix → `host`) |
 
 ## Controls in force
 

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -3,7 +3,7 @@
 > **Status:** 43 controls in force; 0 open findings.
 > **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
 > **Open:** none.
-> **Next:** run `./scripts/qemu-security-gaps-smoke.sh` on QEMU to promote gaps 1–3 to `lab`; re-check pins + full docker usign mode on next `v*` tag; **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate).
+> **Next:** on QEMU, run `./scripts/qemu-security-gaps-smoke.sh` as a lab *smoke* (resolve responsiveness; unprivileged lock deny; pre-stage `firewall_changes_pending` refuse) — do **not** auto-promote gap 2 flock residual or #191 post-stage window to `lab` from a green run; re-check pins + full docker usign on next `v*` tag; **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate).
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass (VVAH-style): [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
 
 What has been reviewed, when, with what strength of proof, and what is still
@@ -156,9 +156,9 @@ path: `tests/validate-feed-keys-mode.test.sh` (gap 4 prefix; wired into
 
 | Property | Status | What would prove it |
 |----------|--------|---------------------|
-| `resolve` really returns within its budget on a loaded router | cannot-prove on host — **script ready** | Lab: `./scripts/qemu-security-gaps-smoke.sh` (flood `fwlive.resolve`, wall clock ≤ slack) |
-| The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host — **script ready**; BusyBox has no `flock -w` (accepted residual if client times out) | Lab: same script holds root flock, calls enable with client timeout; also asserts unprivileged cannot `LOCK_EX` |
-| `uci commit firewall` scope on a live device | prove-next — **script ready** | Lab: same script stages foreign `firewall` delta, expects `firewall_changes_pending`, marker not committed — **host-level fix landed 2026-08-21 (#191), tightened 2026-08-23**; residual window documented in prior entry |
+| `resolve` really returns within its budget on a loaded router | cannot-prove on host — **smoke script ready** | Lab: `./scripts/qemu-security-gaps-smoke.sh` flood is a responsiveness smoke (not blackhole-DNS proof of `RESOLVE_BUDGET`) |
+| The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host — **smoke script ready**; BusyBox has no `flock -w` (**accepted residual** if client times out) | Lab: same script holds root flock + host-side client timeout; documents residual, does not clear it |
+| `uci commit firewall` scope on a live device | prove-next — **smoke script ready** (pre-stage refuse only) | Lab: same script stages foreign delta, expects `firewall_changes_pending`; does **not** cover #191 residual post-stage→commit window |
 | Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + decode/normalize/chmod mirror of `validate-feed-keys.sh` (no SDK pull). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
 
 ## Review procedure

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -157,9 +157,9 @@ path: `tests/validate-feed-keys-mode.test.sh` (gap 4 prefix; wired into
 
 | Property | Status | What would prove it |
 |----------|--------|---------------------|
-| `resolve` really returns within its budget on a loaded router | cannot-prove on host — **smoke script ready** | Lab: `./scripts/qemu-security-gaps-smoke.sh` flood is a responsiveness smoke (not blackhole-DNS proof of `RESOLVE_BUDGET`) |
-| The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host — **smoke script ready**; BusyBox has no `flock -w` (**accepted residual** if client times out) | Lab: same script holds root flock + host-side client timeout; documents residual, does not clear it |
-| Pre-stage `firewall_changes_pending` refuse on a live device | optional lab smoke (**accepted residual** for package-commit ride-along — see above) | Lab: same script stages foreign delta, expects refuse; residual is architectural, not prove-next |
+| `resolve` really returns within its budget on a loaded router | lab smoke 2026-09-04 (responsiveness only; not blackhole-DNS budget proof) | Flood returned in 1s under `RESOLVE_SLACK_SEC=8` |
+| The rpcd script timeout actually bounds a blocked `flock` waiter | lab smoke 2026-09-04; BusyBox has no `flock -w` (**accepted residual** — client timed out, residual holds) | Host-side timeout fired; does not promote residual to cleared |
+| Pre-stage `firewall_changes_pending` refuse on a live device | lab smoke 2026-09-04 (**accepted residual** for package-commit ride-along — see above) | Foreign staging refused; foreign delta neither committed nor dropped |
 | Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + decode/normalize/chmod mirror of `validate-feed-keys.sh` (no SDK pull). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
 
 ## Review procedure

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -3,7 +3,7 @@
 > **Status:** 43 controls in force; 0 open findings.
 > **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
 > **Open:** none.
-> **Next:** on QEMU, run `./scripts/qemu-security-gaps-smoke.sh` as a lab *smoke* (resolve responsiveness; unprivileged lock deny; pre-stage `firewall_changes_pending` refuse) — do **not** auto-promote gap 2 flock residual to `lab` from a green run; re-check pins + full docker usign on next `v*` tag; **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate).
+> **Next:** re-check pins + full docker usign on next `v*` tag (gap 4 close-out); **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate). Lab gaps 1–3 smoked 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green; gap 2 flock residual unchanged).
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass (VVAH-style): [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
 
 What has been reviewed, when, with what strength of proof, and what is still

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -3,8 +3,8 @@
 > **Status:** 43 controls in force; 0 open findings.
 > **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
 > **Open:** none.
-> **Next:** re-check pins + full docker usign on next `v*` tag (gap 4 close-out); **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate). Lab gaps 1–3 smoked 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green; gap 2 flock residual unchanged).
-> **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass (VVAH-style): [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
+> **Next:** On the next `v*` tag, re-check pins and run full docker usign (gap 4). The full surface re-pass is deferred — the gate criteria are not met (skill § Multi-model pass / full-pass gate). Lab gaps 1–3 ran as smoke tests on 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green). The gap 2 flock residual is unchanged.
+> **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass: [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
 
 What has been reviewed, when, with what strength of proof, and what is still
 open. This document is the **record**; it owns no rules.
@@ -145,7 +145,7 @@ Known, judged acceptable. Reopen only with new evidence.
 | Any local UID can inject syslog lines that pass the firewall classifier | `logd` chmods its socket 0666 upstream (ubox `log/syslog.c`). Not fixable from this package; the consequence is forged rows in the view, and every field is already rendered as text |
 | `date +%s` can jump under NTP sync, over- or under-running `RESOLVE_BUDGET` | Worker starvation is still prevented, which is the property the budget exists for |
 | A LuCI admin session is root-equivalent | Structural to LuCI. It is the reason script execution on this page is treated as a root compromise, not a lesser bug |
-| `uci commit firewall` is package-wide ([#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) residual) | OpenWrt has no option-scoped commit. Pre/post-stage gates refuse when foreign staging is visible; a second privileged writer can still stage in the tiny window before commit and ride the same publish — two root processes publishing each other's already-staged work. Unprivileged staging is blocked by libuci dir modes. Reopen only with an unprivileged or cross-session path. |
+| `uci commit firewall` is package-wide ([#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) residual) | OpenWrt has no option-scoped commit. Pre/post-stage gates refuse when foreign staging is visible. A second privileged writer can still stage in the short interval before commit and publish those changes in the same `uci commit` — two root processes publishing each other's already-staged work. Unprivileged staging is blocked by libuci dir modes. Reopen only with an unprivileged or cross-session path. |
 | `feed_publish_ensure_usign` leaves its build dir for the process lifetime | `PATH` points into it and `usign` is called later; the name is unpredictable per invocation, and `/tmp` is reaped on reboot |
 
 ## What this pass could not prove
@@ -159,7 +159,7 @@ path: `tests/validate-feed-keys-mode.test.sh` (gap 4 prefix; wired into
 |----------|--------|---------------------|
 | `resolve` really returns within its budget on a loaded router | lab smoke 2026-09-04 (responsiveness only; not blackhole-DNS budget proof) | Flood returned in 1s under `RESOLVE_SLACK_SEC=8` |
 | The rpcd script timeout actually bounds a blocked `flock` waiter | lab smoke 2026-09-04; BusyBox has no `flock -w` (**accepted residual** — client timed out, residual holds) | Host-side timeout fired; does not promote residual to cleared |
-| Pre-stage `firewall_changes_pending` refuse on a live device | lab smoke 2026-09-04 (**accepted residual** for package-commit ride-along — see above) | Foreign staging refused; foreign delta neither committed nor dropped |
+| Pre-stage `firewall_changes_pending` refuse on a live device | lab smoke 2026-09-04 (**accepted residual** for package-commit publish of foreign staging — see above) | Foreign staging refused; foreign delta neither committed nor dropped |
 | Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + decode/normalize/chmod mirror of `validate-feed-keys.sh` (no SDK pull). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
 
 ## Review procedure
@@ -392,7 +392,7 @@ links to this ledger for review state.
 
 **Finding fixed in-tree (no public issue — Low, fixed same pass).**
 
-- **B-1** — `wan_firewall_zone_same` treated any `name=wan` zone as identical; duplicate wan `.log` deltas could ride a commit. Now compares canonical cfg ids via `uci -X show`. Host test covers duplicate-wan foreign line.
+- **B-1** — `wan_firewall_zone_same` treated any `name=wan` zone as identical. Duplicate wan `.log` deltas were able to publish with a commit. Now compares canonical cfg ids via `uci -X show`. Host test covers duplicate-wan foreign line.
 
 **Non-findings**
 
@@ -401,4 +401,4 @@ links to this ledger for review state.
 - Stage-0 class memory: no new `${{ }}` in `run:`, no new temp-mode/pin regressions in delta.
 - UCI `.log_*` near-miss grammar (#257) holds under Fable checklist.
 
-**Full-pass gate.** Deferred — no class bug beyond B-1 (fixed), no high/medium blast radius, pin ritual not due until next `v*` tag. Next: QEMU `qemu-security-gaps-smoke.sh` for gaps 1–3.
+**Full-pass gate.** Deferred — no class bug beyond B-1 (fixed), no high/medium blast radius. The pin checklist is not due until the next `v*` tag. Next: QEMU `qemu-security-gaps-smoke.sh` for gaps 1–3.

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,10 +1,10 @@
 # Security review state
 
-> **Status:** 42 controls in force; 0 open findings.
-> **Last review:** 2026-09-03 (B-1 canonical WAN zone identity for staged uci changes).
+> **Status:** 43 controls in force; 0 open findings.
+> **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
 > **Open:** none.
-> **Next:** re-check pins before each `v*` tag; close the 4 honest gaps in the lab.
-> **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. For coverage beyond that script, follow [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md). Values current as of this PR.
+> **Next:** run `./scripts/qemu-security-gaps-smoke.sh` on QEMU to promote gaps 1–3 to `lab`; re-check pins + full docker usign mode on next `v*` tag; **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate).
+> **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass (VVAH-style): [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
 
 What has been reviewed, when, with what strength of proof, and what is still
 open. This document is the **record**; it owns no rules.
@@ -12,7 +12,7 @@ open. This document is the **record**; it owns no rules.
 | Read this for | Go here |
 |---------------|---------|
 | What we trust, invariants, ACL scope, supply-chain surface | [security-model.md](security-model.md) |
-| How to run a pass, re-verification commands | [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) |
+| How to run a pass (multi-model stages + surface steps) | [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) |
 | Whether a surface was checked, and whether a control is *proven* | this file |
 
 Start here before a pass. Do not re-derive the trust boundaries, and do not
@@ -63,11 +63,12 @@ should carry a note saying what would raise it.
 | Release pipeline — secrets and key handling | 2026-08-18 | Reproduced | #177 key-mode re-run; R7 pin-before-mount + `--network none` ([#179](https://github.com/lucas-albers-lz4/fwlive/issues/179)); 2026-08-18 hardening parity + R7 wrapper fix |
 | Release pipeline — fetch pinning | 2026-08-18 | Read + host test | #177 fetch-pin gate; R7 digest pin-cache (`tests/sdk-matrix-digests.test.sh`); 2026-08-18 wrapper-export + exact-cache-key |
 | Workflow inputs into `run:` bodies | 2026-08-23 | Read | Clean — inputs pass through `env:`; actions SHA-pinned including `FEED_DEPLOY_KEY`; 2026-08-18: dispatch tag validated (control chars, shape, real-tag + HEAD identity) before repo scripts |
-| LuCI view (templates / shipped JS) | 2026-08-23 | Read | No new sinks; untrusted values remain text nodes |
+| LuCI view (templates / shipped JS) | 2026-09-03 | Delta + Fable | `#fwlive-backend` via `textContent` only; `timeout_missing` warnings; Wave B Playwright = UX contract — XSS SoT remains recording-`innerHTML` harness (NON-FINDING) |
 | Package/install surface (Makefiles, prerm, feed layout) | 2026-08-23 | Read | No ACL or path regressions |
 | Build inputs (`feeds.lock`, `package-lock.json`) | 2026-08-23 | Read | Pins intact |
 | Dev tooling (`.cursor/mcp.json`) | 2026-08-23 | Read + fix | #205: unpinned `@playwright/mcp@latest` removed; UI tests use pinned `playwright` devDep |
 | Lab deploy helper (`scripts/agent-build-and-deploy.sh`) | 2026-09-03 | Read + fix | #261: SSH host-key verification ON by default; `ALLOW_INSECURE_SSH=1` / `--lab-only` opt-in with warning |
+| Lab honest-gap smokes | 2026-09-03 | Scripts landed | `scripts/qemu-security-gaps-smoke.sh` (gaps 1–3; QEMU not run this pass); `tests/validate-feed-keys-mode.test.sh` (gap 4 validate-prefix → `host`) |
 
 ## Controls in force
 
@@ -97,6 +98,7 @@ should carry a note saying what would raise it.
 | Actions SHA-pinned, including the step receiving `FEED_DEPLOY_KEY` | `manual` | `.github/workflows/publish-packages.yml` — `peaceiris/actions-gh-pages@84c30a85c…` = `v4.1.0` (verified 2026-08-13); CodeQL alert 7 closed as **fixed**; re-check before each `v*` tag ([#178](https://github.com/lucas-albers-lz4/fwlive/issues/178)) |
 | SDK image digest-pinned at first **secret-touching** pull | `host` | `sdk_matrix_pull_and_pin` in `validate-feed-keys.sh`; `feed_publish_apply_sdk_pin` before opkg/apk sign; `tests/sdk-matrix-digests.test.sh` |
 | Signing-secret containers have no network | `host` | `docker run --network none` on validate usign check and opkg/apk sign steps (Compose v2 has no `--network` on `compose run`); same test |
+| Signing secrets stay 0600 through validate-feed-keys rewrite prefix (decode/normalize/chmod) | `host` | `tests/validate-feed-keys-mode.test.sh` — mirrors validate path without SDK pull; full docker usign sign on next `v*` still prove-next |
 | `ipkg-make-index.sh` pinned to a commit SHA and sha256-verified | `manual` | `feed_publish_ipkg_index_script` |
 | Only public keys reach `feed-staging/` | `manual` | `feed_publish_copy_keys` |
 | Signing secrets are mode 0600 | `host` | `tests/feed-keys-mode.test.sh` — both storage formats under umask 022 |
@@ -127,7 +129,7 @@ should carry a note saying what would raise it.
 
 | ID | Severity | Issue | Summary | Verified |
 |----|----------|-------|---------|----------|
-| B-1 | Low | `wan_firewall_zone_same` class-matched any `name=wan` zone | Canonical `uci -X` cfg id compare; duplicate wan `.log` stays foreign | 2026-09-03 |
+| B-1 | Low | `wan_firewall_zone_same` class-matched any `name=wan` zone | Canonical `uci -X` cfg id compare; duplicate wan `.log` stays foreign | 2026-09-03 — multi-model audit |
 | [#204](https://github.com/lucas-albers-lz4/fwlive/issues/204) | Low | Predictable lock path opened O_TRUNC without symlink check | Lock under `/etc/fwlive/`; `acquire_wan_log_lock` rejects `-L` before create/tighten/open; Part E | 2026-08-23 — security-audit PR |
 | [#205](https://github.com/lucas-albers-lz4/fwlive/issues/205) | Low | Unpinned `@playwright/mcp@latest` in `.cursor/mcp.json` | MCP entry removed; tests use pinned `playwright@1.60.0` | 2026-08-23 — security-audit PR |
 | [#190](https://github.com/lucas-albers-lz4/fwlive/issues/190) | Low | `is_resolvable_address` hostname-shaped tokens | Strict IPv4/IPv6 validation + selftest cases | merged 2026-08-21 |
@@ -148,18 +150,22 @@ Known, judged acceptable. Reopen only with new evidence.
 ## What this pass could not prove
 
 Honest gaps, so the next pass starts here rather than rediscovering them.
+Lab runner: `./scripts/qemu-security-gaps-smoke.sh` (gaps 1–3). Host validate
+path: `tests/validate-feed-keys-mode.test.sh` (gap 4 prefix; wired into
+`./scripts/fwlive-test.sh`).
 
 | Property | Status | What would prove it |
 |----------|--------|---------------------|
-| `resolve` really returns within its budget on a loaded router | cannot-prove on host | Lab: flood `fwlive.resolve` with unresolvable addresses, measure wall time |
-| The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host | Lab: hold the lock from an unprivileged shell, call the toggle, observe rpcd |
-| `uci commit firewall` scope on a live device | prove-next | Lab: stage an unrelated `firewall` delta over SSH, toggle logging, check whether it committed — **host-level fix landed 2026-08-21 (#191), tightened 2026-08-23**: staging+commit moved inside `commit_wan_log_change` behind (1) a pre-stage `firewall_changes_pending` re-check and (2) a post-stage check that aborts and undoes only our log delta when foreign staging appears after `uci set`/`delete` (never `uci revert firewall` on foreign data); commit-failure path reverts ONLY when our option is the sole staged delta; post-commit read-back verification; residual window is a writer staging between the post-stage check and `uci commit` (or same-option races on `firewall.<wan>.log`) — narrowed to the minimum UCI allows; lab confirmation still pending |
-| Signing keys stay 0600 through a full publish | prove-next | The host test in [#165](https://github.com/lucas-albers-lz4/fwlive/issues/165) covers the library; a real run also passes through `validate-feed-keys.sh` |
+| `resolve` really returns within its budget on a loaded router | cannot-prove on host — **script ready** | Lab: `./scripts/qemu-security-gaps-smoke.sh` (flood `fwlive.resolve`, wall clock ≤ slack) |
+| The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host — **script ready**; BusyBox has no `flock -w` (accepted residual if client times out) | Lab: same script holds root flock, calls enable with client timeout; also asserts unprivileged cannot `LOCK_EX` |
+| `uci commit firewall` scope on a live device | prove-next — **script ready** | Lab: same script stages foreign `firewall` delta, expects `firewall_changes_pending`, marker not committed — **host-level fix landed 2026-08-21 (#191), tightened 2026-08-23**; residual window documented in prior entry |
+| Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + decode/normalize/chmod mirror of `validate-feed-keys.sh` (no SDK pull). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
 
 ## Review procedure
 
 The *how* lives in
-[`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md).
+[`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md)
+(including § Multi-model pass for gaps → delta → gated full pass).
 This section covers only what a pass owes this file.
 
 A pass is not finished until it has:
@@ -377,10 +383,21 @@ links to this ledger for review state.
 
 **Fix.** `[ -O ]` for euid ownership; `find -prune \( -perm -020 -o -perm -002 \)` for group/other write. No `stat`. Part F in `fwlive-logging-lock.test.sh` shadows `stat` on `PATH`.
 
-### 2026-09-03 — B-1 canonical WAN zone identity
+### 2026-09-03 — Multi-model VVAH pass (playbook + delta + B-1)
 
-**Scope.** Fable Stage-2 review of hand-parsed `uci changes` grammar for WAN log commit scope (`wan_firewall_zone_same`).
+**Scope.** Document portable multi-model audit (fwlive skill + usrmanage twin); Stage 0 seed; Stage 1 delta packets (warnings UI, zone grammar, Wave B harness, Stage-0 class memory); Fable Stage 2 on flagged packets; validation panel; Composer fix for B-1. Honest-gap lab scripts landed (QEMU not available this pass).
 
-**Finding.** Class-match on `name=wan` + type `zone` treated any two wan zones as the same section, so a foreign staged `firewall.<dup>.log=` line could ride `uci commit firewall` (Low; admin + duplicate-zone misconfiguration).
+**Method.** Deterministic greps + `./scripts/fwlive-test.sh` / shellcheck; Grok+Luna job packets; Fable 5.1 Engineer Mode on UCI grammar + Wave B proof boundary; Luna validation panel on B-1.
 
-**Fix.** `uci_canonical_firewall_section` via `uci -X show`; identity is equal canonical cfg ids. Host test: duplicate wan foreign `.log` stays foreign; `@zone[N]`↔cfg bridge preserved.
+**Finding fixed in-tree (no public issue — Low, fixed same pass).**
+
+- **B-1** — `wan_firewall_zone_same` treated any `name=wan` zone as identical; duplicate wan `.log` deltas could ride a commit. Now compares canonical cfg ids via `uci -X show`. Host test covers duplicate-wan foreign line.
+
+**Non-findings**
+
+- `#fwlive-backend` / `timeout_missing`: `textContent` + allowlisted `_()` strings only.
+- Wave B Playwright: UX contract only; XSS SoT remains recording-`innerHTML` harness (Fable NON-FINDING).
+- Stage-0 class memory: no new `${{ }}` in `run:`, no new temp-mode/pin regressions in delta.
+- UCI `.log_*` near-miss grammar (#257) holds under Fable checklist.
+
+**Full-pass gate.** Deferred — no class bug beyond B-1 (fixed), no high/medium blast radius, pin ritual not due until next `v*` tag. Next: QEMU `qemu-security-gaps-smoke.sh` for gaps 1–3.

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -3,7 +3,7 @@
 > **Status:** 43 controls in force; 0 open findings.
 > **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
 > **Open:** none.
-> **Next:** on QEMU, run `./scripts/qemu-security-gaps-smoke.sh` as a lab *smoke* (resolve responsiveness; unprivileged lock deny; pre-stage `firewall_changes_pending` refuse) — do **not** auto-promote gap 2 flock residual or #191 post-stage window to `lab` from a green run; re-check pins + full docker usign on next `v*` tag; **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate).
+> **Next:** on QEMU, run `./scripts/qemu-security-gaps-smoke.sh` as a lab *smoke* (resolve responsiveness; unprivileged lock deny; pre-stage `firewall_changes_pending` refuse) — do **not** auto-promote gap 2 flock residual to `lab` from a green run; re-check pins + full docker usign on next `v*` tag; **full surface re-pass deferred** (gate criteria not met — see skill § Multi-model pass / full-pass gate).
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass (VVAH-style): [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
 
 What has been reviewed, when, with what strength of proof, and what is still
@@ -145,6 +145,7 @@ Known, judged acceptable. Reopen only with new evidence.
 | Any local UID can inject syslog lines that pass the firewall classifier | `logd` chmods its socket 0666 upstream (ubox `log/syslog.c`). Not fixable from this package; the consequence is forged rows in the view, and every field is already rendered as text |
 | `date +%s` can jump under NTP sync, over- or under-running `RESOLVE_BUDGET` | Worker starvation is still prevented, which is the property the budget exists for |
 | A LuCI admin session is root-equivalent | Structural to LuCI. It is the reason script execution on this page is treated as a root compromise, not a lesser bug |
+| `uci commit firewall` is package-wide ([#191](https://github.com/lucas-albers-lz4/fwlive/issues/191) residual) | OpenWrt has no option-scoped commit. Pre/post-stage gates refuse when foreign staging is visible; a second privileged writer can still stage in the tiny window before commit and ride the same publish — two root processes publishing each other's already-staged work. Unprivileged staging is blocked by libuci dir modes. Reopen only with an unprivileged or cross-session path. |
 | `feed_publish_ensure_usign` leaves its build dir for the process lifetime | `PATH` points into it and `usign` is called later; the name is unpredictable per invocation, and `/tmp` is reaped on reboot |
 
 ## What this pass could not prove
@@ -158,7 +159,7 @@ path: `tests/validate-feed-keys-mode.test.sh` (gap 4 prefix; wired into
 |----------|--------|---------------------|
 | `resolve` really returns within its budget on a loaded router | cannot-prove on host — **smoke script ready** | Lab: `./scripts/qemu-security-gaps-smoke.sh` flood is a responsiveness smoke (not blackhole-DNS proof of `RESOLVE_BUDGET`) |
 | The rpcd script timeout actually bounds a blocked `flock` waiter | cannot-prove on host — **smoke script ready**; BusyBox has no `flock -w` (**accepted residual** if client times out) | Lab: same script holds root flock + host-side client timeout; documents residual, does not clear it |
-| `uci commit firewall` scope on a live device | prove-next — **smoke script ready** (pre-stage refuse only) | Lab: same script stages foreign delta, expects `firewall_changes_pending`; does **not** cover #191 residual post-stage→commit window |
+| Pre-stage `firewall_changes_pending` refuse on a live device | optional lab smoke (**accepted residual** for package-commit ride-along — see above) | Lab: same script stages foreign delta, expects refuse; residual is architectural, not prove-next |
 | Signing keys stay 0600 through validate rewrite path | `host` (validate-prefix) | `tests/validate-feed-keys-mode.test.sh` — write + decode/normalize/chmod mirror of `validate-feed-keys.sh` (no SDK pull). **Full usign docker sign + real publish** still prove-next on next `v*` tag |
 
 ## Review procedure

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -104,6 +104,9 @@ bash tests/sdk-matrix-cache-owner.test.sh
 echo "== fwlive feed-keys mode (0600) ==" >&2
 bash tests/feed-keys-mode.test.sh
 
+echo "== fwlive validate-feed-keys mode path (0600) ==" >&2
+bash tests/validate-feed-keys-mode.test.sh
+
 echo "== fwlive fetch-pin gate ==" >&2
 bash tests/fetch-pin-gate.test.sh
 

--- a/scripts/lib/feed-keys.sh
+++ b/scripts/lib/feed-keys.sh
@@ -111,3 +111,23 @@ feed_keys_write_from_env() {
 	# Re-assert after normalize/decode (mv can discard a prior chmod).
 	chmod 600 "${dest}/opkg-secret.key" "${dest}/apk-secret.rsa"
 }
+
+# Decode + normalize + chmod only — the rewrite prefix shared by
+# validate-feed-keys.sh before docker usign / openssl proofs (issue #165).
+feed_keys_validate_opkg_rewrite_prefix() {
+	local secret="$1" public="$2"
+	[[ -f "$secret" && -f "$public" ]] || return 1
+	feed_keys_maybe_decode_base64 "$secret"
+	feed_keys_maybe_decode_base64 "$public"
+	feed_keys_normalize_usign_secret "$secret" || return 1
+	feed_keys_normalize_usign_keyfile "$public" || return 1
+	chmod 600 "$secret"
+}
+
+feed_keys_validate_apk_rewrite_prefix() {
+	local secret="$1" public="$2"
+	[[ -f "$secret" && -f "$public" ]] || return 1
+	feed_keys_maybe_decode_base64 "$secret"
+	feed_keys_maybe_decode_base64 "$public"
+	chmod 600 "$secret"
+}

--- a/scripts/lib/feed-keys.sh
+++ b/scripts/lib/feed-keys.sh
@@ -114,20 +114,51 @@ feed_keys_write_from_env() {
 
 # Decode + normalize + chmod only — the rewrite prefix shared by
 # validate-feed-keys.sh before docker usign / openssl proofs (issue #165).
+# Each step prints which key/step failed so publish CI can name the bad input.
 feed_keys_validate_opkg_rewrite_prefix() {
 	local secret="$1" public="$2"
-	[[ -f "$secret" && -f "$public" ]] || return 1
-	feed_keys_maybe_decode_base64 "$secret"
-	feed_keys_maybe_decode_base64 "$public"
-	feed_keys_normalize_usign_secret "$secret" || return 1
-	feed_keys_normalize_usign_keyfile "$public" || return 1
-	chmod 600 "$secret"
+	[[ -f "$secret" && -f "$public" ]] || {
+		echo "feed-keys: missing OPKG secret or public key file" >&2
+		return 1
+	}
+	feed_keys_maybe_decode_base64 "$secret" || {
+		echo "feed-keys: decode OPKG_FEED_SECRET_KEY (base64) failed" >&2
+		return 1
+	}
+	feed_keys_maybe_decode_base64 "$public" || {
+		echo "feed-keys: decode OPKG_FEED_PUBLIC_KEY (base64) failed" >&2
+		return 1
+	}
+	feed_keys_normalize_usign_secret "$secret" || {
+		echo "feed-keys: normalize OPKG_FEED_SECRET_KEY failed" >&2
+		return 1
+	}
+	feed_keys_normalize_usign_keyfile "$public" || {
+		echo "feed-keys: normalize OPKG_FEED_PUBLIC_KEY failed" >&2
+		return 1
+	}
+	chmod 600 "$secret" || {
+		echo "feed-keys: chmod 600 OPKG_FEED_SECRET_KEY failed" >&2
+		return 1
+	}
 }
 
 feed_keys_validate_apk_rewrite_prefix() {
 	local secret="$1" public="$2"
-	[[ -f "$secret" && -f "$public" ]] || return 1
-	feed_keys_maybe_decode_base64 "$secret"
-	feed_keys_maybe_decode_base64 "$public"
-	chmod 600 "$secret"
+	[[ -f "$secret" && -f "$public" ]] || {
+		echo "feed-keys: missing APK secret or public key file" >&2
+		return 1
+	}
+	feed_keys_maybe_decode_base64 "$secret" || {
+		echo "feed-keys: decode APK_FEED_SECRET_KEY (base64) failed" >&2
+		return 1
+	}
+	feed_keys_maybe_decode_base64 "$public" || {
+		echo "feed-keys: decode APK_FEED_PUBLIC_KEY (base64) failed" >&2
+		return 1
+	}
+	chmod 600 "$secret" || {
+		echo "feed-keys: chmod 600 APK_FEED_SECRET_KEY failed" >&2
+		return 1
+	}
 }

--- a/scripts/qemu-security-gaps-smoke.sh
+++ b/scripts/qemu-security-gaps-smoke.sh
@@ -2,7 +2,7 @@
 # Lab proofs for honest gaps in docs/developer/security-review.md:
 #   1. resolve wall-clock budget under flood
 #   2. flock hold vs enable_wan_logging (BusyBox flock has no -w)
-#   3. live uci commit firewall scope (foreign staged delta must not commit)
+#   3. pre-stage firewall_changes_pending refuse (package-commit ride-along = accepted residual)
 #
 #   ./scripts/qemu-security-gaps-smoke.sh
 #   OPENWRT_SSH_PORT=2222 ./scripts/qemu-security-gaps-smoke.sh

--- a/scripts/qemu-security-gaps-smoke.sh
+++ b/scripts/qemu-security-gaps-smoke.sh
@@ -30,10 +30,15 @@ ssh_guest() {
 
 echo "== fwlive security-gaps smoke (root@${HOST}:${PORT}) ==" >&2
 
+command -v timeout >/dev/null 2>&1 \
+	|| die "host 'timeout' required (bounds flock/ubus client wait)"
+
 ssh_guest 'echo connected' >/dev/null 2>&1 \
 	|| die "SSH unreachable — start QEMU and install fwlive first"
 ssh_guest 'command -v ubus >/dev/null && test -x /usr/libexec/rpcd/fwlive' \
 	|| die "fwlive rpcd plugin missing"
+ssh_guest 'command -v su >/dev/null' \
+	|| die "guest 'su' required for unprivileged flock probe"
 
 # --- Gap 1: resolve responsiveness (budget smoke) ---------------------------
 # Flood with RESOLVE_MAX addresses. This is a wall-clock responsiveness smoke
@@ -56,28 +61,28 @@ ok "resolve flood returned in ${ELAPSED_SEC}s (<= ${RESOLVE_SLACK_SEC}s)"
 LOCK_PATH=/etc/fwlive/logging.lock
 ssh_guest "test -d /etc/fwlive || mkdir -p /etc/fwlive; touch '$LOCK_PATH'; chmod 0600 '$LOCK_PATH'"
 
-# Unprivileged probe: nobody (or create fwlivegap)
-UNPRIV_RC="$(ssh_guest 'id nobody >/dev/null 2>&1 || adduser -D -H -s /bin/false fwlivegap 2>/dev/null || true
+# Unprivileged probe: nobody (or create fwlivegap). Fail closed if no usable user.
+UNPRIV_RC="$(ssh_guest '
+id nobody >/dev/null 2>&1 || adduser -D -H -s /bin/false fwlivegap >/dev/null || exit 42
 USER=nobody
 id nobody >/dev/null 2>&1 || USER=fwlivegap
-su -s /bin/sh "$USER" -c "flock -n /etc/fwlive/logging.lock true" >/dev/null 2>&1; echo $?' || echo 1)"
+id "$USER" >/dev/null || exit 42
+su -s /bin/sh "$USER" -c "flock -n /etc/fwlive/logging.lock true" >/dev/null 2>&1
+echo $?
+' || echo SETUP_FAIL)"
+[[ "$UNPRIV_RC" != "SETUP_FAIL" && "$UNPRIV_RC" != "42" && "$UNPRIV_RC" != "" ]] \
+	|| die "unprivileged flock probe setup failed (need nobody or adduser + su)"
 [[ "$UNPRIV_RC" != "0" ]] \
 	|| die "unprivileged flock -n on logging.lock succeeded (expected fail)"
 ok "unprivileged cannot LOCK_EX logging.lock (rc=${UNPRIV_RC})"
 
-# Root holder blocks; call enable with client-side timeout.
+# Root holder blocks; call enable with host-side timeout (required above).
 ssh_guest "flock '$LOCK_PATH' sleep 120" >/dev/null 2>&1 &
 HOLDER_PID=$!
 sleep 1
 set +e
-# Prefer host-side timeout (guest may lack timeout → timeout_missing).
-if command -v timeout >/dev/null 2>&1; then
-	ENABLE_OUT="$(timeout "${FLOCK_WAIT_SEC}" ssh "${SSH_OPTS[@]}" "root@${HOST}" "ubus call fwlive enable_wan_logging" 2>&1)"
-	ENABLE_RC=$?
-else
-	ENABLE_OUT="$(ssh_guest "ubus call fwlive enable_wan_logging" 2>&1)"
-	ENABLE_RC=$?
-fi
+ENABLE_OUT="$(timeout "${FLOCK_WAIT_SEC}" ssh "${SSH_OPTS[@]}" "root@${HOST}" "ubus call fwlive enable_wan_logging" 2>&1)"
+ENABLE_RC=$?
 set -e
 kill "$HOLDER_PID" 2>/dev/null || true
 wait "$HOLDER_PID" 2>/dev/null || true
@@ -103,8 +108,10 @@ ssh_guest "flock -n '$LOCK_PATH' true" >/dev/null 2>&1 \
 ZONE="$(ssh_guest "uci -q show firewall | sed -n \"s/^firewall\\.\\([^.]*\\)\\.name='wan'\$/\\1/p\" | head -1")"
 [[ -n "$ZONE" ]] || die "no WAN zone in firewall config"
 
-# Clean slate
-ssh_guest 'uci revert firewall 2>/dev/null || true; uci commit firewall 2>/dev/null || true'
+# Refuse to wipe operator staging — abort if firewall already has pending changes.
+EXISTING_CHANGES="$(ssh_guest 'uci changes firewall 2>/dev/null || true')"
+[[ -z "${EXISTING_CHANGES//[$'\t\r\n ']/}" ]] \
+	|| die "firewall already has staged changes; abort (will not uci revert): $EXISTING_CHANGES"
 
 # Stage an unrelated option (not the WAN log bit)
 MARKER="fwlive_gap_marker_$$"

--- a/scripts/qemu-security-gaps-smoke.sh
+++ b/scripts/qemu-security-gaps-smoke.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Lab proofs for honest gaps in docs/developer/security-review.md:
+#   1. resolve wall-clock budget under flood
+#   2. flock hold vs enable_wan_logging (BusyBox flock has no -w)
+#   3. live uci commit firewall scope (foreign staged delta must not commit)
+#
+#   ./scripts/qemu-security-gaps-smoke.sh
+#   OPENWRT_SSH_PORT=2222 ./scripts/qemu-security-gaps-smoke.sh
+#
+# Prereqs: QEMU guest up with luci-app-fwlive installed (qemu-smoke-fwlive.sh OK).
+# Gap 4 (signing keys through validate/publish) is host-side:
+#   tests/validate-feed-keys-mode.test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST="${OPENWRT_HOST:-127.0.0.1}"
+PORT="${OPENWRT_SSH_PORT:-2222}"
+# Lab guests often use ephemeral keys; this script is lab-only.
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -p "$PORT")
+# RESOLVE_BUDGET=5 + one in-flight RESOLVE_TIMEOUT=1 → ~6s; allow NTP/SSH slack.
+RESOLVE_SLACK_SEC="${RESOLVE_SLACK_SEC:-8}"
+FLOCK_WAIT_SEC="${FLOCK_WAIT_SEC:-12}"
+
+die() { echo "security-gaps smoke FAIL: $*" >&2; exit 1; }
+ok() { echo "security-gaps smoke OK: $*"; }
+
+ssh_guest() {
+	ssh "${SSH_OPTS[@]}" "root@${HOST}" "$@"
+}
+
+echo "== fwlive security-gaps smoke (root@${HOST}:${PORT}) ==" >&2
+
+ssh_guest 'echo connected' >/dev/null 2>&1 \
+	|| die "SSH unreachable — start QEMU and install fwlive first"
+ssh_guest 'command -v ubus >/dev/null && test -x /usr/libexec/rpcd/fwlive' \
+	|| die "fwlive rpcd plugin missing"
+
+# --- Gap 1: resolve budget -------------------------------------------------
+# Flood with RESOLVE_MAX unresolvable RFC5737 TEST-NET addresses; wall clock
+# must stay under RESOLVE_BUDGET + one lookup + slack (~8s default).
+ADDR_JSON='["203.0.113.1","203.0.113.2","203.0.113.3","203.0.113.4","203.0.113.5","203.0.113.6","203.0.113.7","203.0.113.8","203.0.113.9","203.0.113.10","203.0.113.11","203.0.113.12","203.0.113.13","203.0.113.14","203.0.113.15","203.0.113.16","203.0.113.17","203.0.113.18","203.0.113.19","203.0.113.20","203.0.113.21","203.0.113.22","203.0.113.23","203.0.113.24","203.0.113.25","203.0.113.26","203.0.113.27","203.0.113.28","203.0.113.29","203.0.113.30","203.0.113.31","203.0.113.32"]'
+START_S="$(date +%s)"
+ssh_guest "ubus call fwlive resolve '{\"addresses\":${ADDR_JSON}}'" >/dev/null \
+	|| die "fwlive.resolve flood failed"
+END_S="$(date +%s)"
+ELAPSED_SEC=$((END_S - START_S))
+[[ "$ELAPSED_SEC" -le "$RESOLVE_SLACK_SEC" ]] \
+	|| die "resolve flood took ${ELAPSED_SEC}s (limit ${RESOLVE_SLACK_SEC}s; RESOLVE_BUDGET=5 + lookup slack)"
+ok "resolve flood returned in ${ELAPSED_SEC}s (<= ${RESOLVE_SLACK_SEC}s)"
+
+# --- Gap 2: flock hold vs toggle -------------------------------------------
+# Unprivileged UID must not acquire LOCK_EX on the 0600 lock (#167).
+# A stuck *root* holder blocks BusyBox flock (no -w); ubus client must not
+# hang forever — we bound the client wait and record whether rpcd returns.
+LOCK_PATH=/etc/fwlive/logging.lock
+ssh_guest "test -d /etc/fwlive || mkdir -p /etc/fwlive; touch '$LOCK_PATH'; chmod 0600 '$LOCK_PATH'"
+
+# Unprivileged probe: nobody (or create fwlivegap)
+UNPRIV_RC="$(ssh_guest 'id nobody >/dev/null 2>&1 || adduser -D -H -s /bin/false fwlivegap 2>/dev/null || true
+USER=nobody
+id nobody >/dev/null 2>&1 || USER=fwlivegap
+su -s /bin/sh "$USER" -c "flock -n /etc/fwlive/logging.lock true" >/dev/null 2>&1; echo $?' || echo 1)"
+[[ "$UNPRIV_RC" != "0" ]] \
+	|| die "unprivileged flock -n on logging.lock succeeded (expected fail)"
+ok "unprivileged cannot LOCK_EX logging.lock (rc=${UNPRIV_RC})"
+
+# Root holder blocks; call enable with client-side timeout.
+ssh_guest "flock '$LOCK_PATH' sleep 120" >/dev/null 2>&1 &
+HOLDER_PID=$!
+sleep 1
+set +e
+ENABLE_OUT="$(ssh_guest "timeout ${FLOCK_WAIT_SEC} ubus call fwlive enable_wan_logging" 2>&1)"
+ENABLE_RC=$?
+set -e
+kill "$HOLDER_PID" 2>/dev/null || true
+wait "$HOLDER_PID" 2>/dev/null || true
+# Release any leftover lock from the sleep if still held
+ssh_guest "flock -u '$LOCK_PATH' true 2>/dev/null || true; true" >/dev/null 2>&1 || true
+
+if [[ "$ENABLE_RC" -eq 124 ]]; then
+	# Client timeout fired — rpcd worker still blocked on flock (accepted residual:
+	# BusyBox flock has no -w; document as proven observation, not a pass).
+	ok "stuck root flock holder: ubus client timed out after ${FLOCK_WAIT_SEC}s (rpcd not bounded by flock -w; residual holds)"
+	echo "security-gaps NOTE: flock/rpcd bound = residual (BusyBox no flock -w); proof class stays documented" >&2
+elif printf '%s' "$ENABLE_OUT" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*(true|false)'; then
+	ok "enable returned while lock contention resolved or failed closed: $ENABLE_OUT"
+else
+	die "unexpected enable under lock hold (rc=${ENABLE_RC}): $ENABLE_OUT"
+fi
+
+# Ensure lock released for gap 3
+ssh_guest "flock -n '$LOCK_PATH' true" >/dev/null 2>&1 \
+	|| ssh_guest "rm -f '$LOCK_PATH'; mkdir -p /etc/fwlive; touch '$LOCK_PATH'; chmod 0600 '$LOCK_PATH'"
+
+# --- Gap 3: foreign firewall staging must not be committed -----------------
+ZONE="$(ssh_guest "uci -q show firewall | sed -n \"s/^firewall\\.\\([^.]*\\)\\.name='wan'\$/\\1/p\" | head -1")"
+[[ -n "$ZONE" ]] || die "no WAN zone in firewall config"
+
+# Clean slate
+ssh_guest 'uci revert firewall 2>/dev/null || true; uci commit firewall 2>/dev/null || true'
+
+# Stage an unrelated option (not the WAN log bit)
+MARKER="fwlive_gap_marker_$$"
+ssh_guest "uci set firewall.@defaults[0].fwlive_gap_test='${MARKER}'" \
+	|| die "could not stage foreign firewall delta"
+
+EN="$(ssh_guest 'ubus call fwlive enable_wan_logging' 2>&1 || true)"
+printf '%s' "$EN" | grep -Eq 'firewall_changes_pending' \
+	|| die "expected firewall_changes_pending when foreign delta staged; got: $EN"
+ok "enable refused with firewall_changes_pending under foreign staging"
+
+# Foreign delta must still be staged (not committed away / not applied as committed-only)
+STAGED="$(ssh_guest 'uci changes firewall' || true)"
+printf '%s' "$STAGED" | grep -q "$MARKER" \
+	|| die "foreign staged marker missing after refuse (uci changes: $STAGED)"
+COMMITTED="$(ssh_guest "uci -q get firewall.@defaults[0].fwlive_gap_test || true")"
+[[ "$COMMITTED" != "$MARKER" ]] \
+	|| die "foreign marker was committed to saved config"
+ok "foreign staged delta neither committed nor dropped by toggle refuse"
+
+ssh_guest 'uci revert firewall 2>/dev/null || true'
+
+echo "== security-gaps smoke passed ==" >&2

--- a/scripts/qemu-security-gaps-smoke.sh
+++ b/scripts/qemu-security-gaps-smoke.sh
@@ -85,16 +85,25 @@ ok "unprivileged cannot LOCK_EX logging.lock (rc=${UNPRIV_RC})"
 
 # Root holder blocks; call enable with host-side timeout (required above).
 # The holder must outlive the ssh_guest bound — bypass it explicitly.
+# EXIT trap kills the holder if we die() between start and the explicit release.
+release_flock_holder() {
+	if [[ -n "${HOLDER_PID:-}" ]]; then
+		kill "$HOLDER_PID" 2>/dev/null || true
+		wait "$HOLDER_PID" 2>/dev/null || true
+		HOLDER_PID=
+	fi
+}
 FWLIVE_SSH_NO_TIMEOUT=1 ssh_guest "flock '$LOCK_PATH' sleep 120" >/dev/null 2>&1 &
 HOLDER_PID=$!
+trap release_flock_holder EXIT
 unset FWLIVE_SSH_NO_TIMEOUT
 sleep 1
 set +e
 ENABLE_OUT="$(timeout "${FLOCK_WAIT_SEC}" ssh "${SSH_OPTS[@]}" "root@${HOST}" "ubus call fwlive enable_wan_logging" 2>&1)"
 ENABLE_RC=$?
 set -e
-kill "$HOLDER_PID" 2>/dev/null || true
-wait "$HOLDER_PID" 2>/dev/null || true
+release_flock_holder
+trap - EXIT
 
 if [[ "$ENABLE_RC" -eq 124 ]]; then
 	# Client timeout fired — rpcd worker still blocked on flock (accepted residual:

--- a/scripts/qemu-security-gaps-smoke.sh
+++ b/scripts/qemu-security-gaps-smoke.sh
@@ -35,9 +35,10 @@ ssh_guest 'echo connected' >/dev/null 2>&1 \
 ssh_guest 'command -v ubus >/dev/null && test -x /usr/libexec/rpcd/fwlive' \
 	|| die "fwlive rpcd plugin missing"
 
-# --- Gap 1: resolve budget -------------------------------------------------
-# Flood with RESOLVE_MAX unresolvable RFC5737 TEST-NET addresses; wall clock
-# must stay under RESOLVE_BUDGET + one lookup + slack (~8s default).
+# --- Gap 1: resolve responsiveness (budget smoke) ---------------------------
+# Flood with RESOLVE_MAX addresses. This is a wall-clock responsiveness smoke
+# against RESOLVE_BUDGET+slack — not a controlled blackhole-DNS proof. Prefer
+# non-routable TEST-NET; immediate NXDOMAIN still exercises the loop bound.
 ADDR_JSON='["203.0.113.1","203.0.113.2","203.0.113.3","203.0.113.4","203.0.113.5","203.0.113.6","203.0.113.7","203.0.113.8","203.0.113.9","203.0.113.10","203.0.113.11","203.0.113.12","203.0.113.13","203.0.113.14","203.0.113.15","203.0.113.16","203.0.113.17","203.0.113.18","203.0.113.19","203.0.113.20","203.0.113.21","203.0.113.22","203.0.113.23","203.0.113.24","203.0.113.25","203.0.113.26","203.0.113.27","203.0.113.28","203.0.113.29","203.0.113.30","203.0.113.31","203.0.113.32"]'
 START_S="$(date +%s)"
 ssh_guest "ubus call fwlive resolve '{\"addresses\":${ADDR_JSON}}'" >/dev/null \
@@ -69,8 +70,14 @@ ssh_guest "flock '$LOCK_PATH' sleep 120" >/dev/null 2>&1 &
 HOLDER_PID=$!
 sleep 1
 set +e
-ENABLE_OUT="$(ssh_guest "timeout ${FLOCK_WAIT_SEC} ubus call fwlive enable_wan_logging" 2>&1)"
-ENABLE_RC=$?
+# Prefer host-side timeout (guest may lack timeout → timeout_missing).
+if command -v timeout >/dev/null 2>&1; then
+	ENABLE_OUT="$(timeout "${FLOCK_WAIT_SEC}" ssh "${SSH_OPTS[@]}" "root@${HOST}" "ubus call fwlive enable_wan_logging" 2>&1)"
+	ENABLE_RC=$?
+else
+	ENABLE_OUT="$(ssh_guest "ubus call fwlive enable_wan_logging" 2>&1)"
+	ENABLE_RC=$?
+fi
 set -e
 kill "$HOLDER_PID" 2>/dev/null || true
 wait "$HOLDER_PID" 2>/dev/null || true
@@ -113,9 +120,10 @@ ok "enable refused with firewall_changes_pending under foreign staging"
 STAGED="$(ssh_guest 'uci changes firewall' || true)"
 printf '%s' "$STAGED" | grep -q "$MARKER" \
 	|| die "foreign staged marker missing after refuse (uci changes: $STAGED)"
-COMMITTED="$(ssh_guest "uci -q get firewall.@defaults[0].fwlive_gap_test || true")"
-[[ "$COMMITTED" != "$MARKER" ]] \
-	|| die "foreign marker was committed to saved config"
+# `uci get` includes staged values — inspect the committed file instead.
+COMMITTED="$(ssh_guest "grep -E \"option[[:space:]]+fwlive_gap_test[[:space:]]+'${MARKER}'\" /etc/config/firewall 2>/dev/null || true")"
+[[ -z "$COMMITTED" ]] \
+	|| die "foreign marker was written into committed /etc/config/firewall"
 ok "foreign staged delta neither committed nor dropped by toggle refuse"
 
 ssh_guest 'uci revert firewall 2>/dev/null || true'

--- a/scripts/qemu-security-gaps-smoke.sh
+++ b/scripts/qemu-security-gaps-smoke.sh
@@ -25,7 +25,14 @@ die() { echo "security-gaps smoke FAIL: $*" >&2; exit 1; }
 ok() { echo "security-gaps smoke OK: $*"; }
 
 ssh_guest() {
-	ssh "${SSH_OPTS[@]}" "root@${HOST}" "$@"
+	# ConnectTimeout bounds setup only — wrap the whole command so a hung
+	# guest cannot stall the lab run. Set FWLIVE_SSH_NO_TIMEOUT=1 for the
+	# intentional flock holder (sleep 120), which must outlive this bound.
+	if [[ -n "${FWLIVE_SSH_NO_TIMEOUT:-}" ]]; then
+		ssh "${SSH_OPTS[@]}" "root@${HOST}" "$@"
+	else
+		timeout "${SSH_TIMEOUT_SEC:-60}" ssh "${SSH_OPTS[@]}" "root@${HOST}" "$@"
+	fi
 }
 
 echo "== fwlive security-gaps smoke (root@${HOST}:${PORT}) ==" >&2
@@ -77,8 +84,10 @@ echo $?
 ok "unprivileged cannot LOCK_EX logging.lock (rc=${UNPRIV_RC})"
 
 # Root holder blocks; call enable with host-side timeout (required above).
-ssh_guest "flock '$LOCK_PATH' sleep 120" >/dev/null 2>&1 &
+# The holder must outlive the ssh_guest bound — bypass it explicitly.
+FWLIVE_SSH_NO_TIMEOUT=1 ssh_guest "flock '$LOCK_PATH' sleep 120" >/dev/null 2>&1 &
 HOLDER_PID=$!
+unset FWLIVE_SSH_NO_TIMEOUT
 sleep 1
 set +e
 ENABLE_OUT="$(timeout "${FLOCK_WAIT_SEC}" ssh "${SSH_OPTS[@]}" "root@${HOST}" "ubus call fwlive enable_wan_logging" 2>&1)"
@@ -86,8 +95,6 @@ ENABLE_RC=$?
 set -e
 kill "$HOLDER_PID" 2>/dev/null || true
 wait "$HOLDER_PID" 2>/dev/null || true
-# Release any leftover lock from the sleep if still held
-ssh_guest "flock -u '$LOCK_PATH' true 2>/dev/null || true; true" >/dev/null 2>&1 || true
 
 if [[ "$ENABLE_RC" -eq 124 ]]; then
 	# Client timeout fired — rpcd worker still blocked on flock (accepted residual:
@@ -100,9 +107,21 @@ else
 	die "unexpected enable under lock hold (rc=${ENABLE_RC}): $ENABLE_OUT"
 fi
 
-# Ensure lock released for gap 3
-ssh_guest "flock -n '$LOCK_PATH' true" >/dev/null 2>&1 \
-	|| ssh_guest "rm -f '$LOCK_PATH'; mkdir -p /etc/fwlive; touch '$LOCK_PATH'; chmod 0600 '$LOCK_PATH'"
+# Ensure lock released for gap 3 — same inode, never rm+recreate. A timed-out
+# rpcd worker may still hold the old fd; a new inode would split serialization.
+if ! ssh_guest "flock -n '$LOCK_PATH' true" >/dev/null 2>&1; then
+	RELEASED=0
+	for ((_i = 0; _i < 10; _i++)); do
+		sleep 1
+		if ssh_guest "flock -n '$LOCK_PATH' true" >/dev/null 2>&1; then
+			RELEASED=1
+			break
+		fi
+	done
+	[[ "$RELEASED" == "1" ]] \
+		|| die "logging.lock still held after holder kill (will not rm+recreate: stuck holder keeps old inode)"
+fi
+ok "logging.lock released on the same inode"
 
 # --- Gap 3: foreign firewall staging must not be committed -----------------
 ZONE="$(ssh_guest "uci -q show firewall | sed -n \"s/^firewall\\.\\([^.]*\\)\\.name='wan'\$/\\1/p\" | head -1")"
@@ -117,6 +136,9 @@ EXISTING_CHANGES="$(ssh_guest 'uci changes firewall 2>/dev/null || true')"
 MARKER="fwlive_gap_marker_$$"
 ssh_guest "uci set firewall.@defaults[0].fwlive_gap_test='${MARKER}'" \
 	|| die "could not stage foreign firewall delta"
+# Revert only what this script staged — a package-wide revert would discard
+# an unrelated delta staged after the empty-state check above.
+trap 'ssh_guest "uci revert firewall.@defaults[0].fwlive_gap_test 2>/dev/null || true" >/dev/null 2>&1 || true' EXIT
 
 EN="$(ssh_guest 'ubus call fwlive enable_wan_logging' 2>&1 || true)"
 printf '%s' "$EN" | grep -Eq 'firewall_changes_pending' \
@@ -133,6 +155,7 @@ COMMITTED="$(ssh_guest "grep -E \"option[[:space:]]+fwlive_gap_test[[:space:]]+'
 	|| die "foreign marker was written into committed /etc/config/firewall"
 ok "foreign staged delta neither committed nor dropped by toggle refuse"
 
-ssh_guest 'uci revert firewall 2>/dev/null || true'
+ssh_guest "uci revert firewall.@defaults[0].fwlive_gap_test 2>/dev/null || true"
+trap - EXIT
 
 echo "== security-gaps smoke passed ==" >&2

--- a/scripts/validate-feed-keys.sh
+++ b/scripts/validate-feed-keys.sh
@@ -21,7 +21,7 @@ validate_opkg_usign_key() {
 	require_file "$public" "OPKG_FEED_PUBLIC_KEY"
 
 	feed_keys_validate_opkg_rewrite_prefix "$secret" "$public" \
-		|| die "OPKG_FEED_SECRET_KEY / OPKG_FEED_PUBLIC_KEY must be a usign pair (usign -G) or base64 of those files (rewrite prefix failed)."
+		|| die "OPKG rewrite prefix failed (see feed-keys step above; expect usign -G pair or base64 of those files)."
 
 	# R7: pin the SDK digest at first pull *before* mounting the usign secret.
 	# sdk_matrix_resolve alone uses a mutable tag; a moved tag could exfiltrate
@@ -59,7 +59,7 @@ validate_apk_rsa_key() {
 	require_file "$public" "APK_FEED_PUBLIC_KEY"
 
 	feed_keys_validate_apk_rewrite_prefix "$secret" "$public" \
-		|| die "cannot decode/chmod APK_FEED_SECRET_KEY rewrite prefix"
+		|| die "APK rewrite prefix failed (see feed-keys step above)."
 
 	head -1 "$secret" | grep -q 'BEGIN.*PRIVATE KEY' \
 		|| die "APK_FEED_SECRET_KEY must be an RSA private key (openssl genrsa). Do not use the usign opkg secret here."

--- a/scripts/validate-feed-keys.sh
+++ b/scripts/validate-feed-keys.sh
@@ -20,14 +20,8 @@ validate_opkg_usign_key() {
 	require_file "$secret" "OPKG_FEED_SECRET_KEY"
 	require_file "$public" "OPKG_FEED_PUBLIC_KEY"
 
-	feed_keys_maybe_decode_base64 "$secret"
-	feed_keys_maybe_decode_base64 "$public"
-	feed_keys_normalize_usign_secret "$secret" \
-		|| die "OPKG_FEED_SECRET_KEY must be a usign secret (from: usign -G -s opkg-secret.key -p public.key). Paste both lines or base64-encode the file."
-	feed_keys_normalize_usign_keyfile "$public" \
-		|| die "OPKG_FEED_PUBLIC_KEY must be the matching usign public key (public.key from usign -G). Paste both lines or base64-encode the file."
-	# Decode/normalize rewrite via mv; re-assert secret mode (issue #165).
-	chmod 600 "$secret" || die "cannot chmod 600 OPKG_FEED_SECRET_KEY"
+	feed_keys_validate_opkg_rewrite_prefix "$secret" "$public" \
+		|| die "OPKG_FEED_SECRET_KEY / OPKG_FEED_PUBLIC_KEY must be a usign pair (usign -G) or base64 of those files (rewrite prefix failed)."
 
 	# R7: pin the SDK digest at first pull *before* mounting the usign secret.
 	# sdk_matrix_resolve alone uses a mutable tag; a moved tag could exfiltrate
@@ -64,9 +58,8 @@ validate_apk_rsa_key() {
 	require_file "$secret" "APK_FEED_SECRET_KEY"
 	require_file "$public" "APK_FEED_PUBLIC_KEY"
 
-	feed_keys_maybe_decode_base64 "$secret"
-	feed_keys_maybe_decode_base64 "$public"
-	chmod 600 "$secret" || die "cannot chmod 600 APK_FEED_SECRET_KEY"
+	feed_keys_validate_apk_rewrite_prefix "$secret" "$public" \
+		|| die "cannot decode/chmod APK_FEED_SECRET_KEY rewrite prefix"
 
 	head -1 "$secret" | grep -q 'BEGIN.*PRIVATE KEY' \
 		|| die "APK_FEED_SECRET_KEY must be an RSA private key (openssl genrsa). Do not use the usign opkg secret here."

--- a/tests/validate-feed-keys-mode.test.sh
+++ b/tests/validate-feed-keys-mode.test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Host proof: signing secrets stay mode 0600 through the validate-feed-keys
-# rewrite path (decode + normalize + chmod), not only feed_keys_write_from_env
-# (#165 library test). Does not pull an SDK image — the docker usign/sign step
-# remains a prove-next on the next real publish (or opt-in FWLIVE_VALIDATE_KEYS_DOCKER=1).
+# Host proof: signing secrets stay mode 0600 through the shared validate
+# rewrite prefix (decode + normalize + chmod) in feed-keys.sh — the same
+# helpers validate-feed-keys.sh runs before docker usign / openssl.
+# Does not pull an SDK image — full usign sign stays prove-next on publish.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,51 +28,61 @@ DEST=$(mktemp -d)
 trap 'rm -rf "$DEST"' EXIT
 umask 022
 
-OPKG_ONE_LINE='untrusted comment: fwlive validate-mode test RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
-OPKG_PUB_ONE_LINE='untrusted comment: fwlive validate-mode pub RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
-# Non-PEM placeholders — mode path only (openssl validate needs real RSA; that
-# stays on the library test + real publish).
-APK_PEM='fwlive-apk-test-secret-placeholder-not-a-key'
-APK_PUB_PEM='fwlive-apk-test-public-placeholder-not-a-key'
+# Two-line usign-shaped content, then base64 — exercises maybe_decode rewrite.
+OPKG_PLAIN=$(printf '%s\n%s\n' 'untrusted comment: fwlive validate-mode test' \
+	'RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV')
+OPKG_PUB_PLAIN=$(printf '%s\n%s\n' 'untrusted comment: fwlive validate-mode pub' \
+	'RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV')
+# Non-PEM placeholder (avoid gitleaks); decode still rewrites via mktemp+mv.
+APK_PLAIN='fwlive-apk-test-secret-placeholder-not-a-key'
+APK_PUB_PLAIN='fwlive-apk-test-public-placeholder-not-a-key'
 
-OPKG_SECRET="$OPKG_ONE_LINE" \
-	APK_SECRET="$APK_PEM" \
-	OPKG_PUB="$OPKG_PUB_ONE_LINE" \
-	APK_PUB="$APK_PUB_PEM" \
+b64() {
+	printf '%s' "$1" | base64 -w0 2>/dev/null || printf '%s' "$1" | base64
+}
+
+OPKG_SECRET="$(b64 "$OPKG_PLAIN")" \
+	APK_SECRET="$(b64 "$APK_PLAIN")" \
+	OPKG_PUB="$(b64 "$OPKG_PUB_PLAIN")" \
+	APK_PUB="$(b64 "$APK_PUB_PLAIN")" \
 	feed_keys_write_from_env "$DEST" \
 	|| bad "feed_keys_write_from_env"
 
 assert_600 "${DEST}/opkg-secret.key" "after write opkg-secret.key"
 assert_600 "${DEST}/apk-secret.rsa" "after write apk-secret.rsa"
 
-# Mirror validate_opkg_usign_key / validate_apk_rsa_key rewrite prefix (no docker).
-secret="${DEST}/opkg-secret.key"
-public="${DEST}/public.key"
-apk_secret="${DEST}/apk-secret.rsa"
+# Re-encode plain files so rewrite_prefix must take the base64 branch again.
+printf '%s' "$(b64 "$OPKG_PLAIN")" >"${DEST}/opkg-secret.key"
+printf '%s' "$(b64 "$OPKG_PUB_PLAIN")" >"${DEST}/public.key"
+printf '%s' "$(b64 "$APK_PLAIN")" >"${DEST}/apk-secret.rsa"
+printf '%s' "$(b64 "$APK_PUB_PLAIN")" >"${DEST}/fwlive-feed.rsa.pub"
+chmod 600 "${DEST}/opkg-secret.key" "${DEST}/apk-secret.rsa"
+# World-readable umask would have made 644; prove rewrite restores 600.
+chmod 644 "${DEST}/opkg-secret.key" "${DEST}/apk-secret.rsa" 2>/dev/null || true
+umask 022
 
-feed_keys_maybe_decode_base64 "$secret"
-feed_keys_maybe_decode_base64 "$public"
-feed_keys_normalize_usign_secret "$secret" \
-	|| bad "normalize usign secret"
-feed_keys_normalize_usign_keyfile "$public" \
-	|| bad "normalize usign public"
-chmod 600 "$secret" || bad "chmod 600 opkg secret after normalize"
-assert_600 "$secret" "after validate-prefix normalize opkg-secret.key"
+feed_keys_validate_opkg_rewrite_prefix \
+	"${DEST}/opkg-secret.key" "${DEST}/public.key" \
+	|| bad "feed_keys_validate_opkg_rewrite_prefix"
+assert_600 "${DEST}/opkg-secret.key" "after opkg rewrite_prefix"
 
-feed_keys_maybe_decode_base64 "$apk_secret"
-chmod 600 "$apk_secret" || bad "chmod 600 apk secret after decode"
-assert_600 "$apk_secret" "after validate-prefix apk-secret.rsa"
+feed_keys_validate_apk_rewrite_prefix \
+	"${DEST}/apk-secret.rsa" "${DEST}/fwlive-feed.rsa.pub" \
+	|| bad "feed_keys_validate_apk_rewrite_prefix"
+assert_600 "${DEST}/apk-secret.rsa" "after apk rewrite_prefix"
+
+head -1 "${DEST}/opkg-secret.key" | grep -q 'untrusted comment:' \
+	&& ok "opkg decode restored usign comment line" \
+	|| bad "opkg decode did not restore usign comment"
 
 [ -z "$(find "$DEST" -name '*.tmp' -print -quit)" ] \
-	&& ok "no leftover .tmp after validate-prefix" \
-	|| bad "leftover .tmp after validate-prefix"
+	&& ok "no leftover .tmp after rewrite_prefix" \
+	|| bad "leftover .tmp after rewrite_prefix"
+[ -z "$(find "$DEST" \( -name 'opkg-secret.key.*' -o -name 'apk-secret.rsa.*' \) -print -quit)" ] \
+	&& ok "no leftover mktemp sibling after rewrite_prefix" \
+	|| bad "leftover mktemp sibling after rewrite_prefix"
 
 if [[ "${FWLIVE_VALIDATE_KEYS_DOCKER:-0}" == "1" ]]; then
-	export OPKG_FEED_SECRET_KEY="${DEST}/opkg-secret.key"
-	export OPKG_FEED_PUBLIC_KEY="${DEST}/public.key"
-	export APK_FEED_SECRET_KEY="${DEST}/apk-secret.rsa"
-	export APK_FEED_PUBLIC_KEY="${DEST}/public.key"
-	# Real RSA required for apk path — skip docker unless operator supplies keys.
 	echo "skip: FWLIVE_VALIDATE_KEYS_DOCKER=1 needs real usign+RSA pair; use CI secrets on publish" >&2
 fi
 

--- a/tests/validate-feed-keys-mode.test.sh
+++ b/tests/validate-feed-keys-mode.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Host proof: signing secrets stay mode 0600 through the validate-feed-keys
+# rewrite path (decode + normalize + chmod), not only feed_keys_write_from_env
+# (#165 library test). Does not pull an SDK image — the docker usign/sign step
+# remains a prove-next on the next real publish (or opt-in FWLIVE_VALIDATE_KEYS_DOCKER=1).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/lib/feed-keys.sh
+source "${ROOT}/scripts/lib/feed-keys.sh"
+
+fail=0
+ok() { echo "ok: $*"; }
+bad() { echo "FAIL: $*" >&2; fail=1; }
+
+stat_mode() {
+	local m
+	m=$(stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1")
+	printf '%s' "$m" | sed 's/^0*//'
+}
+
+assert_600() {
+	local f="$1" label="$2"
+	[ "$(stat_mode "$f")" = "600" ] && ok "$label mode 600" || bad "$label mode $(stat_mode "$f")"
+}
+
+DEST=$(mktemp -d)
+trap 'rm -rf "$DEST"' EXIT
+umask 022
+
+OPKG_ONE_LINE='untrusted comment: fwlive validate-mode test RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
+OPKG_PUB_ONE_LINE='untrusted comment: fwlive validate-mode pub RWabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUV'
+# Non-PEM placeholders — mode path only (openssl validate needs real RSA; that
+# stays on the library test + real publish).
+APK_PEM='fwlive-apk-test-secret-placeholder-not-a-key'
+APK_PUB_PEM='fwlive-apk-test-public-placeholder-not-a-key'
+
+OPKG_SECRET="$OPKG_ONE_LINE" \
+	APK_SECRET="$APK_PEM" \
+	OPKG_PUB="$OPKG_PUB_ONE_LINE" \
+	APK_PUB="$APK_PUB_PEM" \
+	feed_keys_write_from_env "$DEST" \
+	|| bad "feed_keys_write_from_env"
+
+assert_600 "${DEST}/opkg-secret.key" "after write opkg-secret.key"
+assert_600 "${DEST}/apk-secret.rsa" "after write apk-secret.rsa"
+
+# Mirror validate_opkg_usign_key / validate_apk_rsa_key rewrite prefix (no docker).
+secret="${DEST}/opkg-secret.key"
+public="${DEST}/public.key"
+apk_secret="${DEST}/apk-secret.rsa"
+
+feed_keys_maybe_decode_base64 "$secret"
+feed_keys_maybe_decode_base64 "$public"
+feed_keys_normalize_usign_secret "$secret" \
+	|| bad "normalize usign secret"
+feed_keys_normalize_usign_keyfile "$public" \
+	|| bad "normalize usign public"
+chmod 600 "$secret" || bad "chmod 600 opkg secret after normalize"
+assert_600 "$secret" "after validate-prefix normalize opkg-secret.key"
+
+feed_keys_maybe_decode_base64 "$apk_secret"
+chmod 600 "$apk_secret" || bad "chmod 600 apk secret after decode"
+assert_600 "$apk_secret" "after validate-prefix apk-secret.rsa"
+
+[ -z "$(find "$DEST" -name '*.tmp' -print -quit)" ] \
+	&& ok "no leftover .tmp after validate-prefix" \
+	|| bad "leftover .tmp after validate-prefix"
+
+if [[ "${FWLIVE_VALIDATE_KEYS_DOCKER:-0}" == "1" ]]; then
+	export OPKG_FEED_SECRET_KEY="${DEST}/opkg-secret.key"
+	export OPKG_FEED_PUBLIC_KEY="${DEST}/public.key"
+	export APK_FEED_SECRET_KEY="${DEST}/apk-secret.rsa"
+	export APK_FEED_PUBLIC_KEY="${DEST}/public.key"
+	# Real RSA required for apk path — skip docker unless operator supplies keys.
+	echo "skip: FWLIVE_VALIDATE_KEYS_DOCKER=1 needs real usign+RSA pair; use CI secrets on publish" >&2
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+	echo "validate-feed-keys-mode: FAILED" >&2
+	exit 1
+fi
+echo "validate-feed-keys-mode: OK" >&2


### PR DESCRIPTION
## Summary
- Adds **Multi-model pass (VVAH-style)** to `.cursor/skills/security-audit/SKILL.md` (stages 0–3, Grok/Luna/Fable/Composer roles, Engineer Mode, full-pass gate).
- Lands `scripts/qemu-security-gaps-smoke.sh` (lab gaps 1–3) and `tests/validate-feed-keys-mode.test.sh` (gap 4 validate-prefix → `host`).
- Shared `feed_keys_validate_*_rewrite_prefix` helpers; fail-closed QEMU smoke prereqs.
- Ledger `Next:` records **full surface re-pass deferred**; points at the skill.
- CodeRabbit docs: quota pre-flight + one-trigger-only path.

Rebased onto `master` after B-1 (#267) landed; duplicate B-1 commits dropped.

## Test plan
- [x] `bash tests/validate-feed-keys-mode.test.sh`
- [x] `bash tests/feed-keys-mode.test.sh`
- [ ] `./scripts/fwlive-test.sh` in CI
- [x] Luna (REQUEST_CHANGES → grounded + fixed) + Bugbot (clean) before Ready
- [x] QEMU: `./scripts/qemu-security-gaps-smoke.sh` (2026-09-04; gaps 1–3 green; script hardened post-Luna)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved feed-key validation with clearer failure reporting and secure permission handling.
  - Added safeguards for security-gap smoke tests, including bounded remote commands and scoped cleanup.
  - Documented remaining security considerations and accepted limitations more clearly.

- **Documentation**
  - Expanded security-review procedures with multi-model audit phases and coverage requirements.
  - Added guidance for checking review quota status, polling completion, and handling rate limits.
  - Updated security model and audit records with current findings.

- **Testing**
  - Added automated coverage for feed-key permissions and security-gap smoke testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->