### PR TITLE
fix(ci): keep feed signing keys out of the workspace-mounted build containers

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -105,18 +105,25 @@ jobs:
           OPKG_PUB: ${{ secrets.OPKG_FEED_PUBLIC_KEY }}
           APK_PUB: ${{ secrets.APK_FEED_PUBLIC_KEY }}
         run: |
+          # Feed signing keys must NOT live in $GITHUB_WORKSPACE: the whole
+          # workspace is bind-mounted read-only into the network-attached SDK
+          # build containers (docker-compose.yml `sdk` service), whose copy-out
+          # step runs as root (sdk-matrix.sh). Secrets in the workspace are
+          # readable by root-capable code in those containers (#269). Write to
+          # $RUNNER_TEMP — no compose service mounts it.
           # shellcheck disable=SC2153 # env vars mapped from secrets above
           test -n "$OPKG_SECRET" && test -n "$APK_SECRET"
+          mkdir -p "${RUNNER_TEMP}/fwlive-keys"
           # shellcheck source=scripts/lib/feed-keys.sh
           source ./scripts/lib/feed-keys.sh
-          feed_keys_write_from_env "$GITHUB_WORKSPACE"
+          feed_keys_write_from_env "${RUNNER_TEMP}/fwlive-keys"
 
       - name: Validate signing keys
         env:
-          OPKG_FEED_SECRET_KEY: ${{ github.workspace }}/opkg-secret.key
-          OPKG_FEED_PUBLIC_KEY: ${{ github.workspace }}/public.key
-          APK_FEED_SECRET_KEY: ${{ github.workspace }}/apk-secret.rsa
-          APK_FEED_PUBLIC_KEY: ${{ github.workspace }}/fwlive-feed.rsa.pub
+          OPKG_FEED_SECRET_KEY: ${{ runner.temp }}/fwlive-keys/opkg-secret.key
+          OPKG_FEED_PUBLIC_KEY: ${{ runner.temp }}/fwlive-keys/public.key
+          APK_FEED_SECRET_KEY: ${{ runner.temp }}/fwlive-keys/apk-secret.rsa
+          APK_FEED_PUBLIC_KEY: ${{ runner.temp }}/fwlive-keys/fwlive-feed.rsa.pub
         run: ./scripts/validate-feed-keys.sh
 
       # #128: bind-mount .ci-sdk-cache into /builder/dl + /builder/feeds (no volume tar/copy).
@@ -151,6 +158,18 @@ jobs:
 
       - name: Build packages (21.02, 22.03, 23.05, 24.10, 25.12)
         run: |
+          set -euo pipefail
+          # #269 fail-closed: no signing-secret material may exist anywhere
+          # under the workspace, which is bind-mounted into the build
+          # containers. POSIX find (no -maxdepth/-quit GNU extensions); a find
+          # error aborts under set -e rather than being swallowed.
+          leaked="$(find "$GITHUB_WORKSPACE" -type f \
+            \( -name 'opkg-secret.key*' -o -name 'apk-secret.rsa*' -o -name 'public.key*' \
+               -o -name 'fwlive-feed.rsa.pub*' \) -print)"
+          if [[ -n "$leaked" ]]; then
+            echo "error: signing key material found in workspace before build: $leaked" >&2
+            exit 1
+          fi
           mkdir -p out
           for ver in 21.02 22.03 23.05 24.10 25.12; do
             echo "=== docker-sdk build: OpenWrt ${ver} ==="
@@ -184,10 +203,10 @@ jobs:
 
       - name: Stage signed feed
         env:
-          OPKG_FEED_SECRET_KEY: ${{ github.workspace }}/opkg-secret.key
-          OPKG_FEED_PUBLIC_KEY: ${{ github.workspace }}/public.key
-          APK_FEED_SECRET_KEY: ${{ github.workspace }}/apk-secret.rsa
-          APK_FEED_PUBLIC_KEY: ${{ github.workspace }}/fwlive-feed.rsa.pub
+          OPKG_FEED_SECRET_KEY: ${{ runner.temp }}/fwlive-keys/opkg-secret.key
+          OPKG_FEED_PUBLIC_KEY: ${{ runner.temp }}/fwlive-keys/public.key
+          APK_FEED_SECRET_KEY: ${{ runner.temp }}/fwlive-keys/apk-secret.rsa
+          APK_FEED_PUBLIC_KEY: ${{ runner.temp }}/fwlive-keys/fwlive-feed.rsa.pub
           FWLIVE_GIT_TAG: ${{ env.FWLIVE_RELEASE_TAG }}
         run: ./scripts/publish-packages.sh feed-staging
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -162,8 +162,10 @@ jobs:
           # #269 fail-closed: no signing-secret material may exist anywhere
           # under the workspace, which is bind-mounted into the build
           # containers. POSIX find (no -maxdepth/-quit GNU extensions); a find
-          # error aborts under set -e rather than being swallowed.
-          leaked="$(find "$GITHUB_WORKSPACE" -type f \
+          # error aborts under set -e rather than being swallowed. Matches
+          # regular files AND symlinks by key name — a symlink named like a key
+          # could point at key material under another filename (CodeRabbit).
+          leaked="$(find "$GITHUB_WORKSPACE" \( -type f -o -type l \) \
             \( -name 'opkg-secret.key*' -o -name 'apk-secret.rsa*' -o -name 'public.key*' \
                -o -name 'fwlive-feed.rsa.pub*' \) -print)"
           if [[ -n "$leaked" ]]; then
@@ -209,6 +211,14 @@ jobs:
           APK_FEED_PUBLIC_KEY: ${{ runner.temp }}/fwlive-keys/fwlive-feed.rsa.pub
           FWLIVE_GIT_TAG: ${{ env.FWLIVE_RELEASE_TAG }}
         run: ./scripts/publish-packages.sh feed-staging
+
+      # #269 (CodeRabbit): scrub the signing-key directory as soon as staging is
+      # done — nothing after this step needs the keys (release assets are
+      # already-signed artifacts from out/). if: always() also covers a staging
+      # failure so keys never survive a job.
+      - name: Remove temporary signing keys
+        if: always()
+        run: rm -rf "${RUNNER_TEMP}/fwlive-keys"
 
       - name: Deploy to GitHub Pages (fwlive-packages)
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0


### PR DESCRIPTION
## Summary

Prevents feed signing keys from being readable by the network-attached SDK build containers.

**Problem (issue #269):** the publish workflow wrote `opkg-secret.key` / `apk-secret.rsa` into `$GITHUB_WORKSPACE` at step "Write signing keys", which runs **before** the "Build packages" cells. The whole workspace is bind-mounted read-only into the `sdk` compose service (`docker-compose.yml:53`), which has normal network access, and `sdk_matrix_copy_out` runs inside it as `--user root` (`sdk-matrix.sh:608`). So root-capable code in those build containers — compromised pinned SDK image or feed recipe — can read the 0600 keys and exfiltrate them over the container network during a release build. Compromise of the signing keys lets an attacker sign arbitrary packages for the published fwlive feed.

**Fix:** move the keys out of the workspace entirely.

- `feed_keys_write_from_env` now writes to `$RUNNER_TEMP/fwlive-keys` — a path no compose service mounts.
- The "Validate signing keys" and "Stage signed feed" steps read keys from `$RUNNER_TEMP` (via `runner.temp`); the sign scripts already accept arbitrary absolute paths through `feed_publish_abspath`, so no script changes were needed.
- A fail-closed pre-build assert fails the job if any signing-secret file exists under `$GITHUB_WORKSPACE`.

This is stronger than the ordering fix usrmanage used for the same class (#159): keys never enter the mounted workspace at all, regardless of step order.

## Test plan
- [x] `actionlint .github/workflows/publish-packages.yml` clean
- [ ] `bash tests/feed-keys-mode.test.sh` (key mode path; unchanged by this fix)
- [ ] Verify on the next real `v*` publish (keys written/validated/staged from `$RUNNER_TEMP`)

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publishing security by storing signing keys in temporary runner storage instead of the workspace.
  * Builds now stop before packaging if unexpected signing-key material, including symlinks, is detected in the workspace.
  * Temporary signing-key files are removed after package feed staging is complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->