### PR TITLE
test(logging): pin timeout presence warning and run_with_timeout contract (#272)

### DIFF
--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -815,17 +815,23 @@ else
 fi
 
 # Gap 3: run_with_timeout contract, tested against the shipped text.
+# Exec/timeout halves need a real timeout binary; the fail-closed half
+# shadows it via the command stub below and runs everywhere.
 _run_with_timeout_src=$(sed -n '/^run_with_timeout()/,/^}/p' "$RPCD")
 [ -n "$_run_with_timeout_src" ] || die "run_with_timeout not found in $RPCD"
 eval "$_run_with_timeout_src"
 unset _run_with_timeout_src
-got=$(run_with_timeout 5 echo hello)
-[ "$got" = "hello" ] || die "run_with_timeout must exec with timeout present, got: $got"
-ok "run_with_timeout execs with timeout present"
-_rc=0
-run_with_timeout 1 sleep 5 2>/dev/null || _rc=$?
-[ "$_rc" -ne 0 ] && [ "$_rc" -ne 127 ] || die "run_with_timeout must time out (non-zero, not 127), got: $_rc"
-ok "run_with_timeout times out without running unbounded"
+if command -v timeout >/dev/null 2>&1; then
+	got=$(run_with_timeout 5 echo hello)
+	[ "$got" = "hello" ] || die "run_with_timeout must exec with timeout present, got: $got"
+	ok "run_with_timeout execs with timeout present"
+	_rc=0
+	run_with_timeout 1 sleep 5 2>/dev/null || _rc=$?
+	[ "$_rc" -ne 0 ] && [ "$_rc" -ne 127 ] || die "run_with_timeout must time out (non-zero, not 127), got: $_rc"
+	ok "run_with_timeout times out without running unbounded"
+else
+	ok "run_with_timeout exec/timeout skipped (no timeout on test host)"
+fi
 # command is a shell keyword, so command command reaches the real builtin.
 command() {
 	case "$1 $2" in

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -784,6 +784,63 @@ esac
 unset -f uci
 ok "B-1 duplicate wan zones stay distinct for commit-scope"
 
+# --- Phase 1 (issue #272): timeout presence half + run_with_timeout ---
+# Gap 2 presence half: timeout on PATH omits timeout_missing from warnings.
+# Round 4 moved timeout_missing from blockers to warnings. Pin the warning.
+if command -v timeout >/dev/null 2>&1; then
+	check_nf_log_ipv4() { return 0; }
+	check_nf_log_ipv6() { return 0; }
+	uci() {
+		case "$*" in
+			'-q show firewall')
+				printf "firewall.@zone[0]=zone\nfirewall.@zone[0].name='wan'\n"
+				;;
+			'-q get firewall.@zone[0]')
+				printf 'zone\n'
+				;;
+			'-q get firewall.@zone[0].log'|'-q get firewall.@zone[0].log_limit')
+				return 1
+				;;
+			*) return 0 ;;
+		esac
+	}
+	out=$(build_logging_status_json)
+	case "$out" in
+		*timeout_missing*) die "timeout present must omit timeout_missing, got: $out" ;;
+	esac
+	unset -f uci check_nf_log_ipv4 check_nf_log_ipv6
+	ok "timeout present omits timeout_missing from warnings"
+else
+	ok "timeout present case skipped (no timeout on test host)"
+fi
+
+# Gap 3: run_with_timeout contract, tested against the shipped text.
+_run_with_timeout_src=$(sed -n '/^run_with_timeout()/,/^}/p' "$RPCD")
+[ -n "$_run_with_timeout_src" ] || die "run_with_timeout not found in $RPCD"
+eval "$_run_with_timeout_src"
+unset _run_with_timeout_src
+got=$(run_with_timeout 5 echo hello)
+[ "$got" = "hello" ] || die "run_with_timeout must exec with timeout present, got: $got"
+ok "run_with_timeout execs with timeout present"
+_rc=0
+run_with_timeout 1 sleep 5 2>/dev/null || _rc=$?
+[ "$_rc" -ne 0 ] && [ "$_rc" -ne 127 ] || die "run_with_timeout must time out (non-zero, not 127), got: $_rc"
+ok "run_with_timeout times out without running unbounded"
+# command is a shell keyword, so command command reaches the real builtin.
+command() {
+	case "$1 $2" in
+		'-v timeout') return 1 ;;
+		*) command command "$@" ;;
+	esac
+}
+got=''
+_rc=0
+got=$(run_with_timeout 5 echo hello 2>/dev/null) || _rc=$?
+[ "$_rc" = "127" ] || die "run_with_timeout without timeout must return 127, got: $_rc"
+[ -z "$got" ] || die "run_with_timeout without timeout must not exec, got: $got"
+unset -f command
+ok "run_with_timeout returns 127 without timeout (fail-closed)"
+
 sh "$RPCD" __selftest >/dev/null || die "rpcd __selftest"
 ok "rpcd __selftest"
 


### PR DESCRIPTION
Closes #272.

Pins the two timeout-absence contracts from the wave plan (#240 Tier 1, Gaps 2-3).

Scope: tests only, no production code changes.

Added to tests/fwlive-logging.test.sh:
- Gap 2 presence half: timeout on PATH omits timeout_missing from warnings. The absence half already existed. Note: timeout_missing is a warning since round 4, not a blocker. The pin asserts the warning behavior.
- Gap 3: run_with_timeout contract against the shipped function text: execs with timeout present, times out without running unbounded, returns 127 without timeout (fail-closed, #229).

Verification:
- tests/fwlive-logging.test.sh passes (new pins in 1.5 s).
- Red-proved: mutating return 127 to return 0 fails with run_with_timeout without timeout must return 127, got: 0.
- scripts/fwlive-test.sh green. Shellcheck green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for logging warning behavior when timeout support is available.
  - Added validation for command execution with timeout support, including successful execution, timeout failures, and fail-closed behavior when timeout support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->