### PR TITLE
chore: SPDX headers + CI gate (#291 C1/C2)

### DIFF
--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass'; /* LuCI require() needs Class.isSubclass — plain return {} fails */
 'require fwlive.log as log';
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/hostname.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/hostname.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass'; /* LuCI require() needs Class.isSubclass — plain return {} fails */
 'require fwlive.log as log';
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 'require fwlive.links as links';
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/proto.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/proto.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass'; /* LuCI require() needs Class.isSubclass — plain return {} fails */
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 'require fwlive.log as log';
 'require fwlive.links as links';

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/tint.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/tint.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 /*
  * LuCI Firewall Live View — client-side view (view.extend + ubus fwlive.poll).
  * UI interaction patterns inspired by OPNsense Live View; original implementation

--- a/scripts/embed-fwlive-css.js
+++ b/scripts/embed-fwlive-css.js
@@ -29,6 +29,8 @@ function generate(cssText) {
 	const styleText = '\n' + body;
 	return [
 		"'use strict';",
+		'/* SPDX-License-Identifier: Apache-2.0 */',
+		'/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */',
 		"'require baseclass';",
 		'',
 		'/**',

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -20,6 +20,34 @@ fi
 echo "== fwlive view syntax (node --check) ==" >&2
 "$NODE" --check openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
 
+echo "== fwlive SPDX headers on shipped surface (#291) ==" >&2
+SPDX_FAIL=0
+SPDX_FILES=(
+	"$ROOT/openwrt-feed/luci-app-fwlive/Makefile"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh"
+	"$ROOT/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js"
+)
+while IFS= read -r -d '' f; do
+	SPDX_FILES+=("$f")
+done < <(find \
+	"$ROOT/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive" \
+	-type f -name '*.js' -print0)
+for f in "${SPDX_FILES[@]}"; do
+	[[ -f "$f" ]] || { echo "FAIL: expected shipped file missing: $f" >&2; SPDX_FAIL=1; continue; }
+	if ! grep -q 'SPDX-License-Identifier' "$f"; then
+		echo "FAIL: missing SPDX-License-Identifier: $f" >&2
+		SPDX_FAIL=1
+	fi
+done
+if [[ "$SPDX_FAIL" -ne 0 ]]; then
+	echo "FAIL: add SPDX-License-Identifier to shipped files (#291 C2)" >&2
+	exit 1
+fi
+echo "OK: SPDX headers present on shipped JS/shell/Makefile" >&2
+
 echo "== fwlive shellcheck (libexec/rpcd) ==" >&2
 bash "$ROOT/scripts/fwlive-shellcheck.sh"
 


### PR DESCRIPTION
## Summary
- Add `SPDX-License-Identifier: Apache-2.0` + copyright to all shipped LuCI JS helpers, the view, and generated `css.js` (via `embed-fwlive-css.js`).
- Wire an SPDX presence gate into `scripts/fwlive-test.sh` (#291 C1/C2).
- **C4 (verify-only):** `pygount --duplicates` on `openwrt-feed/luci-app-fwlive` + `core` shows **no** `__duplicate__` bucket. `core/fwlive-log.js` and `htdocs/.../log.js` are both analyzed JS (intentional mirror; drift gated by `gen-luci-wrapper.js`). `__generated__` covers `css.js` + `fwlive-is-firewall-event.sh`.
- **C5:** already landed in #273 / `tests/fwlive-upstream-cut.test.sh`.
- **C6:** `/wave/` already in `.gitignore`; no `wave/` tree on disk.

## Test plan
- [x] SPDX grep on all shipped JS/shell/Makefile
- [x] `node --test tests/fwlive-theme-css.test.js` (css.js freshness)
- [ ] `./scripts/fwlive-test.sh` CI
- [ ] Luna + Bugbot on draft

Refs #291