### PR TITLE
ci: actionlint + shellcheck warning baseline (#290 L6/L7)

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -69,6 +69,32 @@ jobs:
             "$ZIZMOR_IMAGE" \
             --offline --persona=regular --min-severity=high .
 
+  # #290 L6: actionlint (docker run, not job container — usrmanage #85 EACCES).
+  actionlint:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_IMAGE: rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9
+      ACTIONLINT_VERSION: "1.7.7"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+      - name: Verify actionlint version (pinned image)
+        run: |
+          out="$(docker run --rm "$ACTIONLINT_IMAGE" -version)"
+          printf '%s\n' "$out"
+          if ! printf '%s\n' "$out" | grep -q "${ACTIONLINT_VERSION}"; then
+            echo "expected actionlint ${ACTIONLINT_VERSION} in version output" >&2
+            exit 1
+          fi
+      - name: Run actionlint on workflows
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/repo:ro" \
+            -w /repo \
+            "$ACTIONLINT_IMAGE" \
+            -color
+
   # #121: authoritative Z3 suite (F1-F4).
   z3-verify:
     runs-on: ubuntu-latest

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -415,3 +415,15 @@ links to this ledger for review state.
 
 **Result.** H1 done (no package code change). H2 remains open until the operator UI toggles land; do not treat GHAS sub-features as cleared yet.
 
+### 2026-09-06 — Lint / actionlint / shellcheck baseline (#290)
+
+**Scope.** Upstream-readiness Tier-1 tooling: actionlint CI job (L6) and curated shellcheck `--severity=warning` baseline (L7).
+
+**Artifacts.**
+
+- **actionlint:** job `actionlint` in `.github/workflows/fwlive-test.yml` runs `docker run` (not job-level `container:`) with digest-pinned `rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9` (v1.7.7), same EACCES-safe pattern as zizmor / usrmanage.
+- **shellcheck baseline:** `scripts/shellcheck-baseline.txt` (zero suppressions as of this date — shipped libexec/rpcd clean at warning+style) + `scripts/fwlive-shellcheck.sh` uses `--severity=warning` and applies `--exclude` only for justified baseline ids.
+
+**Result.** New SC warnings and Actions config mistakes fail the PR gate. Baseline grows only with an annotated reason per SC id.
+
+

--- a/scripts/fwlive-shellcheck.sh
+++ b/scripts/fwlive-shellcheck.sh
@@ -15,21 +15,22 @@ fi
 # Empty baseline → no --exclude (fail closed on any new warning).
 EXCLUDE_ARGS=()
 if [[ -f "$BASELINE" ]]; then
-	mapfile -t SC_IDS < <(
-		awk '
-			/^[[:space:]]*#/ { next }
-			/^[[:space:]]*$/ { next }
-			match($0, /^SC[0-9]+/) {
-				id = substr($0, RSTART, RLENGTH)
-				if ($0 !~ /#/) {
-					print "FAIL: shellcheck-baseline entry missing # reason: " $0 > "/dev/stderr"
-					exit 2
-				}
-				print id
-			}
-		' "$BASELINE" | sort -u
-	)
+	SC_IDS=()
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		[[ "$line" =~ ^[[:space:]]*# ]] && continue
+		[[ -z "${line//[[:space:]]/}" ]] && continue
+		if [[ "$line" =~ ^(SC[0-9]+) ]]; then
+			id="${BASH_REMATCH[1]}"
+			if [[ "$line" != *#* ]]; then
+				echo "FAIL: shellcheck-baseline entry missing # reason: $line" >&2
+				exit 1
+			fi
+			SC_IDS+=("$id")
+		fi
+	done < "$BASELINE"
 	if [[ ${#SC_IDS[@]} -gt 0 ]]; then
+		# Unique sorted ids for --exclude=A,B,C
+		mapfile -t SC_IDS < <(printf '%s\n' "${SC_IDS[@]}" | sort -u)
 		EXCLUDE_ARGS=(--exclude="$(IFS=,; echo "${SC_IDS[*]}")")
 	fi
 fi

--- a/scripts/fwlive-shellcheck.sh
+++ b/scripts/fwlive-shellcheck.sh
@@ -1,21 +1,45 @@
 #!/usr/bin/env bash
-# Run shellcheck on shipped rpcd/libexec shell scripts (#86).
+# Run shellcheck on shipped rpcd/libexec shell scripts (#86, #290 L7).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIBEXEC="$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec"
+BASELINE="$ROOT/scripts/shellcheck-baseline.txt"
 
 if ! command -v shellcheck >/dev/null 2>&1; then
 	echo "Install shellcheck (e.g. apt install shellcheck) to run this gate." >&2
 	exit 1
 fi
 
-# Enumerate by discovery, not a fixed list, so a newly added script cannot
-# silently escape this gate (it previously named 4 files explicitly). The
-# shipped rpcd entrypoint `rpcd/fwlive` has no extension, so match *.sh OR
-# that exact name. Do not use -x: sourced paths are runtime-resolved
-# ($FILTER_DIR / $LOGGING_SH).
-find "$LIBEXEC" -type f \( -name '*.sh' -o -name 'fwlive' \) -print0 \
-	| xargs -0 -r shellcheck -s sh
+# Curated exclusions: SC ids from baseline with a "# reason" annotation.
+# Empty baseline → no --exclude (fail closed on any new warning).
+EXCLUDE_ARGS=()
+if [[ -f "$BASELINE" ]]; then
+	mapfile -t SC_IDS < <(
+		awk '
+			/^[[:space:]]*#/ { next }
+			/^[[:space:]]*$/ { next }
+			match($0, /^SC[0-9]+/) {
+				id = substr($0, RSTART, RLENGTH)
+				if ($0 !~ /#/) {
+					print "FAIL: shellcheck-baseline entry missing # reason: " $0 > "/dev/stderr"
+					exit 2
+				}
+				print id
+			}
+		' "$BASELINE" | sort -u
+	)
+	if [[ ${#SC_IDS[@]} -gt 0 ]]; then
+		EXCLUDE_ARGS=(--exclude="$(IFS=,; echo "${SC_IDS[*]}")")
+	fi
+fi
 
-echo "fwlive shellcheck OK" >&2
+# Enumerate by discovery, not a fixed list, so a newly added script cannot
+# silently escape this gate. The shipped rpcd entrypoint `rpcd/fwlive` has no
+# extension, so match *.sh OR that exact name. Do not use -x: sourced paths
+# are runtime-resolved ($FILTER_DIR / $LOGGING_SH).
+# --severity=warning: style-only nits stay non-gating; warnings+ fail the build.
+find "$LIBEXEC" -type f \( -name '*.sh' -o -name 'fwlive' \) -print0 \
+	| xargs -0 -r shellcheck -s sh --severity=warning "${EXCLUDE_ARGS[@]}"
+
+echo "fwlive shellcheck OK (severity=warning; baseline=$(basename "$BASELINE"))" >&2

--- a/scripts/shellcheck-baseline.txt
+++ b/scripts/shellcheck-baseline.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Curated shellcheck exclusions for shipped libexec/rpcd (#290 L7).
+# Format: SC####<optional trailing junk>  then "# reason" on the same line.
+# Only the SC id before the first non-id character is used for --exclude.
+# New SC findings at --severity=warning MUST NOT be added casually — each
+# entry needs a reviewer-auditable reason (same bar as CodeQL suppressions).
+#
+# As of 2026-09-06 the shipped surface is clean at warning (and style) under
+# `shellcheck -s sh`. This file intentionally has zero suppressions so the
+# gate fails closed on the next new SC id.
+


### PR DESCRIPTION
## Summary
- **L6:** `actionlint` job in `fwlive-test.yml` — `docker run` with `rhysd/actionlint@sha256:887a…` (v1.7.7), not job `container:`.
- **L7:** `scripts/shellcheck-baseline.txt` + `fwlive-shellcheck.sh` at `--severity=warning`; baseline currently has zero suppressions (clean at warning+style).
- Ledger note in `docs/developer/security-review.md`.

## Test plan
- [x] `bash scripts/fwlive-shellcheck.sh`
- [x] local `docker run … actionlint -color` clean
- [ ] CI actionlint job on PR
- [ ] Luna + Bugbot

Refs #290