### PR TITLE
test(cut,i18n): pin upstream-cut invariants and .pot msgid parity (#273)

### DIFF
--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -32,6 +32,9 @@ if grep -E '^#: /' "$POT" >/dev/null; then
 fi
 echo "OK: no absolute #: refs in luci-app-fwlive.pot" >&2
 
+echo "== fwlive upstream-cut invariants + .pot parity (#273) ==" >&2
+bash "$ROOT/tests/fwlive-upstream-cut.test.sh"
+
 echo "== fwlive parser sync (core vs LuCI) ==" >&2
 "$NODE" tests/fwlive-parser-sync.test.js
 

--- a/tests/fwlive-upstream-cut.test.sh
+++ b/tests/fwlive-upstream-cut.test.sh
@@ -71,8 +71,28 @@ cp -r "$CUT_WORK/cut" "$CUT_WORK/scanwork/luci-app-fwlive"
 python3 - "$CUT_WORK/scanwork/fresh.pot" "$POT" <<'EOF' || die "msgid parity failed"
 import re, sys
 def msgids(p):
+    # Multiline-aware: msgid "" + continuation "..." lines form one entry.
+    # Single-line regexes silently drop those and can pass on a mismatch.
     s = open(p, encoding='utf-8', errors='replace').read()
-    return set(re.findall(r'^msgid "(.*)"$', s, re.M)) - {''}
+    out = set()
+    cur = None
+    for line in s.splitlines():
+        m = re.match(r'^msgid "(.*)"$', line)
+        if m:
+            if cur:
+                out.add("".join(cur))
+            cur = [m.group(1)]
+            continue
+        m = re.match(r'^"(.*)"$', line)
+        if m and cur is not None:
+            cur.append(m.group(1))
+            continue
+        if cur:
+            out.add("".join(cur))
+            cur = None
+    if cur:
+        out.add("".join(cur))
+    return out - {''}
 fresh, checked = msgids(sys.argv[1]), msgids(sys.argv[2])
 only_fresh = sorted(fresh - checked)
 only_checked = sorted(checked - fresh)

--- a/tests/fwlive-upstream-cut.test.sh
+++ b/tests/fwlive-upstream-cut.test.sh
@@ -12,11 +12,25 @@ die() { echo "fwlive-upstream-cut test FAIL: $*" >&2; exit 1; }
 ok() { echo "fwlive-upstream-cut test OK: $*"; }
 
 CUT_WORK=$(mktemp -d)
-trap 'rm -rf "$CUT_WORK"; git -C "$ROOT" branch -D upstream/luci-app-fwlive >/dev/null 2>&1 || true' EXIT
+# Preserve a pre-existing regenerable split ref; only delete if we created it.
+SAVED_UPSTREAM_CUT_SHA=
+if git -C "$ROOT" rev-parse --verify refs/heads/upstream/luci-app-fwlive >/dev/null 2>&1; then
+	SAVED_UPSTREAM_CUT_SHA=$(git -C "$ROOT" rev-parse refs/heads/upstream/luci-app-fwlive)
+fi
+_restore_upstream_cut_ref() {
+	rm -rf "$CUT_WORK"
+	if [ -n "${SAVED_UPSTREAM_CUT_SHA:-}" ]; then
+		git -C "$ROOT" update-ref refs/heads/upstream/luci-app-fwlive "$SAVED_UPSTREAM_CUT_SHA" >/dev/null 2>&1 || true
+	else
+		git -C "$ROOT" branch -D upstream/luci-app-fwlive >/dev/null 2>&1 || true
+	fi
+}
+trap _restore_upstream_cut_ref EXIT
 
 # Gap 4: the cut must stay luci-shaped. Time it for the wave record.
+# Keep stderr so named invariant failures from the cut script reach CI.
 _start=$(date +%s)
-"$ROOT/scripts/upstream-cut.sh" "$CUT_WORK/cut" >/dev/null 2>&1 || die "upstream-cut.sh failed"
+"$ROOT/scripts/upstream-cut.sh" "$CUT_WORK/cut" >/dev/null || die "upstream-cut.sh failed"
 _end=$(date +%s)
 echo "fwlive-upstream-cut test INFO: cut wall time $((_end - _start))s"
 

--- a/tests/fwlive-upstream-cut.test.sh
+++ b/tests/fwlive-upstream-cut.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Phase 2 (issue #273): upstream-cut invariants + .pot msgid parity.
+# Runs scripts/upstream-cut.sh to a temp dir and pins the luci-shaped output.
+# Gap 5 needs i18n-scan.pl (openwrt/luci build tree); when absent the parity
+# half skips — CI has no luci checkout, so the cut invariants are the gate.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POT="$ROOT/openwrt-feed/luci-app-fwlive/po/templates/luci-app-fwlive.pot"
+
+die() { echo "fwlive-upstream-cut test FAIL: $*" >&2; exit 1; }
+ok() { echo "fwlive-upstream-cut test OK: $*"; }
+
+CUT_WORK=$(mktemp -d)
+trap 'rm -rf "$CUT_WORK"; git -C "$ROOT" branch -D upstream/luci-app-fwlive >/dev/null 2>&1 || true' EXIT
+
+# Gap 4: the cut must stay luci-shaped. Time it for the wave record.
+_start=$(date +%s)
+"$ROOT/scripts/upstream-cut.sh" "$CUT_WORK/cut" >/dev/null 2>&1 || die "upstream-cut.sh failed"
+_end=$(date +%s)
+echo "fwlive-upstream-cut test INFO: cut wall time $((_end - _start))s"
+
+[ -f "$CUT_WORK/cut/Makefile" ] || die "cut Makefile missing"
+grep -q '^include ../../luci.mk' "$CUT_WORK/cut/Makefile" \
+	|| die "Makefile include not rewritten to ../../luci.mk"
+! grep -q 'SOURCE_DATE_EPOCH' "$CUT_WORK/cut/Makefile" \
+	|| die "SOURCE_DATE_EPOCH block remains in luci-shaped Makefile"
+! grep -q 'docker-sdk' "$CUT_WORK/cut/Makefile" \
+	|| die "docker-sdk reference remains in luci-shaped Makefile"
+ok "cut Makefile is luci-shaped (include, no SOURCE_DATE_EPOCH, no docker-sdk)"
+
+grep -q 'github.com/lucas-albers-lz4/fwlive/blob/master' "$CUT_WORK/cut/README.md" \
+	|| die "README links not rewritten to the blob URL"
+! grep -q '\.\./\.\./docs' "$CUT_WORK/cut/README.md" \
+	|| die "monorepo-relative docs links remain in cut README"
+ok "cut README points at blob URLs, no monorepo-relative links"
+
+[ -f "$CUT_WORK/cut/po/templates/luci-app-fwlive.pot" ] \
+	|| die "po/templates/luci-app-fwlive.pot missing from cut"
+for lang in de ru zh_Hans; do
+	[ ! -e "$CUT_WORK/cut/po/$lang" ] || die "locale dir po/$lang still present"
+done
+ok "cut ships .pot only (template present, locale dirs dropped)"
+
+# The cut keeps the checked-in .pot byte-identical (monorepo paths); the fresh
+# luci-tree .pot comes from i18n-scan.pl in Gap 5. Pin repo-relative refs.
+if grep -E '^#: /' "$CUT_WORK/cut/po/templates/luci-app-fwlive.pot" >/dev/null; then
+	die "absolute #: refs in cut .pot"
+fi
+ok "cut .pot has repo-relative #: refs"
+
+# Gap 5: fresh-scan msgid parity. Scanner source: env override, PATH, else skip.
+SCAN="${FWLIVE_I18N_SCAN:-}"
+if [ -z "$SCAN" ] && command -v i18n-scan.pl >/dev/null 2>&1; then
+	SCAN=$(command -v i18n-scan.pl)
+fi
+if [ -z "$SCAN" ] || [ ! -f "$SCAN" ]; then
+	ok "msgid parity skipped (no i18n-scan.pl; set FWLIVE_I18N_SCAN)"
+	echo "fwlive-upstream-cut tests passed"
+	exit 0
+fi
+command -v xgettext >/dev/null 2>&1 \
+	|| { ok "msgid parity skipped (xgettext missing)"; echo "fwlive-upstream-cut tests passed"; exit 0; }
+command -v python3 >/dev/null 2>&1 \
+	|| { ok "msgid parity skipped (python3 missing)"; echo "fwlive-upstream-cut tests passed"; exit 0; }
+
+mkdir -p "$CUT_WORK/scanwork"
+cp -r "$CUT_WORK/cut" "$CUT_WORK/scanwork/luci-app-fwlive"
+(cd "$CUT_WORK/scanwork" && perl "$SCAN" luci-app-fwlive > fresh.pot 2>/dev/null) \
+	|| die "i18n-scan.pl failed on the cut tree"
+python3 - "$CUT_WORK/scanwork/fresh.pot" "$POT" <<'EOF' || die "msgid parity failed"
+import re, sys
+def msgids(p):
+    s = open(p, encoding='utf-8', errors='replace').read()
+    return set(re.findall(r'^msgid "(.*)"$', s, re.M)) - {''}
+fresh, checked = msgids(sys.argv[1]), msgids(sys.argv[2])
+only_fresh = sorted(fresh - checked)
+only_checked = sorted(checked - fresh)
+if only_fresh or only_checked:
+    print("fresh-only: %s" % only_fresh[:10])
+    print("checked-only: %s" % only_checked[:10])
+    sys.exit(1)
+print("msgid parity: %d/%d" % (len(fresh), len(checked)))
+EOF
+ok "fresh-scan msgids match the checked-in .pot"
+
+echo "fwlive-upstream-cut tests passed"


### PR DESCRIPTION
Closes #273.

Pins Tier-1 Gaps 4+5 from the wave plan (#240 section 3).

Scope: tests only. New tests/fwlive-upstream-cut.test.sh (wired into scripts/fwlive-test.sh), no production changes.

Gap 4: runs scripts/upstream-cut.sh to a temp dir and asserts the luci-shaped output: Makefile include rewritten to ../../luci.mk, no SOURCE_DATE_EPOCH block, no docker-sdk references, README links rewritten to the blob URL, po/templates present, locale dirs dropped, cut .pot has repo-relative refs. Cut wall time about 4 s on this host; the test prints it for the wave record.

Gap 5: fresh i18n-scan.pl scan of the cut tree, msgid-set compared against the checked-in .pot. Proven 132/132 locally via FWLIVE_I18N_SCAN. The scanner ships with the openwrt/luci tree, which CI does not have, so the parity half skips gracefully when no scanner is found (env override FWLIVE_I18N_SCAN, else PATH). The cut invariants are the CI gate.

Deviation from the issue text: the issue says .pot paths applications/-prefixed, but the cut keeps the checked-in .pot byte-identical (openwrt-feed/ paths); the applications/-shaped .pot is regenerated in the luci tree by i18n-scan.pl per the cut script step 5/5. Pinned current shape per the no-redesign non-goal.

Verification:
- New test green both with and without a scanner (skip path).
- Red-proved twice: a committed SOURCE_DATE_EPOCH line fails the cut; a committed absolute #: ref fails with absolute #: refs in cut .pot.
- Shellcheck green. Test leaves no trace (temp dir + split branch cleaned by trap).