### PR TITLE
review: audit backlog wave (already on master) — CodeRabbit aggregate

### DIFF
--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -16,8 +16,13 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6
         with:
           node-version: '22'
-      - name: Install shellcheck and busybox
-        run: sudo apt-get update && sudo apt-get install -y shellcheck busybox
+      - name: Install shellcheck, busybox, and ruff
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck busybox pipx
+          pipx install ruff
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: npm ci
       - run: ./scripts/fwlive-test.sh
       - name: Shell parity under busybox sh
         run: SH='busybox sh' node tests/fwlive-shell-filter.test.js

--- a/.github/workflows/fwlive-test.yml
+++ b/.github/workflows/fwlive-test.yml
@@ -69,6 +69,32 @@ jobs:
             "$ZIZMOR_IMAGE" \
             --offline --persona=regular --min-severity=high .
 
+  # #290 L6: actionlint (docker run, not job container — usrmanage #85 EACCES).
+  actionlint:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONLINT_IMAGE: rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9
+      ACTIONLINT_VERSION: "1.7.7"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+      - name: Verify actionlint version (pinned image)
+        run: |
+          out="$(docker run --rm "$ACTIONLINT_IMAGE" -version)"
+          printf '%s\n' "$out"
+          if ! printf '%s\n' "$out" | grep -q "${ACTIONLINT_VERSION}"; then
+            echo "expected actionlint ${ACTIONLINT_VERSION} in version output" >&2
+            exit 1
+          fi
+      - name: Run actionlint on workflows
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/repo:ro" \
+            -w /repo \
+            "$ACTIONLINT_IMAGE" \
+            -color
+
   # #121: authoritative Z3 suite (F1-F4).
   z3-verify:
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+out/
+build/
+node_modules/
+lab/
+wave/
+coverage/
+openwrt/
+.sdk/
+.ci-sdk-cache/
+package-lock.json
+*.min.js
+# Generated CSS embed — format via source fwlive.css + embed script
+openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+	"useTabs": true,
+	"tabWidth": 4,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"printWidth": 100,
+	"semi": true,
+	"bracketSpacing": true,
+	"arrowParens": "always",
+	"quoteProps": "preserve"
+}

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,9 @@
+out/
+build/
+node_modules/
+lab/
+wave/
+coverage/
+openwrt/
+.sdk/
+.ci-sdk-cache/

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,31 @@
+{
+	"extends": "stylelint-config-standard",
+	"rules": {
+		"color-hex-length": null,
+		"color-function-alias-notation": null,
+		"color-function-notation": null,
+		"alpha-value-notation": null,
+		"value-keyword-case": null,
+		"selector-class-pattern": null,
+		"custom-property-pattern": null,
+		"keyframes-name-pattern": null,
+		"declaration-block-no-redundant-longhand-properties": null,
+		"no-descending-specificity": null,
+		"media-feature-range-notation": null,
+		"import-notation": null,
+		"declaration-empty-line-before": null,
+		"rule-empty-line-before": null,
+		"comment-empty-line-before": null,
+		"at-rule-empty-line-before": null,
+		"custom-property-empty-line-before": null,
+		"property-no-vendor-prefix": null,
+		"value-no-vendor-prefix": null,
+		"selector-no-vendor-prefix": null,
+		"function-url-quotes": null,
+		"declaration-block-single-line-max-declarations": null,
+		"declaration-property-value-keyword-no-deprecated": null,
+		"property-no-deprecated": null,
+		"block-no-empty": null,
+		"no-duplicate-selectors": null
+	}
+}

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,9 +1,9 @@
 # Security review state
 
-> **Status:** 45 controls in force; 0 open findings.
-> **Last review:** 2026-09-03 (multi-model VVAH pass: playbook + B-1 zone identity; #261/#257 closed).
-> **Open:** none.
-> **Next:** On the next `v*` tag, re-check pins and run full docker usign (gap 4). The full surface re-pass is deferred — the gate criteria are not met (skill § Multi-model pass / full-pass gate). Lab gaps 1–3 ran as smoke tests on 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green). The gap 2 flock residual is unchanged.
+> **Status:** 45 controls in force; 0 open security findings; housekeeping GHAS sub-features pending operator UI toggle (#293 H2).
+> **Last review:** 2026-09-06 (housekeeping hygiene #293: H1 stale branch deleted; H2 Validity checks + Non-provider patterns still operator-pending).
+> **Open:** #293 H2 — enable secret scanning Validity checks and Non-provider patterns (repo Settings → Code security; User-account UI-only).
+> **Next:** After H2 toggles, re-scan with housekeeping (expect `secret_validity_checks_off` / `secret_nonprovider_patterns_off` clear). On the next `v*` tag, re-check pins and run full docker usign (gap 4). The full surface re-pass is deferred — the gate criteria are not met (skill § Multi-model pass / full-pass gate). Lab gaps 1–3 ran as smoke tests on 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green). The gap 2 flock residual is unchanged.
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass: [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
 
 What has been reviewed, when, with what strength of proof, and what is still
@@ -402,3 +402,16 @@ links to this ledger for review state.
 - UCI `.log_*` near-miss grammar (#257) holds under Fable checklist.
 
 **Full-pass gate.** Deferred — no class bug beyond B-1 (fixed), no high/medium blast radius. The pin checklist is not due until the next `v*` tag. Next: QEMU `qemu-security-gaps-smoke.sh` for gaps 1–3.
+
+### 2026-09-06 — Housekeeping hygiene (#293)
+
+**Scope.** Carryover from upstream-readiness review (#288 M10, M12) and live housekeeping scan: stale merged branch + GHAS secret-scanning sub-features (User-account UI toggles; no REST path).
+
+**Actions.**
+
+- **H1:** Deleted remote `fix/rpcd-hardening` (merged via PR #68 on 2026-07-29; predated `delete_branch_on_merge`). Verified `GET .../git/refs/heads/fix/rpcd-hardening` → 404.
+- **H2:** Repo Settings → Code security: enable secret scanning **Validity checks** and **Non-provider patterns** (User account; UI-only, no API). Base secret scanning + push protection already `enabled` (API-confirmed 2026-09-06). **Still operator-pending** as of this entry; housekeeping still reports `secret_validity_checks_off` / `secret_nonprovider_patterns_off` until toggled and re-scanned.
+- **H3:** This ledger entry records H1 complete and H2 pending for the next housekeeping re-scan.
+
+**Result.** H1 done (no package code change). H2 remains open until the operator UI toggles land; do not treat GHAS sub-features as cleared yet.
+

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -415,3 +415,15 @@ links to this ledger for review state.
 
 **Result.** H1 done (no package code change). H2 remains open until the operator UI toggles land; do not treat GHAS sub-features as cleared yet.
 
+### 2026-09-06 — Lint / actionlint / shellcheck baseline (#290)
+
+**Scope.** Upstream-readiness Tier-1 tooling: actionlint CI job (L6) and curated shellcheck `--severity=warning` baseline (L7).
+
+**Artifacts.**
+
+- **actionlint:** job `actionlint` in `.github/workflows/fwlive-test.yml` runs `docker run` (not job-level `container:`) with digest-pinned `rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9` (v1.7.7), same EACCES-safe pattern as zizmor / usrmanage.
+- **shellcheck baseline:** `scripts/shellcheck-baseline.txt` (zero suppressions as of this date — shipped libexec/rpcd clean at warning+style) + `scripts/fwlive-shellcheck.sh` uses `--severity=warning` and applies `--exclude` only for justified baseline ids.
+
+**Result.** New SC warnings and Actions config mistakes fail the PR gate. Baseline grows only with an annotated reason per SC id.
+
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,153 @@
+'use strict';
+
+/**
+ * Flat ESLint config for shipped LuCI JS (#290 / #288 M1).
+ * LuCI AMD modules use top-level `return` and `'require …';` strings.
+ * We wrap each file in an IIFE for parsing (runtime still loads via LuCI).
+ */
+
+const path = require('node:path');
+const js = require('@eslint/js');
+
+const luciBrowserGlobals = {
+	document: 'readonly',
+	window: 'readonly',
+	localStorage: 'readonly',
+	location: 'readonly',
+	setTimeout: 'readonly',
+	clearTimeout: 'readonly',
+	requestAnimationFrame: 'readonly',
+	console: 'readonly',
+	URL: 'readonly',
+	URLSearchParams: 'readonly',
+	JSON: 'readonly',
+	Math: 'readonly',
+	Date: 'readonly',
+	Object: 'readonly',
+	Array: 'readonly',
+	String: 'readonly',
+	Number: 'readonly',
+	Boolean: 'readonly',
+	Error: 'readonly',
+	Promise: 'readonly',
+	Map: 'readonly',
+	Set: 'readonly',
+	parseInt: 'readonly',
+	parseFloat: 'readonly',
+	isNaN: 'readonly',
+	encodeURIComponent: 'readonly',
+	decodeURIComponent: 'readonly',
+};
+
+const luciRuntimeGlobals = {
+	L: 'readonly',
+	_: 'readonly',
+	E: 'readonly',
+	baseclass: 'readonly',
+	view: 'readonly',
+	poll: 'readonly',
+	rpc: 'readonly',
+	dom: 'readonly',
+	ui: 'readonly',
+	form: 'readonly',
+	fs: 'readonly',
+	uci: 'readonly',
+	network: 'readonly',
+};
+
+const fwliveViewAliases = {
+	log: 'readonly',
+	constants: 'readonly',
+	css: 'readonly',
+	tint: 'readonly',
+	chips: 'readonly',
+	logging: 'readonly',
+	table: 'readonly',
+	buffer: 'readonly',
+	hostname: 'readonly',
+	proto: 'readonly',
+	links: 'readonly',
+};
+
+/** Wrap LuCI AMD bodies so top-level `return` parses under Espree. */
+const luciAmdWrap = {
+	preprocess(text, filename) {
+		const name = path.basename(filename);
+		return [
+			{
+				text: '(function () {\n' + text + '\n})();\n',
+				filename: name + '.wrapped',
+			},
+		];
+	},
+	postprocess(messages) {
+		/* Drop the synthetic wrapper file name; shift lines by -1 for the wrap. */
+		return messages.flat().map((msg) => {
+			if (typeof msg.line === 'number' && msg.line > 1)
+				return { ...msg, line: msg.line - 1 };
+			return msg;
+		});
+	},
+	supportsAutofix: false,
+};
+
+module.exports = [
+	{
+		ignores: [
+			'out/**',
+			'build/**',
+			'node_modules/**',
+			'lab/**',
+			'wave/**',
+			'coverage/**',
+			'openwrt/**',
+			'.sdk/**',
+			'.ci-sdk-cache/**',
+			'core/**',
+			'tests/**',
+			'scripts/**',
+		],
+	},
+	{
+		files: [
+			'openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/**/*.js',
+			'openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js',
+		],
+		plugins: {
+			'luci-amd-wrap': {
+				processors: {
+					wrap: luciAmdWrap,
+				},
+			},
+		},
+		processor: 'luci-amd-wrap/wrap',
+		languageOptions: {
+			ecmaVersion: 2020,
+			sourceType: 'script',
+			globals: {
+				...luciBrowserGlobals,
+				...luciRuntimeGlobals,
+				...fwliveViewAliases,
+			},
+		},
+		rules: {
+			...js.configs.recommended.rules,
+			'no-undef': 'error',
+			'no-implicit-globals': 'error',
+			'no-eval': 'error',
+			'no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_',
+				},
+			],
+			/* LuCI AMD: `'require foo';` is an intentional unused expression. */
+			'no-unused-expressions': 'off',
+			indent: 'off',
+			semi: ['error', 'always'],
+			'no-var': 'off',
+		},
+	},
+];

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/buffer.js
@@ -18,26 +18,24 @@ function ingestCap(paused, rowLimit, fetchLinesMax) {
 
 function mergeById(entries, normalized, cap) {
 	if (!normalized || !normalized.length) {
-		if (!entries || !entries.length)
-			return [];
+		if (!entries || !entries.length) return [];
 		return entries.slice(-cap);
 	}
 
 	const byId = {};
 	let i;
 	if (entries) {
-		for (i = 0; i < entries.length; i++)
-			byId[entries[i].id] = entries[i];
+		for (i = 0; i < entries.length; i++) byId[entries[i].id] = entries[i];
 	}
-	for (i = 0; i < normalized.length; i++)
-		byId[normalized[i].id] = normalized[i];
+	for (i = 0; i < normalized.length; i++) byId[normalized[i].id] = normalized[i];
 
-	const merged = Object.keys(byId).map(function(id) { return byId[id]; });
-	merged.sort(function(a, b) {
+	const merged = Object.keys(byId).map(function (id) {
+		return byId[id];
+	});
+	merged.sort(function (a, b) {
 		const ta = a.timestamp || 0;
 		const tb = b.timestamp || 0;
-		if (ta !== tb)
-			return ta - tb;
+		if (ta !== tb) return ta - tb;
 		return (a.log_id || 0) - (b.log_id || 0);
 	});
 	return merged.slice(-cap);
@@ -60,13 +58,10 @@ function applyFetchedEntries(entries, normalized, opts) {
 	const merge = paused || resumeMerge;
 
 	let next;
-	if (merge)
-		next = mergeById(entries, normalized, cap);
-	else
-		next = (normalized || []).slice(-cap);
+	if (merge) next = mergeById(entries, normalized, cap);
+	else next = (normalized || []).slice(-cap);
 
-	if (!paused && next.length > rowLimit)
-		next = next.slice(-rowLimit);
+	if (!paused && next.length > rowLimit) next = next.slice(-rowLimit);
 
 	return next;
 }

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
@@ -18,16 +18,13 @@
 
 function chipValueNodes(field, val) {
 	const p = log.parseFilterValue(val);
-	if (!p.value)
-		return [ '' ];
+	if (!p.value) return [''];
 
-	const valueNode = p.negate
-		? E('span', { 'class': 'fwlive-chip-strike' }, [ p.value ])
-		: p.value;
+	const valueNode = p.negate ? E('span', { 'class': 'fwlive-chip-strike' }, [p.value]) : p.value;
 
 	if (!p.negate) {
 		return [
-			E('span', { 'class': 'fwlive-chip-polarity' }, [ _('is') ]),
+			E('span', { 'class': 'fwlive-chip-polarity' }, [_('is')]),
 			' ',
 			log.formatFilterChipLabel(field, val)
 		];
@@ -36,26 +33,24 @@ function chipValueNodes(field, val) {
 	if (field === 'q' || field === 'src' || field === 'dst')
 		return [
 			field + ': ',
-			E('strong', { 'class': 'fwlive-chip-not' }, [ _('not') ]),
+			E('strong', { 'class': 'fwlive-chip-not' }, [_('not')]),
 			' contains ',
 			valueNode
 		];
 
-	return [
-		field + ': ',
-		E('strong', { 'class': 'fwlive-chip-not' }, [ _('not') ]),
-		' ',
-		valueNode
-	];
+	return [field + ': ', E('strong', { 'class': 'fwlive-chip-not' }, [_('not')]), ' ', valueNode];
 }
 
 function chipLeadingSym(negated) {
-	if (!negated)
-		return null;
-	return E('span', {
-		'class': 'fwlive-chip-sym fwlive-chip-sym-light',
-		'aria-hidden': 'true'
-	}, [ '≠' ]);
+	if (!negated) return null;
+	return E(
+		'span',
+		{
+			'class': 'fwlive-chip-sym fwlive-chip-sym-light',
+			'aria-hidden': 'true'
+		},
+		['≠']
+	);
 }
 
 function renderFilterChips(host, state, callbacks) {
@@ -66,38 +61,62 @@ function renderFilterChips(host, state, callbacks) {
 	for (let i = 0; i < chipFields.length; i++) {
 		const spec = chipFields[i];
 		const val = filters[spec.key];
-		if (!val)
-			continue;
+		if (!val) continue;
 
 		const parsed = log.parseFilterValue(val);
 		const negated = parsed.negate;
 		const kids = [];
 		const lead = chipLeadingSym(negated);
-		if (lead)
-			kids.push(lead);
+		if (lead) kids.push(lead);
 
 		kids.push(E('span', { 'class': 'fwlive-chip-label' }, chipValueNodes(spec.label, val)));
-		kids.push(E('span', {
-			'class': 'fwlive-chip-invert-wrap',
-			'data-tip': negated ? _('Include instead') : _('Exclude instead')
-		}, [
-			E('button', {
-				'type': 'button',
-				'class': 'fwlive-chip-invert',
-				'click': function(ev) { callbacks.onInvert(spec.key, ev); }
-			}, [ '≠' ])
-		]));
-		kids.push(E('a', {
-			'href': '#',
-			'class': 'fwlive-chip-remove',
-			'title': _('Remove filter'),
-			'click': function(ev) { callbacks.onClear(spec.key, ev); }
-		}, [ '×' ]));
+		kids.push(
+			E(
+				'span',
+				{
+					'class': 'fwlive-chip-invert-wrap',
+					'data-tip': negated ? _('Include instead') : _('Exclude instead')
+				},
+				[
+					E(
+						'button',
+						{
+							'type': 'button',
+							'class': 'fwlive-chip-invert',
+							'click': function (ev) {
+								callbacks.onInvert(spec.key, ev);
+							}
+						},
+						['≠']
+					)
+				]
+			)
+		);
+		kids.push(
+			E(
+				'a',
+				{
+					'href': '#',
+					'class': 'fwlive-chip-remove',
+					'title': _('Remove filter'),
+					'click': function (ev) {
+						callbacks.onClear(spec.key, ev);
+					}
+				},
+				['×']
+			)
+		);
 
-		chips.push(E('span', {
-			'class': 'fwlive-chip'
-				+ (negated ? ' fwlive-chip-negated' : ' fwlive-chip-include')
-		}, kids));
+		chips.push(
+			E(
+				'span',
+				{
+					'class':
+						'fwlive-chip' + (negated ? ' fwlive-chip-negated' : ' fwlive-chip-include')
+				},
+				kids
+			)
+		);
 	}
 
 	host.className = 'fwlive-chips fwlive-chips-labels';
@@ -108,14 +127,21 @@ function renderFilterChips(host, state, callbacks) {
 	}
 
 	host.style.display = 'flex';
-	for (let i = 0; i < chips.length; i++)
-		host.appendChild(chips[i]);
+	for (let i = 0; i < chips.length; i++) host.appendChild(chips[i]);
 
-	host.appendChild(E('a', {
-		'href': '#',
-		'class': 'fwlive-chip-clear',
-		'click': function(ev) { callbacks.onClearAll(ev); }
-	}, [ _('Clear all') ]));
+	host.appendChild(
+		E(
+			'a',
+			{
+				'href': '#',
+				'class': 'fwlive-chip-clear',
+				'click': function (ev) {
+					callbacks.onClearAll(ev);
+				}
+			},
+			[_('Clear all')]
+		)
+	);
 }
 
 return baseclass.extend({

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/chips.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass'; /* LuCI require() needs Class.isSubclass — plain return {} fails */
 'require fwlive.log as log';
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
@@ -10,17 +10,32 @@
 return baseclass.extend({
 	/* Keep in sync with openwrt-feed/luci-app-fwlive/Makefile PKG_VERSION. */
 	APP_VERSION: '0.1.38',
-	ROW_LIMIT_OPTIONS: [ 25, 50, 100, 250, 500, 1000, 2000 ],
+	ROW_LIMIT_OPTIONS: [25, 50, 100, 250, 500, 1000, 2000],
 	DEFAULT_ROW_LIMIT: 100,
 	/* Row pass/deny tint (#40): classic green/red default; accessible teal/orange */
-	ROW_TINT_OPTIONS: [ 'off', 'classic', 'accessible' ],
+	ROW_TINT_OPTIONS: ['off', 'classic', 'accessible'],
 	DEFAULT_ROW_TINT: 'classic',
-	FETCH_LINES_MAX: 2000, /* ubus poll / logd ring cap (~2000 lines ≈ typical ring) */
+	FETCH_LINES_MAX: 2000 /* ubus poll / logd ring cap (~2000 lines ≈ typical ring) */,
 	/* DOM budget: ~250 new/updated rows painted per second on typical LuCI routers */
 	RENDER_CAP_PER_SEC: 250,
-	VIEW_MODES: [ 'simple', 'detailed' ],
+	VIEW_MODES: ['simple', 'detailed'],
 	COLUMN_SETS: {
-		simple: [ 'action', 'time', 'iface', 'flow', 'proto', 'rule' ],
-		detailed: [ 'time', 'action', 'rule', 'iface_in', 'iface_out', 'dir', 'proto', 'src', 'sport', 'dst', 'dport', 'flags', 'len', 'message' ]
+		simple: ['action', 'time', 'iface', 'flow', 'proto', 'rule'],
+		detailed: [
+			'time',
+			'action',
+			'rule',
+			'iface_in',
+			'iface_out',
+			'dir',
+			'proto',
+			'src',
+			'sport',
+			'dst',
+			'dport',
+			'flags',
+			'len',
+			'message'
+		]
 	}
 });

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/constants.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/css.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/hostname.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/hostname.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/hostname.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/hostname.js
@@ -13,10 +13,9 @@ return baseclass.extend({
 	FAIL_MAX: 1000,
 
 	/* Touch-on-write LRU: re-insert moves key to newest; evict oldest when over max. */
-	lruSet: function(map, key, value, max) {
+	lruSet: function (map, key, value, max) {
 		const cap = max || this.CACHE_MAX;
-		if (map.has(key))
-			map.delete(key);
+		if (map.has(key)) map.delete(key);
 		map.set(key, value);
 		while (map.size > cap) {
 			const oldest = map.keys().next().value;
@@ -25,33 +24,30 @@ return baseclass.extend({
 		return map;
 	},
 
-	lruGet: function(map, key) {
-		if (!map.has(key))
-			return undefined;
+	lruGet: function (map, key) {
+		if (!map.has(key)) return undefined;
 		const value = map.get(key);
 		map.delete(key);
 		map.set(key, value);
 		return value;
 	},
 
-	failIsHot: function(failedMap, ip, nowMs, ttlMs) {
-		if (!failedMap || !failedMap.has(ip))
-			return false;
+	failIsHot: function (failedMap, ip, nowMs, ttlMs) {
+		if (!failedMap || !failedMap.has(ip)) return false;
 		const at = failedMap.get(ip);
 		const ttl = ttlMs == null ? this.FAIL_TTL_MS : ttlMs;
 		const now = nowMs == null ? Date.now() : nowMs;
-		if ((now - at) >= ttl) {
+		if (now - at >= ttl) {
 			failedMap.delete(ip);
 			return false;
 		}
 		return true;
 	},
 
-	failMark: function(failedMap, ip, nowMs, max) {
+	failMark: function (failedMap, ip, nowMs, max) {
 		const cap = max || this.FAIL_MAX;
 		const now = nowMs == null ? Date.now() : nowMs;
-		if (failedMap.has(ip))
-			failedMap.delete(ip);
+		if (failedMap.has(ip)) failedMap.delete(ip);
 		failedMap.set(ip, now);
 		while (failedMap.size > cap) {
 			const oldest = failedMap.keys().next().value;

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass'; /* LuCI require() needs Class.isSubclass — plain return {} fails */
 'require fwlive.log as log';
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/links.js
@@ -18,8 +18,7 @@
  */
 
 function luciUrl(path) {
-	if (typeof L !== 'undefined' && L.url)
-		return L.url(path);
+	if (typeof L !== 'undefined' && L.url) return L.url(path);
 
 	return '/cgi-bin/luci/' + path;
 }
@@ -33,10 +32,14 @@ function firewallZonesUrl() {
 }
 
 function firewallZonesLink(label) {
-	return E('a', {
-		'href': firewallZonesUrl(),
-		'class': 'fwlive-filter-link'
-	}, [ label || _('Network → Firewall') ]);
+	return E(
+		'a',
+		{
+			'href': firewallZonesUrl(),
+			'class': 'fwlive-filter-link'
+		},
+		[label || _('Network → Firewall')]
+	);
 }
 
 /**
@@ -46,15 +49,20 @@ function firewallZonesLink(label) {
  * @param {function} onFilterClick - callback(field, value, ev)
  */
 function filterLink(field, value, label, onFilterClick) {
-	if (!value)
-		return log.formatCell(value);
+	if (!value) return log.formatCell(value);
 
-	return E('a', {
-		'href': '#',
-		'class': 'fwlive-filter-link',
-		'title': _('Filter by %s').format(field),
-		'click': function(ev) { onFilterClick(field, value, ev); }
-	}, [ label || value ]);
+	return E(
+		'a',
+		{
+			'href': '#',
+			'class': 'fwlive-filter-link',
+			'title': _('Filter by %s').format(field),
+			'click': function (ev) {
+				onFilterClick(field, value, ev);
+			}
+		},
+		[label || value]
+	);
 }
 
 /**
@@ -65,19 +73,24 @@ function filterLink(field, value, label, onFilterClick) {
  * @param {function} onFilterClick - callback(field, value, ev)
  */
 function addrFilterLink(field, ip, showHostnames, hostnameCache, onFilterClick) {
-	if (!ip)
-		return log.formatCell(ip);
+	if (!ip) return log.formatCell(ip);
 
 	const name = showHostnames && hostnameCache ? hostnameCache.get(ip) : null;
 	const display = name || ip;
 	const title = name ? ip : _('Filter by %s').format(field);
 
-	return E('a', {
-		'href': '#',
-		'class': 'fwlive-filter-link',
-		'title': title,
-		'click': function(ev) { onFilterClick(field, ip, ev); }
-	}, [ display ]);
+	return E(
+		'a',
+		{
+			'href': '#',
+			'class': 'fwlive-filter-link',
+			'title': title,
+			'click': function (ev) {
+				onFilterClick(field, ip, ev);
+			}
+		},
+		[display]
+	);
 }
 
 /**
@@ -85,11 +98,9 @@ function addrFilterLink(field, ip, showHostnames, hostnameCache, onFilterClick) 
  * @param {string} firewallBackend - 'nft' or 'iptables'
  */
 function ruleAdminPath(hint, firewallBackend) {
-	if (hint === 'fw4')
-		return 'admin/network/firewall/rules';
+	if (hint === 'fw4') return 'admin/network/firewall/rules';
 
-	if (firewallBackend === 'iptables')
-		return 'admin/status/iptables';
+	if (firewallBackend === 'iptables') return 'admin/status/iptables';
 
 	return 'admin/status/nftables';
 }
@@ -101,27 +112,31 @@ function ruleAdminPath(hint, firewallBackend) {
  * @param {function} onFilterClick - callback(field, value, ev)
  */
 function ruleAdminLink(hint, label, firewallBackend, onFilterClick) {
-	if (!hint)
-		return log.formatCell(hint);
+	if (!hint) return log.formatCell(hint);
 
 	const path = ruleAdminPath(hint, firewallBackend);
 	const url = '%s#%s'.format(luciUrl(path), encodeURIComponent(hint));
 	const text = label || hint;
 
-	return E('a', {
-		'href': '#',
-		'class': 'fwlive-filter-link fwlive-rule-link',
-		'title': _('Filter logs by rule (hint: %s). Ctrl+click to open firewall settings.').format(hint),
-		'click': function(ev) {
-			if (ev && (ev.ctrlKey || ev.metaKey)) {
-				if (ev.preventDefault)
-					ev.preventDefault();
-				window.location = url;
-				return;
+	return E(
+		'a',
+		{
+			'href': '#',
+			'class': 'fwlive-filter-link fwlive-rule-link',
+			'title': _(
+				'Filter logs by rule (hint: %s). Ctrl+click to open firewall settings.'
+			).format(hint),
+			'click': function (ev) {
+				if (ev && (ev.ctrlKey || ev.metaKey)) {
+					if (ev.preventDefault) ev.preventDefault();
+					window.location = url;
+					return;
+				}
+				onFilterClick('q', hint, ev);
 			}
-			onFilterClick('q', hint, ev);
-		}
-	}, [ text ]);
+		},
+		[text]
+	);
 }
 
 /**
@@ -129,15 +144,20 @@ function ruleAdminLink(hint, label, firewallBackend, onFilterClick) {
  * @param {function} onFilterClick - callback(field, value, ev)
  */
 function ifaceLink(value, onFilterClick) {
-	if (!value)
-		return log.formatCell(value);
+	if (!value) return log.formatCell(value);
 
-	return E('a', {
-		'href': '#',
-		'class': 'fwlive-filter-link fwlive-iface-badge',
-		'title': _('Filter by interface'),
-		'click': function(ev) { onFilterClick('interface', value, ev); }
-	}, [ value ]);
+	return E(
+		'a',
+		{
+			'href': '#',
+			'class': 'fwlive-filter-link fwlive-iface-badge',
+			'title': _('Filter by interface'),
+			'click': function (ev) {
+				onFilterClick('interface', value, ev);
+			}
+		},
+		[value]
+	);
 }
 
 return baseclass.extend({

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
@@ -10,236 +10,253 @@
  */
 return baseclass.extend({
 	CLASSIFY_SPEC: {
-		glueKeys: ['IN', 'OUT', 'SRC', 'DST', 'PROTO', 'SPT', 'DPT', 'LEN', 'MAC', 'TYPE', 'CODE', 'TTL', 'TOS', 'PREC', 'DF'],
-		nonFirewallPrefixes: ['dnsmasq', 'procd', 'ubusd', 'netifd', 'odhcpd', 'logd', 'dropbear', 'uhttpd', 'hostapd', 'wpad'],
+		glueKeys: [
+			'IN',
+			'OUT',
+			'SRC',
+			'DST',
+			'PROTO',
+			'SPT',
+			'DPT',
+			'LEN',
+			'MAC',
+			'TYPE',
+			'CODE',
+			'TTL',
+			'TOS',
+			'PREC',
+			'DF'
+		],
+		nonFirewallPrefixes: [
+			'dnsmasq',
+			'procd',
+			'ubusd',
+			'netifd',
+			'odhcpd',
+			'logd',
+			'dropbear',
+			'uhttpd',
+			'hostapd',
+			'wpad'
+		],
 		firewallHints: ['fw4', 'nft', 'iptables', 'kernel', 'firewall'],
 		actionWords: ['ACCEPT', 'ALLOW', 'PASS', 'DROP', 'REJECT', 'DENY', 'BLOCK'],
 		rules: [
-			{ or: [
-				{ and: [ { kv: ['SRC'] }, { kv: ['DST'] } ] },
-				{ and: [ { kvAny: ['IN', 'OUT'] }, { kvAny: ['SRC', 'DST', 'PROTO', 'SPT', 'DPT'] } ] },
-				{ and: [ { action: 'known' }, { kvAny: ['IN', 'OUT', 'PROTO', 'SRC', 'DST'] } ] }
-			]},
-			{ and: [ { hint: true }, { action: 'known' } ] },
-			{ and: [ { hint: true }, { kvAny: ['IN', 'OUT', 'SRC', 'DST', 'PROTO'] } ] }
+			{
+				or: [
+					{ and: [{ kv: ['SRC'] }, { kv: ['DST'] }] },
+					{
+						and: [
+							{ kvAny: ['IN', 'OUT'] },
+							{ kvAny: ['SRC', 'DST', 'PROTO', 'SPT', 'DPT'] }
+						]
+					},
+					{ and: [{ action: 'known' }, { kvAny: ['IN', 'OUT', 'PROTO', 'SRC', 'DST'] }] }
+				]
+			},
+			{ and: [{ hint: true }, { action: 'known' }] },
+			{ and: [{ hint: true }, { kvAny: ['IN', 'OUT', 'SRC', 'DST', 'PROTO'] }] }
 		]
 	},
 
 	TCP_FLAG_TAIL: /\b(SYN|ACK|FIN|RST|PSH|URG)(?:\s+(?:SYN|ACK|FIN|RST|PSH|URG))*\s*$/i,
-	NETFILTER_KV_GLUE: /([^\s])(?=(IN|OUT|SRC|DST|PROTO|SPT|DPT|LEN|MAC|TYPE|CODE|TTL|TOS|PREC|DF)=)/g,
+	NETFILTER_KV_GLUE:
+		/([^\s])(?=(IN|OUT|SRC|DST|PROTO|SPT|DPT|LEN|MAC|TYPE|CODE|TTL|TOS|PREC|DF)=)/g,
 
-	wordPattern: function(words) {
+	wordPattern: function (words) {
 		const alt = words.join('|');
 		return new RegExp('(^|[^A-Za-z0-9_])(' + alt + ')([^A-Za-z0-9_]|$)', 'i');
 	},
 
-	kvHas: function(msg, key) {
+	kvHas: function (msg, key) {
 		return new RegExp('(^|[^A-Za-z0-9_])' + key + '=').test(msg);
 	},
 
-	NON_FIREWALL_PREFIX: /^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)([^A-Za-z0-9_]|$)/i,
+	NON_FIREWALL_PREFIX:
+		/^(dnsmasq|procd|ubusd|netifd|odhcpd|logd|dropbear|uhttpd|hostapd|wpad)([^A-Za-z0-9_]|$)/i,
 	FIREWALL_HINT: /(^|[^A-Za-z0-9_])(fw4|nft|iptables|kernel|firewall)([^A-Za-z0-9_]|$)/i,
 	ACTION_RE: /(^|[^A-Za-z0-9_])(ACCEPT|ALLOW|PASS|DROP|REJECT|DENY|BLOCK)([^A-Za-z0-9_]|$)/i,
 	DENY_ACTION: /(^|[^A-Za-z0-9_])(DROP|REJECT|DENY|BLOCK)([^A-Za-z0-9_]|$)/i,
 
-	normalizeNetfilterMessage: function(message) {
+	normalizeNetfilterMessage: function (message) {
 		return (message || '').replace(this.NETFILTER_KV_GLUE, '$1 ');
 	},
 
-	parseKeyValueLog: function(message) {
+	parseKeyValueLog: function (message) {
 		const out = {};
 		const re = /\b([A-Z]+)=([^\s]+)/g;
 		const normalized = this.normalizeNetfilterMessage(message);
 		let match;
 
-		while ((match = re.exec(normalized)) !== null)
-			out[match[1]] = match[2];
+		while ((match = re.exec(normalized)) !== null) out[match[1]] = match[2];
 
 		return out;
 	},
 
-	detectAction: function(message) {
+	detectAction: function (message) {
 		const m = message.match(this.ACTION_RE);
 		return m ? m[2].toUpperCase() : 'UNKNOWN';
 	},
 
-	evaluateClassifySpec: function(message, actionRaw) {
+	evaluateClassifySpec: function (message, actionRaw) {
 		const msg = this.normalizeNetfilterMessage(message || '');
 		const action = actionRaw === undefined ? this.detectAction(msg) : actionRaw;
 		const self = this;
-		const has = function(key) { return self.kvHas(msg, key); };
-		const hasAny = function(keys) {
+		const has = function (key) {
+			return self.kvHas(msg, key);
+		};
+		const hasAny = function (keys) {
 			for (let i = 0; i < keys.length; i++) {
-				if (has(keys[i]))
-					return true;
+				if (has(keys[i])) return true;
 			}
 			return false;
 		};
 
 		const pred = {
-			kv: function(c) {
+			kv: function (c) {
 				for (let i = 0; i < c.kv.length; i++) {
-					if (!has(c.kv[i]))
-						return false;
+					if (!has(c.kv[i])) return false;
 				}
 				return true;
 			},
-			kvAny: function(c) { return hasAny(c.kvAny); },
-			action: function(c) { return (c.action === 'known') ? action !== 'UNKNOWN' : true; },
-			hint: function() { return self.FIREWALL_HINT.test(msg); }
+			kvAny: function (c) {
+				return hasAny(c.kvAny);
+			},
+			action: function (c) {
+				return c.action === 'known' ? action !== 'UNKNOWN' : true;
+			},
+			hint: function () {
+				return self.FIREWALL_HINT.test(msg);
+			}
 		};
 
-		const evalNode = function(node) {
+		const evalNode = function (node) {
 			if (node.and) {
 				for (let i = 0; i < node.and.length; i++) {
-					if (!evalNode(node.and[i]))
-						return false;
+					if (!evalNode(node.and[i])) return false;
 				}
 				return true;
 			}
 			if (node.or) {
 				for (let i = 0; i < node.or.length; i++) {
-					if (evalNode(node.or[i]))
-						return true;
+					if (evalNode(node.or[i])) return true;
 				}
 				return false;
 			}
 			const keys = Object.keys(node);
 			for (let i = 0; i < keys.length; i++) {
 				const k = keys[i];
-				if (pred[k])
-					return pred[k](node);
+				if (pred[k]) return pred[k](node);
 			}
 			return false;
 		};
 
 		for (let i = 0; i < this.CLASSIFY_SPEC.rules.length; i++) {
-			if (evalNode(this.CLASSIFY_SPEC.rules[i]))
-				return true;
+			if (evalNode(this.CLASSIFY_SPEC.rules[i])) return true;
 		}
 		return false;
 	},
 
-	normalizeAction: function(raw) {
+	normalizeAction: function (raw) {
 		const a = (raw || '').toUpperCase();
 		const words = this.CLASSIFY_SPEC.actionWords;
 		const pass = words.slice(0, 3); /* ACCEPT|ALLOW|PASS */
 		const denyClass = words.slice(3); /* DROP|REJECT|DENY|BLOCK — positional */
-		if (pass.indexOf(a) >= 0)
-			return 'pass';
-		if (a === words[3]) /* DROP */
-			return 'drop';
-		if (a === words[4]) /* REJECT */
-			return 'reject';
-		if (denyClass.indexOf(a) >= 0) /* DENY|BLOCK */
-			return 'block';
+		if (pass.indexOf(a) >= 0) return 'pass';
+		if (a === words[3]) /* DROP */ return 'drop';
+		if (a === words[4]) /* REJECT */ return 'reject';
+		if (denyClass.indexOf(a) >= 0) /* DENY|BLOCK */ return 'block';
 		return 'unknown';
 	},
 
-	parseRuleHint: function(message) {
+	parseRuleHint: function (message) {
 		let msg = this.normalizeNetfilterMessage(message || '').trim();
 		msg = msg.replace(/^\[\s*[\d.]+\]\s*/, '');
 
-		if (/^fw4:\s*/i.test(msg))
-			return 'fw4';
+		if (/^fw4:\s*/i.test(msg)) return 'fw4';
 
 		const beforeKv = msg.match(/^([A-Za-z0-9_.-]+)(?::|\s+)(?=IN=|OUT=|SRC=|DST=|PROTO=)/);
-		if (beforeKv)
-			return beforeKv[1];
+		if (beforeKv) return beforeKv[1];
 
 		const colon = msg.match(/^([A-Za-z0-9_.-]+):/);
 		if (colon) {
 			const tag = colon[1].toLowerCase();
-			if (tag !== 'kernel' && tag !== 'iptables')
-				return colon[1];
+			if (tag !== 'kernel' && tag !== 'iptables') return colon[1];
 		}
 
 		return '';
 	},
 
-	formatRuleLabel: function(hint) {
-		if (!hint)
-			return '';
+	formatRuleLabel: function (hint) {
+		if (!hint) return '';
 
-		if (hint === 'fw4')
-			return 'Firewall4';
+		if (hint === 'fw4') return 'Firewall4';
 
 		return hint.replace(/-/g, ' ');
 	},
 
-	inferActionRaw: function(message, kv, actionRaw) {
-		if (actionRaw && actionRaw !== 'UNKNOWN')
-			return actionRaw;
+	inferActionRaw: function (message, kv, actionRaw) {
+		if (actionRaw && actionRaw !== 'UNKNOWN') return actionRaw;
 
 		const msg = this.normalizeNetfilterMessage(message || '');
 		const withoutKv = msg.replace(/\b[A-Z]+=[^\s]*/g, ' ');
-		if (this.DENY_ACTION.test(withoutKv))
-			return 'UNKNOWN';
+		if (this.DENY_ACTION.test(withoutKv)) return 'UNKNOWN';
 
-		if (/^kernel:/i.test(msg.trim()))
-			return 'UNKNOWN';
+		if (/^kernel:/i.test(msg.trim())) return 'UNKNOWN';
 
 		const hasTuple = !!(kv.IN || kv.OUT) && !!(kv.SRC || kv.DST || kv.PROTO);
-		if (hasTuple)
-			return 'PASS';
+		if (hasTuple) return 'PASS';
 
 		return 'UNKNOWN';
 	},
 
-	parseFlags: function(message, kv) {
-		if (kv.TCPFLAGS)
-			return kv.TCPFLAGS;
-		if (kv.FLAGS)
-			return kv.FLAGS;
+	parseFlags: function (message, kv) {
+		if (kv.TCPFLAGS) return kv.TCPFLAGS;
+		if (kv.FLAGS) return kv.FLAGS;
 
 		const m = message.match(this.TCP_FLAG_TAIL);
-		if (!m)
-			return '';
+		if (!m) return '';
 
 		return m[0].trim().toUpperCase().replace(/\s+/g, ',');
 	},
 
-	parseLength: function(kv) {
+	parseLength: function (kv) {
 		const len = kv.LEN || kv.LENGTH || '';
-		if (!len)
-			return null;
+		if (!len) return null;
 
 		const n = parseInt(len, 10);
 		return isFinite(n) ? n : null;
 	},
 
-	timestampUnix: function(entry) {
-		if (!entry || entry.time == null || entry.time === '')
-			return null;
+	timestampUnix: function (entry) {
+		if (!entry || entry.time == null || entry.time === '') return null;
 
 		if (typeof entry.time === 'string' && /^\d{4}-\d{2}-\d{2}[T ]/.test(entry.time)) {
 			const ms = new Date(entry.time).getTime();
-			if (isFinite(ms))
-				return Math.floor(ms / 1000);
+			if (isFinite(ms)) return Math.floor(ms / 1000);
 		}
 
 		const n = Number(entry.time);
-		if (!isFinite(n))
-			return null;
+		if (!isFinite(n)) return null;
 
 		return n > 1e12 ? Math.floor(n / 1000) : Math.floor(n);
 	},
 
-	formatTimestampDisplay: function(entry) {
+	formatTimestampDisplay: function (entry) {
 		const unix = this.timestampUnix(entry);
-		if (unix == null)
-			return '';
+		if (unix == null) return '';
 
 		return new Date(unix * 1000).toISOString();
 	},
 
 	/* @fwlive-codegen:luci-preserve-begin */
-	formatTimestampLocal: function(unix) {
-		if (unix == null || !isFinite(unix))
-			return '';
+	formatTimestampLocal: function (unix) {
+		if (unix == null || !isFinite(unix)) return '';
 
 		const d = new Date(unix * 1000);
-		const pad = function(n) { return (n < 10 ? '0' : '') + n; };
+		const pad = function (n) {
+			return (n < 10 ? '0' : '') + n;
+		};
 
 		return '%d-%s-%s %s:%s:%s'.format(
 			d.getFullYear(),
@@ -251,17 +268,18 @@ return baseclass.extend({
 		);
 	},
 
-	formatTimestampCompact: function(unix) {
-		if (unix == null || !isFinite(unix))
-			return '';
+	formatTimestampCompact: function (unix) {
+		if (unix == null || !isFinite(unix)) return '';
 
 		const d = new Date(unix * 1000);
-		const pad = function(n) { return (n < 10 ? '0' : '') + n; };
+		const pad = function (n) {
+			return (n < 10 ? '0' : '') + n;
+		};
 
 		return '%s:%s:%s'.format(pad(d.getHours()), pad(d.getMinutes()), pad(d.getSeconds()));
 	},
 
-	formatFlowDisplay: function(row) {
+	formatFlowDisplay: function (row) {
 		const src = row && row.src ? String(row.src) : '';
 		const dst = row && row.dst ? String(row.dst) : '';
 		const sport = row && row.sport ? String(row.sport) : '';
@@ -269,75 +287,89 @@ return baseclass.extend({
 		let left = src;
 		let right = dst;
 
-		if (sport)
-			left = left ? (left + ':' + sport) : (':' + sport);
-		if (dport)
-			right = right ? (right + ':' + dport) : (':' + dport);
+		if (sport) left = left ? left + ':' + sport : ':' + sport;
+		if (dport) right = right ? right + ':' + dport : ':' + dport;
 
-		if (!left && !right)
-			return '—';
-		if (!right)
-			return left;
-		if (!left)
-			return '→ ' + right;
+		if (!left && !right) return '—';
+		if (!right) return left;
+		if (!left) return '→ ' + right;
 
 		return left + ' → ' + right;
 	},
 
-	formatCell: function(value) {
-		if (value == null || value === '')
-			return '';
+	formatCell: function (value) {
+		if (value == null || value === '') return '';
 
 		return String(value);
 	},
 
-	formatActionLabel: function(action) {
+	formatActionLabel: function (action) {
 		const a = (action || '').toLowerCase();
-		if (!a || a === 'unknown')
-			return '—';
+		if (!a || a === 'unknown') return '—';
 		return a;
 	},
 
-	formatMessageDisplay: function(message, layout) {
+	formatMessageDisplay: function (message, layout) {
 		let m = this.normalizeNetfilterMessage(message || '');
 		m = m.replace(/^\[\s*[\d.]+\]\s*/, '');
 		m = m.replace(/\bMAC=[^\s]+/g, '');
 		m = m.replace(/\s+/g, ' ').trim();
 
-		if (layout === 'oneline')
-			return m;
+		if (layout === 'oneline') return m;
 
-		if (m.length > 240)
-			return m.substring(0, 237) + '…';
+		if (m.length > 240) return m.substring(0, 237) + '…';
 
 		return m;
 	},
 	/* @fwlive-codegen:luci-preserve-end */
 
-	isFirewallEvent: function(entry) {
+	isFirewallEvent: function (entry) {
 		const msg = this.normalizeNetfilterMessage((entry && entry.msg) || '');
-		if (!msg.trim())
-			return false;
+		if (!msg.trim()) return false;
 
-		if (this.NON_FIREWALL_PREFIX.test(msg))
-			return false;
+		if (this.NON_FIREWALL_PREFIX.test(msg)) return false;
 
 		return this.evaluateClassifySpec(msg);
 	},
 
-	makeEntryId: function(entry, tsUnix, action, src, dst, sport, dport, proto, ifaceIn, ifaceOut) {
-		if (entry && entry.id != null && entry.id !== '')
-			return 'log:' + entry.id;
+	makeEntryId: function (
+		entry,
+		tsUnix,
+		action,
+		src,
+		dst,
+		sport,
+		dport,
+		proto,
+		ifaceIn,
+		ifaceOut
+	) {
+		if (entry && entry.id != null && entry.id !== '') return 'log:' + entry.id;
 
-		return [tsUnix, action, src, dst, sport, dport, proto, ifaceIn, ifaceOut, entry.msg || ''].join('|');
+		return [
+			tsUnix,
+			action,
+			src,
+			dst,
+			sport,
+			dport,
+			proto,
+			ifaceIn,
+			ifaceOut,
+			entry.msg || ''
+		].join('|');
 	},
 
-	normalizeEntry: function(entry) {
+	normalizeEntry: function (entry) {
 		const kv = this.parseKeyValueLog(entry.msg || '');
 		const tsUnix = this.timestampUnix(entry);
 		const tsDisplay = this.formatTimestampDisplay(entry);
 		const proto = (kv.PROTO || '').toUpperCase();
-		const actionRaw = this.inferActionRaw(entry.msg || '', kv, this.detectAction(entry.msg || ''));
+		const actionRaw = this.inferActionRaw(
+			entry.msg || '',
+			kv,
+			this.detectAction(entry.msg || '')
+		);
 		const action = this.normalizeAction(actionRaw);
 		const src = kv.SRC || '';
 		const dst = kv.DST || '';
@@ -346,14 +378,25 @@ return baseclass.extend({
 		const ifaceIn = kv.IN || '';
 		const ifaceOut = kv.OUT || '';
 		const iface = ifaceIn || ifaceOut || '';
-		const dir = ifaceIn && ifaceOut ? 'forward' : (ifaceIn ? 'in' : (ifaceOut ? 'out' : 'unknown'));
+		const dir = ifaceIn && ifaceOut ? 'forward' : ifaceIn ? 'in' : ifaceOut ? 'out' : 'unknown';
 		const flags = this.parseFlags(entry.msg || '', kv);
 		const length = this.parseLength(kv);
 		const ruleHint = this.parseRuleHint(entry.msg || '');
 		const ruleLabel = this.formatRuleLabel(ruleHint);
 
 		return {
-			id: this.makeEntryId(entry, tsUnix, action, src, dst, sport, dport, proto, ifaceIn, ifaceOut),
+			id: this.makeEntryId(
+				entry,
+				tsUnix,
+				action,
+				src,
+				dst,
+				sport,
+				dport,
+				proto,
+				ifaceIn,
+				ifaceOut
+			),
 			log_id: entry && entry.id != null ? Number(entry.id) : null,
 			timestamp: tsUnix,
 			timestamp_display: tsDisplay,
@@ -376,29 +419,25 @@ return baseclass.extend({
 		};
 	},
 
-	parseFilterValue: function(val) {
+	parseFilterValue: function (val) {
 		const s = (val || '').trim();
-		if (!s)
-			return { negate: false, value: '' };
+		if (!s) return { negate: false, value: '' };
 
-		if (s.charAt(0) === '!')
-			return { negate: true, value: s.slice(1).trim() };
+		if (s.charAt(0) === '!') return { negate: true, value: s.slice(1).trim() };
 
 		return { negate: false, value: s };
 	},
 
-	toggleFilterNegation: function(val) {
+	toggleFilterNegation: function (val) {
 		const p = this.parseFilterValue(val);
-		if (!p.value)
-			return val;
+		if (!p.value) return val;
 
 		return p.negate ? p.value : '!' + p.value;
 	},
 
-	formatFilterChipLabel: function(field, val) {
+	formatFilterChipLabel: function (field, val) {
 		const p = this.parseFilterValue(val);
-		if (!p.value)
-			return '';
+		if (!p.value) return '';
 
 		if (p.negate) {
 			if (field === 'q' || field === 'src' || field === 'dst')
@@ -410,19 +449,17 @@ return baseclass.extend({
 		return '%s: %s'.format(field, val);
 	},
 
-	matchesTextField: function(haystack, spec) {
+	matchesTextField: function (haystack, spec) {
 		const p = this.parseFilterValue(spec);
-		if (!p.value)
-			return true;
+		if (!p.value) return true;
 
 		const hit = (haystack || '').indexOf(p.value) !== -1;
 		return p.negate ? !hit : hit;
 	},
 
-	matchesExactField: function(haystack, spec) {
+	matchesExactField: function (haystack, spec) {
 		const p = this.parseFilterValue(spec);
-		if (!p.value)
-			return true;
+		if (!p.value) return true;
 
 		const want = p.value.toUpperCase();
 		const got = (haystack || '').toUpperCase();
@@ -430,18 +467,16 @@ return baseclass.extend({
 		return p.negate ? !hit : hit;
 	},
 
-	matchesFilter: function(row, filters) {
+	matchesFilter: function (row, filters) {
 		if (filters.q) {
 			const p = this.parseFilterValue(filters.q);
 			if (p.value) {
 				const keys = Object.keys(row);
 				const parts = [];
-				for (let i = 0; i < keys.length; i++)
-					parts.push(row[keys[i]]);
+				for (let i = 0; i < keys.length; i++) parts.push(row[keys[i]]);
 				const blob = parts.join(' ').toLowerCase();
 				const hit = blob.indexOf(p.value.toLowerCase()) !== -1;
-				if (p.negate ? hit : !hit)
-					return false;
+				if (p.negate ? hit : !hit) return false;
 			}
 		}
 
@@ -449,10 +484,10 @@ return baseclass.extend({
 			const p = this.parseFilterValue(filters.action);
 			if (p.value) {
 				const want = p.value.toLowerCase();
-				const hit = row.action === want
-					|| (row.action_raw || '').toUpperCase() === p.value.toUpperCase();
-				if (p.negate ? hit : !hit)
-					return false;
+				const hit =
+					row.action === want ||
+					(row.action_raw || '').toUpperCase() === p.value.toUpperCase();
+				if (p.negate ? hit : !hit) return false;
 			}
 		}
 
@@ -460,33 +495,26 @@ return baseclass.extend({
 			const p = this.parseFilterValue(filters.interface);
 			if (p.value) {
 				const iface = p.value;
-				const hit = row.interface === iface
-					|| row.interface_in === iface
-					|| row.interface_out === iface;
-				if (p.negate ? hit : !hit)
-					return false;
+				const hit =
+					row.interface === iface ||
+					row.interface_in === iface ||
+					row.interface_out === iface;
+				if (p.negate ? hit : !hit) return false;
 			}
 		}
 
-		if (filters.proto && !this.matchesExactField(row.proto, filters.proto))
-			return false;
-		if (filters.src && !this.matchesTextField(row.src, filters.src))
-			return false;
-		if (filters.dst && !this.matchesTextField(row.dst, filters.dst))
-			return false;
-		if (filters.sport && !this.matchesExactField(row.sport, filters.sport))
-			return false;
-		if (filters.dport && !this.matchesExactField(row.dport, filters.dport))
-			return false;
+		if (filters.proto && !this.matchesExactField(row.proto, filters.proto)) return false;
+		if (filters.src && !this.matchesTextField(row.src, filters.src)) return false;
+		if (filters.dst && !this.matchesTextField(row.dst, filters.dst)) return false;
+		if (filters.sport && !this.matchesExactField(row.sport, filters.sport)) return false;
+		if (filters.dport && !this.matchesExactField(row.dport, filters.dport)) return false;
 		return true;
 	},
 
-	actionRowClass: function(action) {
+	actionRowClass: function (action) {
 		const a = (action || '').toLowerCase();
-		if (a === 'drop' || a === 'reject' || a === 'block')
-			return 'fwlive-action fwlive-deny';
-		if (a === 'pass')
-			return 'fwlive-action fwlive-pass';
+		if (a === 'drop' || a === 'reject' || a === 'block') return 'fwlive-action fwlive-deny';
+		if (a === 'pass') return 'fwlive-action fwlive-pass';
 		return 'fwlive-action fwlive-unknown';
 	}
 });

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/log.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
@@ -48,10 +48,11 @@ function persistConsentDismissed() {
 
 function blockerCode(state) {
 	const blockers = (state.loggingStatus && state.loggingStatus.blockers) || [];
-	if (blockers.indexOf('no_wan_zone') >= 0)
-		return 'no_wan_zone';
-	if (blockers.indexOf('nf_log_ipv4_missing') >= 0 ||
-	    blockers.indexOf('nf_log_ipv6_missing') >= 0)
+	if (blockers.indexOf('no_wan_zone') >= 0) return 'no_wan_zone';
+	if (
+		blockers.indexOf('nf_log_ipv4_missing') >= 0 ||
+		blockers.indexOf('nf_log_ipv6_missing') >= 0
+	)
 		return 'nf_log_missing';
 	return '';
 }
@@ -68,15 +69,21 @@ function renderToolbar(host, state, callbacks) {
 	const blocker = blockerCode(state);
 
 	if (blocker === 'no_wan_zone') {
-		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-			[ _('WAN logging unavailable: no WAN zone') ]));
+		host.appendChild(
+			E('span', { 'class': 'fwlive-logging-status' }, [
+				_('WAN logging unavailable: no WAN zone')
+			])
+		);
 		host.appendChild(links.firewallZonesLink());
 		return;
 	}
 
 	if (blocker === 'nf_log_missing') {
-		host.appendChild(E('span', { 'class': 'fwlive-logging-status' },
-			[ _('WAN logging unavailable: missing kernel log modules') ]));
+		host.appendChild(
+			E('span', { 'class': 'fwlive-logging-status' }, [
+				_('WAN logging unavailable: missing kernel log modules')
+			])
+		);
 		return;
 	}
 
@@ -84,48 +91,64 @@ function renderToolbar(host, state, callbacks) {
 	if (st.wan_log) {
 		const busy = !!state.loggingBusy;
 		const children = busy
-			? [ _('Disabling…') ]
+			? [_('Disabling…')]
 			: [
-				E('span', { 'class': 'fwlive-log-on-dot', 'aria-hidden': 'true' }, [ '' ]),
-				E('span', { 'class': 'fwlive-log-label' }, [ _('WAN logging on') ]),
-				E('span', { 'class': 'fwlive-log-rate' }, [ _('· %s').format(limit) ])
-			];
-		host.appendChild(E('button', {
-			'class': 'cbi-button fwlive-log-merged',
-			'type': 'button',
-			'title': _('WAN logging on (%s). Click to disable.').format(limit),
-			'disabled': busy ? '' : null,
-			'click': function() { callbacks.onDisable(); }
-		}, children));
+					E('span', { 'class': 'fwlive-log-on-dot', 'aria-hidden': 'true' }, ['']),
+					E('span', { 'class': 'fwlive-log-label' }, [_('WAN logging on')]),
+					E('span', { 'class': 'fwlive-log-rate' }, [_('· %s').format(limit)])
+				];
+		host.appendChild(
+			E(
+				'button',
+				{
+					'class': 'cbi-button fwlive-log-merged',
+					'type': 'button',
+					'title': _('WAN logging on (%s). Click to disable.').format(limit),
+					'disabled': busy ? '' : null,
+					'click': function () {
+						callbacks.onDisable();
+					}
+				},
+				children
+			)
+		);
 		return;
 	}
 
-	host.appendChild(E('button', {
-		'class': 'cbi-button cbi-button-action',
-		'type': 'button',
-		'title': _('Enable WAN zone drop/reject logging (same as Network → Firewall).'),
-		'disabled': state.loggingBusy ? '' : null,
-		'click': function() { callbacks.onEnable(); }
-	}, [ state.loggingBusy ? _('Enabling…') : _('Enable logging') ]));
+	host.appendChild(
+		E(
+			'button',
+			{
+				'class': 'cbi-button cbi-button-action',
+				'type': 'button',
+				'title': _('Enable WAN zone drop/reject logging (same as Network → Firewall).'),
+				'disabled': state.loggingBusy ? '' : null,
+				'click': function () {
+					callbacks.onEnable();
+				}
+			},
+			[state.loggingBusy ? _('Enabling…') : _('Enable logging')]
+		)
+	);
 }
 
 function buildConsentPanel(state, callbacks) {
 	const dontShowId = 'fwlive-consent-dont-show';
 	const panel = E('div', { 'class': 'fwlive-consent', 'id': 'fwlive-consent' }, [
-		E('p', { 'class': 'fwlive-empty-title' }, [ _('Before you enable logging') ]),
+		E('p', { 'class': 'fwlive-empty-title' }, [_('Before you enable logging')]),
 		E('ul', { 'class': 'fwlive-consent-list' }, [
 			E('li', {}, [
-				E('strong', {}, [ _('Changes:') ]),
+				E('strong', {}, [_('Changes:')]),
 				' ',
 				_('sets log on the WAN firewall zone and reloads the firewall.')
 			]),
 			E('li', {}, [
-				E('strong', {}, [ _('Does not change:') ]),
+				E('strong', {}, [_('Does not change:')]),
 				' ',
 				_('allow/deny rules, LAN logging, or anything else.')
 			]),
 			E('li', {}, [
-				E('strong', {}, [ _('Undo:') ]),
+				E('strong', {}, [_('Undo:')]),
 				' ',
 				_('turn it back off with the WAN logging on control on the watch strip.')
 			])
@@ -141,28 +164,34 @@ function buildConsentPanel(state, callbacks) {
 			])
 		]),
 		E('p', { 'class': 'fwlive-consent-actions' }, [
-			E('button', {
-				'class': 'cbi-button cbi-button-action',
-				'type': 'button',
-				'disabled': state.loggingBusy ? '' : null,
-				'click': function() {
-					persistConsentDismissed();
-					callbacks.onEnable();
-				}
-			}, [ state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging') ]),
-			' ',
-			E('button', {
-				'class': 'cbi-button',
-				'type': 'button',
-				'click': function() {
-					const box = document.getElementById(dontShowId);
-					const persist = !!(box && box.checked);
-					if (persist)
+			E(
+				'button',
+				{
+					'class': 'cbi-button cbi-button-action',
+					'type': 'button',
+					'disabled': state.loggingBusy ? '' : null,
+					'click': function () {
 						persistConsentDismissed();
-					if (callbacks.onDismissConsent)
-						callbacks.onDismissConsent(persist);
-				}
-			}, [ _('Not now') ]),
+						callbacks.onEnable();
+					}
+				},
+				[state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging')]
+			),
+			' ',
+			E(
+				'button',
+				{
+					'class': 'cbi-button',
+					'type': 'button',
+					'click': function () {
+						const box = document.getElementById(dontShowId);
+						const persist = !!(box && box.checked);
+						if (persist) persistConsentDismissed();
+						if (callbacks.onDismissConsent) callbacks.onDismissConsent(persist);
+					}
+				},
+				[_('Not now')]
+			),
 			' ',
 			links.firewallZonesLink(_('I’ll configure this under Network → Firewall'))
 		])
@@ -176,41 +205,71 @@ function buildEmptyStateNodes(state, callbacks) {
 	const blocker = blockerCode(state);
 
 	if (state.loggingNotice) {
-		nodes.push(E('p', { 'class': 'fwlive-logging-notice' }, [
-			state.loggingNotice,
-			' ',
-			links.firewallZonesLink()
-		]));
+		nodes.push(
+			E('p', { 'class': 'fwlive-logging-notice' }, [
+				state.loggingNotice,
+				' ',
+				links.firewallZonesLink()
+			])
+		);
 	}
 
 	if (blocker === 'no_wan_zone') {
-		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('No WAN zone found') ]));
-		nodes.push(E('p', {}, [
-			_('No WAN firewall zone found in /etc/config/firewall. Configure zones under '),
-			links.firewallZonesLink()
-		]));
+		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [_('No WAN zone found')]));
+		nodes.push(
+			E('p', {}, [
+				_('No WAN firewall zone found in /etc/config/firewall. Configure zones under '),
+				links.firewallZonesLink()
+			])
+		);
 		return nodes;
 	}
 
 	if (blocker === 'nf_log_missing') {
-		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('Kernel log modules missing') ]));
-		nodes.push(E('p', {}, [ _('Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall.') ]));
-		nodes.push(E('p', {}, [
-			E('code', {}, [ 'opkg update && opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6' ])
-		]));
+		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [_('Kernel log modules missing')]));
+		nodes.push(
+			E('p', {}, [
+				_(
+					'Kernel netfilter log modules are missing. Install kmod-nf-log-ipv4 and kmod-nf-log-ipv6 (or kmod-nf-log / kmod-nf-log6), then reload the firewall.'
+				)
+			])
+		);
+		nodes.push(
+			E('p', {}, [
+				E('code', {}, ['opkg update && opkg install kmod-nf-log-ipv4 kmod-nf-log-ipv6'])
+			])
+		);
 		return nodes;
 	}
 
 	if (st && st.wan_log) {
-		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('Waiting for firewall events') ]));
-		nodes.push(E('p', {}, [ _('WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not.') ]));
-		nodes.push(E('p', { 'class': 'fwlive-empty-muted' }, [ _('If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide.') ]));
+		nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [_('Waiting for firewall events')]));
+		nodes.push(
+			E('p', {}, [
+				_(
+					'WAN drop/reject logging is on. Blocked inbound WAN traffic will show up here. Normal LAN browsing will not.'
+				)
+			])
+		);
+		nodes.push(
+			E('p', { 'class': 'fwlive-empty-muted' }, [
+				_(
+					'If the WAN is quiet, wait for probes or use the optional ping check in Help / the enabling-logs guide.'
+				)
+			])
+		);
 		nodes.push(E('p', {}, links.firewallZonesLink(_('Open firewall zone settings'))));
 		return nodes;
 	}
 
-	nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [ _('Logging is off on this router') ]));
-	nodes.push(E('p', {}, [ _('OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules.') ]));
+	nodes.push(E('p', { 'class': 'fwlive-empty-title' }, [_('Logging is off on this router')]));
+	nodes.push(
+		E('p', {}, [
+			_(
+				'OpenWrt does not write firewall events to the log until you turn logging on. Live View only shows what the firewall already logs — it does not add allow/deny rules.'
+			)
+		])
+	);
 
 	/* Consent bullets already spell out the effect — do not repeat it or the CTA. */
 	if (state.showConsent) {
@@ -218,29 +277,42 @@ function buildEmptyStateNodes(state, callbacks) {
 		return nodes;
 	}
 
-	nodes.push(E('p', {}, [ _('Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged.') ]));
-	nodes.push(E('p', { 'class': 'fwlive-empty-muted' }, [ _('Nothing changes until you click Enable.') ]));
-	nodes.push(E('p', {}, [
-		E('button', {
-			'class': 'cbi-button cbi-button-action',
-			'type': 'button',
-			'disabled': state.loggingBusy ? '' : null,
-			'click': function() {
-				persistConsentDismissed();
-				callbacks.onEnable();
-			}
-		}, [ state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging') ]),
-		' ',
-		links.firewallZonesLink(_('I’ll configure this under Network → Firewall'))
-	]));
+	nodes.push(
+		E('p', {}, [
+			_(
+				'Turns on WAN zone drop/reject logging (same as Network → Firewall → wan → Log). Rate-limited by the zone log_limit (OpenWrt default 10/minute). Normal LAN browsing is not logged.'
+			)
+		])
+	);
+	nodes.push(
+		E('p', { 'class': 'fwlive-empty-muted' }, [_('Nothing changes until you click Enable.')])
+	);
+	nodes.push(
+		E('p', {}, [
+			E(
+				'button',
+				{
+					'class': 'cbi-button cbi-button-action',
+					'type': 'button',
+					'disabled': state.loggingBusy ? '' : null,
+					'click': function () {
+						persistConsentDismissed();
+						callbacks.onEnable();
+					}
+				},
+				[state.loggingBusy ? _('Enabling…') : _('Enable WAN drop/reject logging')]
+			),
+			' ',
+			links.firewallZonesLink(_('I’ll configure this under Network → Firewall'))
+		])
+	);
 	return nodes;
 }
 
 function renderEmptyState(host, state, callbacks) {
 	const nodes = buildEmptyStateNodes(state, callbacks);
 	host.innerHTML = '';
-	for (let i = 0; i < nodes.length; i++)
-		host.appendChild(nodes[i]);
+	for (let i = 0; i < nodes.length; i++) host.appendChild(nodes[i]);
 }
 
 /**
@@ -252,11 +324,19 @@ function renderManualTestNodes(host, state, _callbacks) {
 	host.innerHTML = '';
 	if (state.firewallBackend === 'iptables') {
 		host.appendChild(document.createTextNode(_('Manual test (System → Terminal): ')));
-		host.appendChild(E('code', {}, [ 'iptables -I INPUT -p icmp --icmp-type echo-request -j LOG --log-prefix "fwlive-ping: "' ]));
+		host.appendChild(
+			E('code', {}, [
+				'iptables -I INPUT -p icmp --icmp-type echo-request -j LOG --log-prefix "fwlive-ping: "'
+			])
+		);
 		host.appendChild(document.createTextNode(_(' then ping the router.')));
 	} else {
 		host.appendChild(document.createTextNode(_('Manual test (System → Terminal): ')));
-		host.appendChild(E('code', {}, [ 'nft insert rule inet fw4 input ip protocol icmp icmp type echo-request log prefix "fwlive-ping " accept' ]));
+		host.appendChild(
+			E('code', {}, [
+				'nft insert rule inet fw4 input ip protocol icmp icmp type echo-request log prefix "fwlive-ping " accept'
+			])
+		);
 		host.appendChild(document.createTextNode(_(' then ping the router.')));
 	}
 }

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/logging.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 'require fwlive.links as links';
 

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/proto.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/proto.js
@@ -9,25 +9,23 @@
  */
 
 return baseclass.extend({
-	readProtoFilter: function() {
+	readProtoFilter: function () {
 		const custom = document.getElementById('fwlive-proto-custom');
 		if (custom) {
 			const typed = (custom.value || '').trim();
-			if (typed)
-				return typed;
+			if (typed) return typed;
 		}
 		const sel = document.getElementById('fwlive-proto');
-		return sel ? (sel.value || '') : '';
+		return sel ? sel.value || '' : '';
 	},
 
-	setProtoFilterValue: function(value) {
+	setProtoFilterValue: function (value) {
 		const sel = document.getElementById('fwlive-proto');
 		const custom = document.getElementById('fwlive-proto-custom');
-		if (!sel)
-			return false;
+		if (!sel) return false;
 
 		value = value || '';
-		let inMenu = (value === '');
+		let inMenu = value === '';
 		if (!inMenu) {
 			for (let i = 0; i < sel.options.length; i++) {
 				if (sel.options[i].value === value) {
@@ -39,12 +37,10 @@ return baseclass.extend({
 
 		if (inMenu) {
 			sel.value = value;
-			if (custom)
-				custom.value = '';
+			if (custom) custom.value = '';
 		} else {
 			sel.value = '';
-			if (custom)
-				custom.value = value;
+			if (custom) custom.value = value;
 		}
 
 		return true;

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/proto.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/proto.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass'; /* LuCI require() needs Class.isSubclass — plain return {} fails */
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 'require fwlive.log as log';
 'require fwlive.links as links';

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/table.js
@@ -53,23 +53,36 @@ function columnLabel(col) {
 
 function columnCellClass(col) {
 	switch (col) {
-	case 'time': return 'fwlive-time';
-	case 'action': return 'fwlive-action';
-	case 'rule': return 'fwlive-rule';
-	case 'iface':
-	case 'iface_in':
-	case 'iface_out': return 'fwlive-iface';
-	case 'dir': return 'fwlive-dir';
-	case 'proto': return 'fwlive-proto';
-	case 'src':
-	case 'dst': return 'fwlive-addr';
-	case 'sport':
-	case 'dport': return 'fwlive-port';
-	case 'flags': return 'fwlive-flags';
-	case 'len': return 'fwlive-len';
-	case 'flow': return 'fwlive-flow-cell';
-	case 'message': return 'fwlive-message fwlive-th-message';
-	default: return '';
+		case 'time':
+			return 'fwlive-time';
+		case 'action':
+			return 'fwlive-action';
+		case 'rule':
+			return 'fwlive-rule';
+		case 'iface':
+		case 'iface_in':
+		case 'iface_out':
+			return 'fwlive-iface';
+		case 'dir':
+			return 'fwlive-dir';
+		case 'proto':
+			return 'fwlive-proto';
+		case 'src':
+		case 'dst':
+			return 'fwlive-addr';
+		case 'sport':
+		case 'dport':
+			return 'fwlive-port';
+		case 'flags':
+			return 'fwlive-flags';
+		case 'len':
+			return 'fwlive-len';
+		case 'flow':
+			return 'fwlive-flow-cell';
+		case 'message':
+			return 'fwlive-message fwlive-th-message';
+		default:
+			return '';
 	}
 }
 
@@ -77,26 +90,30 @@ function flowCell(row, state, callbacks) {
 	const parts = [];
 	const onFilterClick = callbacks.onFilterClick;
 	const pushAddr = (addr, port, addrField, portField) => {
-		if (!addr && !port)
-			return;
+		if (!addr && !port) return;
 
 		if (addr)
-			parts.push(links.addrFilterLink(addrField, addr,
-				!!state.showHostnames, state.hostnameCache, onFilterClick));
+			parts.push(
+				links.addrFilterLink(
+					addrField,
+					addr,
+					!!state.showHostnames,
+					state.hostnameCache,
+					onFilterClick
+				)
+			);
 		if (port) {
-			if (addr)
-				parts.push(':');
+			if (addr) parts.push(':');
 			parts.push(links.filterLink(portField, port, port, onFilterClick));
 		}
 	};
 
 	pushAddr(row.src, row.sport, 'src', 'sport');
 	if (parts.length && (row.dst || row.dport))
-		parts.push(E('span', { 'class': 'fwlive-flow-arrow' }, [ ' → ' ]));
+		parts.push(E('span', { 'class': 'fwlive-flow-arrow' }, [' → ']));
 	pushAddr(row.dst, row.dport, 'dst', 'dport');
 
-	if (!parts.length)
-		return '—';
+	if (!parts.length) return '—';
 
 	return E('span', { 'class': 'fwlive-flow' }, parts);
 }
@@ -104,76 +121,120 @@ function flowCell(row, state, callbacks) {
 function buildColumnCell(col, row, state, callbacks) {
 	const onFilterClick = callbacks.onFilterClick;
 	const msgDisplay = log.formatMessageDisplay(row.message, state.messageLayout);
-	const actionCell = row.action && row.action !== 'unknown'
-		? links.filterLink('action', row.action, log.formatActionLabel(row.action), onFilterClick)
-		: log.formatActionLabel(row.action);
+	const actionCell =
+		row.action && row.action !== 'unknown'
+			? links.filterLink(
+					'action',
+					row.action,
+					log.formatActionLabel(row.action),
+					onFilterClick
+				)
+			: log.formatActionLabel(row.action);
 
 	switch (col) {
-	case 'time': {
-		const timeAttrs = { 'class': columnCellClass(col) };
-		if (state.viewMode === 'simple')
-			timeAttrs.title = _('Click a row for the full message');
-		return E('td', timeAttrs,
-			[ state.viewMode === 'simple'
-				? log.formatTimestampCompact(row.timestamp)
-				: log.formatTimestampLocal(row.timestamp) ]);
-	}
-	case 'action':
-		return E('td', { 'class': log.actionRowClass(row.action) }, [ actionCell ]);
-	case 'rule':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.ruleAdminLink(row.rule_hint, row.rule_label, state.firewallBackend, onFilterClick) ]);
-	case 'iface':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.ifaceLink(row.interface_in, onFilterClick) ]);
-	case 'iface_in':
-	case 'iface_out':
-		return E('td', { 'class': columnCellClass(col) }, [ links.ifaceLink(
-			col === 'iface_in' ? row.interface_in : row.interface_out, onFilterClick) ]);
-	case 'dir':
-		return E('td', { 'class': columnCellClass(col) }, [ log.formatCell(row.direction) ]);
-	case 'proto':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.filterLink('proto', row.proto, null, onFilterClick) ]);
-	case 'src':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.addrFilterLink('src', row.src, !!state.showHostnames, state.hostnameCache, onFilterClick) ]);
-	case 'sport':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.filterLink('sport', row.sport, null, onFilterClick) ]);
-	case 'dst':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.addrFilterLink('dst', row.dst, !!state.showHostnames, state.hostnameCache, onFilterClick) ]);
-	case 'dport':
-		return E('td', { 'class': columnCellClass(col) },
-			[ links.filterLink('dport', row.dport, null, onFilterClick) ]);
-	case 'flags':
-		return E('td', { 'class': columnCellClass(col) }, [ log.formatCell(row.flags) ]);
-	case 'len':
-		return E('td', { 'class': columnCellClass(col) }, [ row.length != null ? String(row.length) : '' ]);
-	case 'flow':
-		return E('td', { 'class': columnCellClass(col) }, [ flowCell(row, state, callbacks) ]);
-	case 'message':
-		if (state.messageLayout === 'wrap') {
-			return E('td', {
-				'class': 'fwlive-message',
-				'title': msgDisplay || ''
-			}, E('div', { 'class': 'fwlive-message-wrap' }, [ msgDisplay || '—' ]));
+		case 'time': {
+			const timeAttrs = { 'class': columnCellClass(col) };
+			if (state.viewMode === 'simple')
+				timeAttrs.title = _('Click a row for the full message');
+			return E('td', timeAttrs, [
+				state.viewMode === 'simple'
+					? log.formatTimestampCompact(row.timestamp)
+					: log.formatTimestampLocal(row.timestamp)
+			]);
 		}
-		return E('td', {
-			'class': 'fwlive-message',
-			'title': msgDisplay || ''
-		}, [ msgDisplay || '—' ]);
-	default:
-		return E('td', {}, [ '' ]);
+		case 'action':
+			return E('td', { 'class': log.actionRowClass(row.action) }, [actionCell]);
+		case 'rule':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.ruleAdminLink(
+					row.rule_hint,
+					row.rule_label,
+					state.firewallBackend,
+					onFilterClick
+				)
+			]);
+		case 'iface':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.ifaceLink(row.interface_in, onFilterClick)
+			]);
+		case 'iface_in':
+		case 'iface_out':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.ifaceLink(
+					col === 'iface_in' ? row.interface_in : row.interface_out,
+					onFilterClick
+				)
+			]);
+		case 'dir':
+			return E('td', { 'class': columnCellClass(col) }, [log.formatCell(row.direction)]);
+		case 'proto':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.filterLink('proto', row.proto, null, onFilterClick)
+			]);
+		case 'src':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.addrFilterLink(
+					'src',
+					row.src,
+					!!state.showHostnames,
+					state.hostnameCache,
+					onFilterClick
+				)
+			]);
+		case 'sport':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.filterLink('sport', row.sport, null, onFilterClick)
+			]);
+		case 'dst':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.addrFilterLink(
+					'dst',
+					row.dst,
+					!!state.showHostnames,
+					state.hostnameCache,
+					onFilterClick
+				)
+			]);
+		case 'dport':
+			return E('td', { 'class': columnCellClass(col) }, [
+				links.filterLink('dport', row.dport, null, onFilterClick)
+			]);
+		case 'flags':
+			return E('td', { 'class': columnCellClass(col) }, [log.formatCell(row.flags)]);
+		case 'len':
+			return E('td', { 'class': columnCellClass(col) }, [
+				row.length != null ? String(row.length) : ''
+			]);
+		case 'flow':
+			return E('td', { 'class': columnCellClass(col) }, [flowCell(row, state, callbacks)]);
+		case 'message':
+			if (state.messageLayout === 'wrap') {
+				return E(
+					'td',
+					{
+						'class': 'fwlive-message',
+						'title': msgDisplay || ''
+					},
+					E('div', { 'class': 'fwlive-message-wrap' }, [msgDisplay || '—'])
+				);
+			}
+			return E(
+				'td',
+				{
+					'class': 'fwlive-message',
+					'title': msgDisplay || ''
+				},
+				[msgDisplay || '—']
+			);
+		default:
+			return E('td', {}, ['']);
 	}
 }
 
 function renderThead(host, state, _callbacks) {
 	const columns = state.columns || [];
 	const tr = host.querySelector('thead tr');
-	if (!tr)
-		return;
+	if (!tr) return;
 
 	let colgroup = host.querySelector('colgroup');
 
@@ -187,8 +248,10 @@ function renderThead(host, state, _callbacks) {
 
 	for (let i = 0; i < columns.length; i++) {
 		const col = columns[i];
-		colgroup.appendChild(E('col', { 'class': 'fwlive-col fwlive-col-' + col.replace(/_/g, '-') }));
-		tr.appendChild(E('th', { 'class': columnCellClass(col) }, [ columnLabel(col) ]));
+		colgroup.appendChild(
+			E('col', { 'class': 'fwlive-col fwlive-col-' + col.replace(/_/g, '-') })
+		);
+		tr.appendChild(E('th', { 'class': columnCellClass(col) }, [columnLabel(col)]));
 	}
 }
 
@@ -205,26 +268,34 @@ function renderRows(host, state, callbacks) {
 			state.viewMode === 'simple' ? 'fwlive-row-clickable' : '',
 			state.expandedRowId === r.id ? 'fwlive-row-expanded' : '',
 			state.rowTint ? callbacks.actionRowTintClass(r.action) : ''
-		].filter(Boolean).join(' ');
+		]
+			.filter(Boolean)
+			.join(' ');
 		const cells = [];
 		for (let c = 0; c < columns.length; c++)
 			cells.push(buildColumnCell(columns[c], r, state, callbacks));
 
-		const tr = E('tr', {
-			'class': rowClass,
-			'click': state.viewMode === 'simple'
-				? (ev) => callbacks.onRowClick(r.id, ev) : null
-		}, cells);
+		const tr = E(
+			'tr',
+			{
+				'class': rowClass,
+				'click': state.viewMode === 'simple' ? (ev) => callbacks.onRowClick(r.id, ev) : null
+			},
+			cells
+		);
 		host.appendChild(tr);
 
 		if (state.viewMode === 'simple' && state.expandedRowId === r.id) {
-			host.appendChild(E('tr', { 'class': 'fwlive-msg-expand' }, [
-				E('td', { 'colspan': String(columns.length) }, [
-					E('div', { 'class': 'fwlive-msg-expand-label' }, [ _('Message') ]),
-					E('pre', { 'class': 'fwlive-msg-expand-body' },
-						[ log.formatMessageDisplay(r.message, 'wrap') || '—' ])
+			host.appendChild(
+				E('tr', { 'class': 'fwlive-msg-expand' }, [
+					E('td', { 'colspan': String(columns.length) }, [
+						E('div', { 'class': 'fwlive-msg-expand-label' }, [_('Message')]),
+						E('pre', { 'class': 'fwlive-msg-expand-body' }, [
+							log.formatMessageDisplay(r.message, 'wrap') || '—'
+						])
+					])
 				])
-			]));
+			);
 		}
 	}
 }

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/tint.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/tint.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 'require baseclass';
 
 /**

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/tint.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/tint.js
@@ -23,8 +23,7 @@ var PASS_HEX = CLASSIC_PASS_HEX;
 var DENY_HEX = CLASSIC_DENY_HEX;
 
 function normalizeRowTint(mode) {
-	if (mode === 'off' || mode === 'accessible' || mode === 'classic')
-		return mode;
+	if (mode === 'off' || mode === 'accessible' || mode === 'classic') return mode;
 	return 'classic';
 }
 
@@ -35,16 +34,13 @@ function hexPairForMode(mode) {
 }
 
 function parseCssRgbChannels(value) {
-	if (!value)
-		return null;
+	if (!value) return null;
 
 	const s = String(value).trim().toLowerCase();
-	if (s === 'transparent' || s === 'rgba(0, 0, 0, 0)' || s === 'rgba(0,0,0,0)')
-		return null;
+	if (s === 'transparent' || s === 'rgba(0, 0, 0, 0)' || s === 'rgba(0,0,0,0)') return null;
 
 	const rgb = s.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
-	if (rgb)
-		return [ parseFloat(rgb[1]), parseFloat(rgb[2]), parseFloat(rgb[3]) ];
+	if (rgb) return [parseFloat(rgb[1]), parseFloat(rgb[2]), parseFloat(rgb[3])];
 
 	/* color-mix() often serializes as color(srgb r g b[/a]) with 0..1 channels. */
 	const modern = s.match(/color\(\s*srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/i);
@@ -62,27 +58,22 @@ function cssColorPaintDelta(a, b) {
 	const ca = parseCssRgbChannels(a);
 	const cb = parseCssRgbChannels(b);
 	/* Transparent vs opaque color is a real paint change (common off-state). */
-	if (!ca && !cb)
-		return 0;
-	if (!ca && cb)
-		return Math.abs(cb[0]) + Math.abs(cb[1]) + Math.abs(cb[2]);
-	if (ca && !cb)
-		return Math.abs(ca[0]) + Math.abs(ca[1]) + Math.abs(ca[2]);
+	if (!ca && !cb) return 0;
+	if (!ca && cb) return Math.abs(cb[0]) + Math.abs(cb[1]) + Math.abs(cb[2]);
+	if (ca && !cb) return Math.abs(ca[0]) + Math.abs(ca[1]) + Math.abs(ca[2]);
 
 	return Math.abs(ca[0] - cb[0]) + Math.abs(ca[1] - cb[1]) + Math.abs(ca[2] - cb[2]);
 }
 
 function tintShouldEngageFallback(opts) {
 	const o = opts || {};
-	const minDelta = (typeof o.minDelta === 'number') ? o.minDelta : PAINT_DELTA_MIN;
+	const minDelta = typeof o.minDelta === 'number' ? o.minDelta : PAINT_DELTA_MIN;
 
 	/* Visible paint is the success criterion; token/CSS.supports are only used when
 	   paint cannot be measured (no delta sample yet). */
-	if (typeof o.paintDelta === 'number')
-		return o.paintDelta < minDelta;
+	if (typeof o.paintDelta === 'number') return o.paintDelta < minDelta;
 
-	if (o.tokenResolved === false)
-		return true;
+	if (o.tokenResolved === false) return true;
 
 	return false;
 }

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -23,7 +23,7 @@
 const callFwlivePoll = rpc.declare({
 	object: 'fwlive',
 	method: 'poll',
-	params: [ 'addresses' ]
+	params: ['addresses']
 	/* Full reply object kept so reply.error reaches fetchEntries (#233). */
 });
 
@@ -35,23 +35,25 @@ const callFwliveRules = rpc.declare({
 const callFwliveResolve = rpc.declare({
 	object: 'fwlive',
 	method: 'resolve',
-	params: [ 'addresses' ],
+	params: ['addresses'],
 	expect: { names: {} }
 });
 
 const callFwliveLoggingStatus = rpc.declare({
 	object: 'fwlive',
 	method: 'logging_status',
-	expect: { '': {
-		wan_zone: null,
-		wan_log: false,
-		wan_log_limit: null,
-		nf_log_ipv4: false,
-		nf_log_ipv6: false,
-		ready: false,
-		blockers: [],
-		warnings: []
-	} }
+	expect: {
+		'': {
+			wan_zone: null,
+			wan_log: false,
+			wan_log_limit: null,
+			nf_log_ipv4: false,
+			nf_log_ipv6: false,
+			ready: false,
+			blockers: [],
+			warnings: []
+		}
+	}
 });
 
 const callFwliveEnableLogging = rpc.declare({
@@ -69,7 +71,7 @@ const callFwliveDisableLogging = rpc.declare({
 function storedValue(key, fallback) {
 	try {
 		const v = localStorage.getItem(key);
-		return (v === null) ? fallback : v;
+		return v === null ? fallback : v;
 	} catch (e) {
 		return fallback;
 	}
@@ -86,7 +88,7 @@ function storeValue(key, value) {
 function optionNodes(pairs) {
 	const opts = [];
 	for (let i = 0; i < pairs.length; i++)
-		opts.push(E('option', { 'value': pairs[i][0] }, [ pairs[i][1] ]));
+		opts.push(E('option', { 'value': pairs[i][0] }, [pairs[i][1]]));
 	return opts;
 }
 
@@ -148,7 +150,7 @@ return view.extend({
 	readFilters() {
 		const val = (id) => {
 			const el = document.getElementById(id);
-			return el ? (el.value || '') : '';
+			return el ? el.value || '' : '';
 		};
 		return {
 			q: val('fwlive-q').trim(),
@@ -168,20 +170,17 @@ return view.extend({
 			.map((k) => '%s=%s'.format(encodeURIComponent(k), encodeURIComponent(filters[k])));
 		if (this.rowLimit !== constants.DEFAULT_ROW_LIMIT)
 			parts.push('limit=%s'.format(encodeURIComponent(this.rowLimit)));
-		if (this.viewMode === 'detailed')
-			parts.push('view=detailed');
+		if (this.viewMode === 'detailed') parts.push('view=detailed');
 		location.hash = parts.join('&');
 	},
 
 	applyHash() {
-		if (!location.hash || location.hash.length < 2)
-			return;
+		if (!location.hash || location.hash.length < 2) return;
 
 		const entries = location.hash.substring(1).split('&');
 		for (let i = 0; i < entries.length; i++) {
 			const kv = entries[i].split('=');
-			if (kv.length !== 2)
-				continue;
+			if (kv.length !== 2) continue;
 			const key = decodeURIComponent(kv[0]);
 			const val = decodeURIComponent(kv[1]);
 			if (key === 'limit') {
@@ -193,10 +192,8 @@ return view.extend({
 				continue;
 			}
 			if (key === 'view') {
-				if (val === 'advanced' || val === 'detailed')
-					this.viewMode = 'detailed';
-				else if (val === 'simple')
-					this.viewMode = 'simple';
+				if (val === 'advanced' || val === 'detailed') this.viewMode = 'detailed';
+				else if (val === 'simple') this.viewMode = 'simple';
 				continue;
 			}
 			const el = document.getElementById('fwlive-' + key);
@@ -204,17 +201,14 @@ return view.extend({
 				proto.setProtoFilterValue(val);
 				continue;
 			}
-			if (el)
-				el.value = val;
+			if (el) el.value = val;
 		}
 	},
 
 	readViewMode() {
 		const v = storedValue('fwlive-view-mode', null);
-		if (v === 'advanced' || v === 'detailed')
-			return 'detailed';
-		if (v === 'simple')
-			return 'simple';
+		if (v === 'advanced' || v === 'detailed') return 'detailed';
+		if (v === 'simple') return 'simple';
 		return 'simple';
 	},
 
@@ -232,15 +226,11 @@ return view.extend({
 
 	readRowTint() {
 		const v = storedValue('fwlive-row-tint', null);
-		if (v === null)
-			return constants.DEFAULT_ROW_TINT;
+		if (v === null) return constants.DEFAULT_ROW_TINT;
 		/* Migrate pre-mode checkbox storage. */
-		if (v === '1' || v === 'true')
-			return 'classic';
-		if (v === '0' || v === 'false')
-			return 'off';
-		if (constants.ROW_TINT_OPTIONS.indexOf(v) >= 0)
-			return v;
+		if (v === '1' || v === 'true') return 'classic';
+		if (v === '0' || v === 'false') return 'off';
+		if (constants.ROW_TINT_OPTIONS.indexOf(v) >= 0) return v;
 		return constants.DEFAULT_ROW_TINT;
 	},
 
@@ -250,8 +240,8 @@ return view.extend({
 
 	rowTintPaletteOptions() {
 		return optionNodes([
-			[ 'classic', _('Classic (green/red)') ],
-			[ 'accessible', _('Accessible (teal/orange)') ]
+			['classic', _('Classic (green/red)')],
+			['accessible', _('Accessible (teal/orange)')]
 		]);
 	},
 
@@ -261,23 +251,20 @@ return view.extend({
 
 	applyRowTintMode() {
 		const map = document.querySelector('.fwlive-map');
-		if (!map)
-			return;
+		if (!map) return;
 
 		map.setAttribute('data-row-tint', this.rowTint);
-		if (!this.rowTintEnabled() && this.tintFallbackActive)
-			this.clearTintFallback(map);
+		if (!this.rowTintEnabled() && this.tintFallbackActive) this.clearTintFallback(map);
 	},
 
 	onRowTintEnabledChange(ev) {
 		const on = !!(ev && ev.target && ev.target.checked);
 		if (on) {
-			const pal = (this.rowTintPalette === 'accessible') ? 'accessible' : 'classic';
+			const pal = this.rowTintPalette === 'accessible' ? 'accessible' : 'classic';
 			this.rowTintPalette = pal;
 			this.rowTint = pal;
 		} else {
-			if (this.rowTintEnabled())
-				this.rowTintPalette = this.rowTint;
+			if (this.rowTintEnabled()) this.rowTintPalette = this.rowTint;
 			this.rowTint = 'off';
 		}
 		this.commitRowTintChange();
@@ -293,10 +280,9 @@ return view.extend({
 
 	onRowTintPaletteChange(ev) {
 		const v = ev && ev.target ? ev.target.value : 'classic';
-		const pal = (v === 'accessible') ? 'accessible' : 'classic';
+		const pal = v === 'accessible' ? 'accessible' : 'classic';
 		this.rowTintPalette = pal;
-		if (!this.rowTintEnabled())
-			return;
+		if (!this.rowTintEnabled()) return;
 		this.rowTint = pal;
 		this.commitRowTintChange();
 	},
@@ -304,36 +290,30 @@ return view.extend({
 	updateRowTintUi() {
 		const on = this.rowTintEnabled();
 		const cb = document.getElementById('fwlive-row-tint-toggle');
-		if (cb)
-			cb.checked = on;
+		if (cb) cb.checked = on;
 
 		const wrap = document.getElementById('fwlive-row-tint-palette-wrap');
 		if (wrap) {
-			if (on)
-				wrap.classList.remove('fwlive-hidden');
-			else
-				wrap.classList.add('fwlive-hidden');
+			if (on) wrap.classList.remove('fwlive-hidden');
+			else wrap.classList.add('fwlive-hidden');
 		}
 
 		const tintSel = document.getElementById('fwlive-row-tint');
 		if (tintSel) {
 			const pal = on ? this.rowTint : this.rowTintPalette;
-			tintSel.value = (pal === 'accessible') ? 'accessible' : 'classic';
+			tintSel.value = pal === 'accessible' ? 'accessible' : 'classic';
 		}
 	},
 
 	actionRowTintClass(action) {
 		const a = (action || '').toLowerCase();
-		if (a === 'pass')
-			return 'fwlive-row-pass';
-		if (a === 'drop' || a === 'reject' || a === 'block')
-			return 'fwlive-row-deny';
+		if (a === 'pass') return 'fwlive-row-pass';
+		if (a === 'drop' || a === 'reject' || a === 'block') return 'fwlive-row-deny';
 		return '';
 	},
 
 	applyTintFallback(map) {
-		if (!map)
-			return;
+		if (!map) return;
 
 		const pair = tint.hexPairForMode(this.rowTint);
 		map.style.setProperty('--fwlive-pass-color', pair.pass);
@@ -344,8 +324,7 @@ return view.extend({
 	},
 
 	clearTintFallback(map) {
-		if (!map)
-			return;
+		if (!map) return;
 
 		map.style.removeProperty('--fwlive-pass-color');
 		map.style.removeProperty('--fwlive-deny-color');
@@ -356,8 +335,7 @@ return view.extend({
 
 	updateTintWarnUi() {
 		const el = document.getElementById('fwlive-tint-warn');
-		if (!el)
-			return;
+		if (!el) return;
 
 		el.style.display = this.tintFallbackActive ? 'inline' : 'none';
 	},
@@ -365,19 +343,15 @@ return view.extend({
 	probeRowTintPaint() {
 		const map = document.querySelector('.fwlive-map');
 		const body = document.querySelector('#fwlive-table tbody');
-		if (!map || !body)
-			return;
+		if (!map || !body) return;
 
 		/* Prefer a non-alt row — zebra --background-color-medium can look "tinted" when transparent. */
 		let tr = body.querySelector('tr:not(.fwlive-row-alt)');
-		if (!tr)
-			tr = body.querySelector('tr');
-		if (!tr)
-			return;
+		if (!tr) tr = body.querySelector('tr');
+		if (!tr) return;
 
 		const td = tr.querySelector('td');
-		if (!td || typeof getComputedStyle !== 'function')
-			return;
+		if (!td || typeof getComputedStyle !== 'function') return;
 
 		const hadPass = tr.classList.contains('fwlive-row-pass');
 		const hadDeny = tr.classList.contains('fwlive-row-deny');
@@ -389,10 +363,8 @@ return view.extend({
 		const onBg = getComputedStyle(td).backgroundColor;
 
 		tr.classList.remove('fwlive-row-pass', 'fwlive-row-deny');
-		if (hadPass)
-			tr.classList.add('fwlive-row-pass');
-		if (hadDeny)
-			tr.classList.add('fwlive-row-deny');
+		if (hadPass) tr.classList.add('fwlive-row-pass');
+		if (hadDeny) tr.classList.add('fwlive-row-deny');
 
 		const passToken = getComputedStyle(map).getPropertyValue('--fwlive-pass-color').trim();
 		const paintDelta = tint.cssColorPaintDelta(onBg, offBg);
@@ -406,17 +378,13 @@ return view.extend({
 		});
 
 		this.tintProbeDone = true;
-		if (broken)
-			this.applyTintFallback(map);
-		else if (this.tintFallbackActive)
-			this.clearTintFallback(map);
-		else
-			this.updateTintWarnUi();
+		if (broken) this.applyTintFallback(map);
+		else if (this.tintFallbackActive) this.clearTintFallback(map);
+		else this.updateTintWarnUi();
 	},
 
 	isLikelyIp(addr) {
-		if (!addr)
-			return false;
+		if (!addr) return false;
 
 		return /^[\da-fA-F:.]+$/.test(addr);
 	},
@@ -426,8 +394,7 @@ return view.extend({
 	},
 
 	setViewMode(mode) {
-		if (constants.VIEW_MODES.indexOf(mode) < 0 || mode === this.viewMode)
-			return;
+		if (constants.VIEW_MODES.indexOf(mode) < 0 || mode === this.viewMode) return;
 
 		this.viewMode = mode;
 		this.expandedRowId = null;
@@ -442,22 +409,18 @@ return view.extend({
 		const simpleBtn = document.getElementById('fwlive-view-simple');
 		const detailBtn = document.getElementById('fwlive-view-detail');
 		const detailed = this.viewMode === 'detailed';
-		if (simpleBtn)
-			simpleBtn.setAttribute('aria-pressed', detailed ? 'false' : 'true');
-		if (detailBtn)
-			detailBtn.setAttribute('aria-pressed', detailed ? 'true' : 'false');
+		if (simpleBtn) simpleBtn.setAttribute('aria-pressed', detailed ? 'false' : 'true');
+		if (detailBtn) detailBtn.setAttribute('aria-pressed', detailed ? 'true' : 'false');
 
 		const map = document.querySelector('.fwlive-map');
-		if (map)
-			map.setAttribute('data-view', this.viewMode);
+		if (map) map.setAttribute('data-view', this.viewMode);
 
 		this.updateFilterPanelUi();
 	},
 
 	updateFilterPanelUi() {
 		const details = document.getElementById('fwlive-more-filters');
-		if (!details)
-			return;
+		if (!details) return;
 
 		if (this.viewMode === 'detailed') {
 			details.open = true;
@@ -465,18 +428,20 @@ return view.extend({
 		}
 
 		const filters = this.readFilters();
-		const hasExtra = !!(filters.interface || filters.src || filters.dst
-			|| filters.sport || filters.dport);
-		if (hasExtra)
-			details.open = true;
+		const hasExtra = !!(
+			filters.interface ||
+			filters.src ||
+			filters.dst ||
+			filters.sport ||
+			filters.dport
+		);
+		if (hasExtra) details.open = true;
 	},
 
 	onRowClick(rowId, ev) {
-		if (this.viewMode !== 'simple')
-			return;
+		if (this.viewMode !== 'simple') return;
 
-		if (ev && ev.target && ev.target.closest
-			&& ev.target.closest('a.fwlive-filter-link'))
+		if (ev && ev.target && ev.target.closest && ev.target.closest('a.fwlive-filter-link'))
 			return;
 
 		this.expandedRowId = this.expandedRowId === rowId ? null : rowId;
@@ -485,8 +450,7 @@ return view.extend({
 
 	renderThead() {
 		const el = document.getElementById('fwlive-table');
-		if (!el)
-			return;
+		if (!el) return;
 
 		table.renderThead(el, { columns: this.activeColumns().slice() }, {});
 	},
@@ -498,8 +462,7 @@ return view.extend({
 			this.firewallBackend = (res && res.backend) || 'nft';
 			/* Bounds / mktemp failures are reply.error — same idea as poll (#245). */
 			this.lastRulesError = (res && res.error) || null;
-			if (this.lastRulesError)
-				console.warn('fwlive rules map error:', this.lastRulesError);
+			if (this.lastRulesError) console.warn('fwlive rules map error:', this.lastRulesError);
 		} catch (e) {
 			this.rulesMap = {};
 			this.firewallBackend = 'nft';
@@ -509,17 +472,14 @@ return view.extend({
 	},
 
 	backendDisplayLabel() {
-		if (this.firewallBackend === 'iptables')
-			return _('using iptables');
-		if (this.firewallBackend === 'nft')
-			return _('using fw4');
+		if (this.firewallBackend === 'iptables') return _('using iptables');
+		if (this.firewallBackend === 'nft') return _('using fw4');
 		return '';
 	},
 
 	updateBackendUi() {
 		const map = document.querySelector('.fwlive-map');
-		if (map)
-			map.setAttribute('data-backend', this.firewallBackend || 'unknown');
+		if (map) map.setAttribute('data-backend', this.firewallBackend || 'unknown');
 
 		const label = document.getElementById('fwlive-backend');
 		if (label) {
@@ -531,8 +491,7 @@ return view.extend({
 					err = _('Rule labels incomplete — map truncated');
 				else if (this.lastRulesError === 'mktemp_failed')
 					err = _('Rule labels unavailable — temp file failed');
-				else
-					err = _('Rule labels unavailable');
+				else err = _('Rule labels unavailable');
 				text = text ? text + ' \u00b7 ' + err : err;
 				degraded = true;
 			}
@@ -561,8 +520,7 @@ return view.extend({
 	},
 
 	async handleEnableLogging() {
-		if (this.loggingBusy)
-			return;
+		if (this.loggingBusy) return;
 
 		this.loggingBusy = true;
 		this.loggingNotice = '';
@@ -573,19 +531,23 @@ return view.extend({
 			const res = await callFwliveEnableLogging();
 			if (!res || !res.ok) {
 				if (res && res.error === 'nf_log_missing')
-					this.loggingNotice = _('Cannot enable logging until kernel log modules are installed.');
+					this.loggingNotice = _(
+						'Cannot enable logging until kernel log modules are installed.'
+					);
 				else if (res && res.error === 'firewall_changes_pending')
-					this.loggingNotice = _('Another change is staged for the firewall; apply or revert it first.');
-				else
-					this.loggingNotice = _('Could not enable logging.');
+					this.loggingNotice = _(
+						'Another change is staged for the firewall; apply or revert it first.'
+					);
+				else this.loggingNotice = _('Could not enable logging.');
 				await this.loadLoggingStatus();
 				return;
 			}
 
 			if (res.changed)
-				this.loggingNotice = _('WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing.');
-			else
-				this.loggingNotice = _('WAN logging is already enabled.');
+				this.loggingNotice = _(
+					'WAN drop/reject logging is on. Blocked inbound traffic should appear here as it happens — not normal LAN browsing.'
+				);
+			else this.loggingNotice = _('WAN logging is already enabled.');
 
 			logging.persistConsentDismissed();
 			await this.loadLoggingStatus();
@@ -600,8 +562,7 @@ return view.extend({
 	},
 
 	async handleDisableLogging() {
-		if (this.loggingBusy)
-			return;
+		if (this.loggingBusy) return;
 
 		this.loggingBusy = true;
 		this.loggingNotice = '';
@@ -611,15 +572,15 @@ return view.extend({
 			const res = await callFwliveDisableLogging();
 			if (!res || !res.ok) {
 				if (res && res.error === 'firewall_changes_pending')
-					this.loggingNotice = _('Another change is staged for the firewall; apply or revert it first.');
-				else
-					this.loggingNotice = _('Could not disable logging.');
+					this.loggingNotice = _(
+						'Another change is staged for the firewall; apply or revert it first.'
+					);
+				else this.loggingNotice = _('Could not disable logging.');
 				await this.loadLoggingStatus();
 				return;
 			}
 
-			if (res.changed)
-				this.loggingNotice = _('WAN drop/reject logging is off.');
+			if (res.changed) this.loggingNotice = _('WAN drop/reject logging is off.');
 			await this.loadLoggingStatus();
 		} catch (e) {
 			this.loggingNotice = _('Administrator access is required to disable logging.');
@@ -633,21 +594,16 @@ return view.extend({
 
 	shouldShowLoggingConsent() {
 		const st = this.loggingStatus;
-		if (!st || st.wan_log)
-			return false;
+		if (!st || st.wan_log) return false;
 		const blockers = st.blockers || [];
-		if (blockers.length)
-			return false;
-		if (logging.consentDismissedPermanent())
-			return false;
-		if (this.consentDismissedSession)
-			return false;
+		if (blockers.length) return false;
+		if (logging.consentDismissedPermanent()) return false;
+		if (this.consentDismissedSession) return false;
 		return true;
 	},
 
 	handleDismissConsent(persist) {
-		if (persist)
-			logging.persistConsentDismissed();
+		if (persist) logging.persistConsentDismissed();
 		this.consentDismissedSession = true;
 		this._loggingEmptySig = '';
 		this.updateEmptyStateUi();
@@ -668,9 +624,7 @@ return view.extend({
 	loggingUiSignature() {
 		const st = this.loggingStatus;
 		/* Sort blockers so unstable backend order does not force a rebuild. */
-		const blockers = (st && st.blockers)
-			? st.blockers.slice().sort().join(',')
-			: '';
+		const blockers = st && st.blockers ? st.blockers.slice().sort().join(',') : '';
 		return [
 			st ? (st.wan_log ? '1' : '0') : 'x',
 			st ? String(st.wan_log_limit || '') : '',
@@ -683,12 +637,10 @@ return view.extend({
 
 	updateLoggingToolbarUi() {
 		const bar = document.getElementById('fwlive-logging-bar');
-		if (!bar)
-			return;
+		if (!bar) return;
 
 		const sig = this.loggingUiSignature();
-		if (sig === this._loggingToolbarSig)
-			return;
+		if (sig === this._loggingToolbarSig) return;
 
 		logging.renderToolbar(bar, this.loggingState(), {
 			onEnable: () => this.handleEnableLogging(),
@@ -699,33 +651,27 @@ return view.extend({
 
 	updateEmptyStateUi() {
 		const empty = document.getElementById('fwlive-empty');
-		if (!empty)
-			return;
+		if (!empty) return;
 
 		const sig = this.loggingUiSignature();
-		if (sig === this._loggingEmptySig)
-			return;
+		if (sig === this._loggingEmptySig) return;
 
 		const visible = empty.style.display !== 'none';
 		logging.renderEmptyState(empty, this.loggingState(), {
 			onEnable: () => this.handleEnableLogging(),
 			onDismissConsent: (persist) => this.handleDismissConsent(persist)
 		});
-		if (visible)
-			empty.style.display = 'block';
+		if (visible) empty.style.display = 'block';
 		this._loggingEmptySig = sig;
 	},
 
 	resolveRuleLabel(hint) {
-		if (!hint)
-			return '';
+		if (!hint) return '';
 
-		if (this.rulesMap[hint])
-			return this.rulesMap[hint];
+		if (this.rulesMap[hint]) return this.rulesMap[hint];
 
 		const slug = hint.toLowerCase();
-		if (this.rulesMap[slug])
-			return this.rulesMap[slug];
+		if (this.rulesMap[slug]) return this.rulesMap[slug];
 
 		return log.formatRuleLabel(hint);
 	},
@@ -741,15 +687,12 @@ return view.extend({
 		let pollNew = 0;
 
 		for (let i = 0; i < raw.length; i++) {
-			if (!log.isFirewallEvent(raw[i]))
-				continue;
+			if (!log.isFirewallEvent(raw[i])) continue;
 
 			const row = this.enrichEntry(log.normalizeEntry(raw[i]));
-			if (seen[row.id])
-				continue;
+			if (seen[row.id]) continue;
 			seen[row.id] = true;
-			if (this.rememberSessionId(row.id))
-				pollNew++;
+			if (this.rememberSessionId(row.id)) pollNew++;
 			normalized.push(row);
 		}
 
@@ -757,8 +700,7 @@ return view.extend({
 	},
 
 	async fetchEntries() {
-		if (!this.sessionSeen)
-			this.sessionSeen = new Set();
+		if (!this.sessionSeen) this.sessionSeen = new Set();
 
 		let reply;
 		try {
@@ -769,7 +711,7 @@ return view.extend({
 				? constants.FETCH_LINES_MAX
 				: Math.min(Math.max(this.rowLimit * 4, 100), constants.FETCH_LINES_MAX);
 			reply = await callFwlivePoll({
-				addresses: [ String(fetchLines) ]
+				addresses: [String(fetchLines)]
 			});
 		} catch (e) {
 			this.lastPollError = true;
@@ -805,10 +747,8 @@ return view.extend({
 	},
 
 	rememberSessionId(id) {
-		if (!this.sessionSeen)
-			this.sessionSeen = new Set();
-		if (this.sessionSeen.has(id))
-			return false;
+		if (!this.sessionSeen) this.sessionSeen = new Set();
+		if (this.sessionSeen.has(id)) return false;
 
 		this.sessionSeen.add(id);
 		const cap = Math.max(this.rowLimit * 2, constants.FETCH_LINES_MAX);
@@ -826,15 +766,12 @@ return view.extend({
 	statusSuffix() {
 		const bits = [];
 		if (this.paused) {
-			if (this.pauseBufferLoading)
-				bits.push(_('loading buffer'));
+			if (this.pauseBufferLoading) bits.push(_('loading buffer'));
 		}
 
 		const cap = this.ingestCap();
-		if (this.entries.length >= cap && cap > 0)
-			bits.push(_('buffer full'));
-		if (this.floodSuppressed)
-			bits.push(_('render paused (high rate)'));
+		if (this.entries.length >= cap && cap > 0) bits.push(_('buffer full'));
+		if (this.floodSuppressed) bits.push(_('render paused (high rate)'));
 		if (!this.paused && !this.followLive)
 			bits.push(_('scroll frozen — scroll to top to follow live'));
 		return bits.length ? ' — ' + bits.join(', ') : '';
@@ -842,14 +779,13 @@ return view.extend({
 
 	refillRenderBucket() {
 		const now = Date.now();
-		if (!this.renderBucketMs)
-			this.renderBucketMs = now;
+		if (!this.renderBucketMs) this.renderBucketMs = now;
 
 		const elapsed = now - this.renderBucketMs;
 		this.renderBucketMs = now;
 		this.renderBucket = Math.min(
 			constants.RENDER_CAP_PER_SEC,
-			this.renderBucket + (elapsed * constants.RENDER_CAP_PER_SEC / 1000)
+			this.renderBucket + (elapsed * constants.RENDER_CAP_PER_SEC) / 1000
 		);
 	},
 
@@ -875,31 +811,29 @@ return view.extend({
 		const count = rows ? rows.length : 0;
 		const headId = count ? rows[0].id : '';
 
-		if (!count && !this.lastRenderedRowCount)
-			return 0;
+		if (!count && !this.lastRenderedRowCount) return 0;
 
-		if (count === this.lastRenderedRowCount && headId === this.lastRenderedHeadId)
-			return 0;
+		if (count === this.lastRenderedRowCount && headId === this.lastRenderedHeadId) return 0;
 
 		/*
 		 * Visible row-count changes (Limit up/down, trim) must not be skipped by
 		 * the flood throttle — otherwise status can show N/limit while the table
 		 * still paints the previous size under ping -A.
 		 */
-		if (count !== this.lastRenderedRowCount)
-			return 1;
+		if (count !== this.lastRenderedRowCount) return 1;
 
 		return Math.max(1, this.lastPollNewEvents || 1);
 	},
 
 	updateFloodBanner() {
 		const el = document.getElementById('fwlive-flood');
-		if (!el)
-			return;
+		if (!el) return;
 
 		if (this.floodSuppressed) {
 			el.style.display = 'block';
-			el.textContent = _('High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically.');
+			el.textContent = _(
+				'High event rate — table refresh is throttled to protect the browser. The buffer still updates; refresh will resume automatically.'
+			);
 		} else {
 			el.style.display = 'none';
 			el.textContent = '';
@@ -926,22 +860,18 @@ return view.extend({
 			shown = this.entries.filter((row) => log.matchesFilter(row, filters)).length;
 		}
 
-		if (this.pauseBufferLoading && stored === 0)
-			return _('loading…') + suffix;
+		if (this.pauseBufferLoading && stored === 0) return _('loading…') + suffix;
 
-		if (shown)
-			return _('%d matching · %d/%d stored').format(shown, stored, limit) + suffix;
+		if (shown) return _('%d matching · %d/%d stored').format(shown, stored, limit) + suffix;
 
-		if (stored)
-			return _('0 matching · %d/%d stored').format(stored, limit) + suffix;
+		if (stored) return _('0 matching · %d/%d stored').format(stored, limit) + suffix;
 
 		return '';
 	},
 
 	updateStatus(rows) {
 		const status = document.getElementById('fwlive-status');
-		if (!status)
-			return;
+		if (!status) return;
 
 		const matchCount = rows ? rows.length : this.filteredRows().length;
 		const suffix = this.statusSuffix();
@@ -952,16 +882,13 @@ return view.extend({
 			return;
 		}
 
-		status.className = this.paused
-			? 'fwlive-status fwlive-status-paused'
-			: 'fwlive-status';
+		status.className = this.paused ? 'fwlive-status fwlive-status-paused' : 'fwlive-status';
 		status.textContent = this.compactCountText(matchCount);
 	},
 
 	readRowLimit() {
 		const n = parseInt(storedValue('fwlive-row-limit', null), 10);
-		if (constants.ROW_LIMIT_OPTIONS.indexOf(n) >= 0)
-			return n;
+		if (constants.ROW_LIMIT_OPTIONS.indexOf(n) >= 0) return n;
 		return constants.DEFAULT_ROW_LIMIT;
 	},
 
@@ -970,10 +897,10 @@ return view.extend({
 	},
 
 	applyRowLimit(limit) {
-		const n = constants.ROW_LIMIT_OPTIONS.indexOf(limit) >= 0 ? limit : constants.DEFAULT_ROW_LIMIT;
+		const n =
+			constants.ROW_LIMIT_OPTIONS.indexOf(limit) >= 0 ? limit : constants.DEFAULT_ROW_LIMIT;
 		this.rowLimit = n;
-		if (!this.paused && this.entries.length > n)
-			this.entries = this.entries.slice(-n);
+		if (!this.paused && this.entries.length > n) this.entries = this.entries.slice(-n);
 	},
 
 	updateStreamControlsUi() {
@@ -985,25 +912,17 @@ return view.extend({
 		const hostCb = document.getElementById('fwlive-show-hostnames');
 
 		if (map) {
-			if (this.paused)
-				map.classList.add('fwlive-watch-paused');
-			else
-				map.classList.remove('fwlive-watch-paused');
+			if (this.paused) map.classList.add('fwlive-watch-paused');
+			else map.classList.remove('fwlive-watch-paused');
 		}
 		if (dot) {
-			if (this.paused)
-				dot.classList.remove('fwlive-dot-on');
-			else
-				dot.classList.add('fwlive-dot-on');
+			if (this.paused) dot.classList.remove('fwlive-dot-on');
+			else dot.classList.add('fwlive-dot-on');
 		}
-		if (label)
-			label.textContent = this.paused ? _('Paused') : _('Watching');
-		if (pauseBtn)
-			pauseBtn.textContent = this.paused ? _('Resume') : _('Pause');
-		if (sel)
-			sel.value = String(this.rowLimit);
-		if (hostCb)
-			hostCb.checked = !!this.showHostnames;
+		if (label) label.textContent = this.paused ? _('Paused') : _('Watching');
+		if (pauseBtn) pauseBtn.textContent = this.paused ? _('Resume') : _('Pause');
+		if (sel) sel.value = String(this.rowLimit);
+		if (hostCb) hostCb.checked = !!this.showHostnames;
 		this.updateRowTintUi();
 	},
 
@@ -1014,10 +933,8 @@ return view.extend({
 		this.resolveGeneration = (this.resolveGeneration || 0) + 1;
 		this.resolveInFlight = false;
 
-		if (this.showHostnames)
-			this.resolveHostnamesForEntries(this.filteredRows());
-		else
-			this.renderRows(true);
+		if (this.showHostnames) this.resolveHostnamesForEntries(this.filteredRows());
+		else this.renderRows(true);
 	},
 
 	onPauseClick() {
@@ -1029,11 +946,13 @@ return view.extend({
 			this.pauseBufferLoading = true;
 			this.updateStatus();
 			this.fetchEntries()
-				.catch(function() {})
-				.finally(function() {
-					this.pauseBufferLoading = false;
-					this.updateStatus();
-				}.bind(this));
+				.catch(function () {})
+				.finally(
+					function () {
+						this.pauseBufferLoading = false;
+						this.updateStatus();
+					}.bind(this)
+				);
 			return;
 		}
 
@@ -1043,16 +962,17 @@ return view.extend({
 			this.resumeMerge = true;
 			this.fetchEntries()
 				.then(() => this.renderRows(true))
-				.finally(function() {
-					this.resumeMerge = false;
-				}.bind(this));
+				.finally(
+					function () {
+						this.resumeMerge = false;
+					}.bind(this)
+				);
 		}
 	},
 
 	onRowLimitChange(ev) {
 		const n = parseInt(ev && ev.target ? ev.target.value : '', 10);
-		if (!isFinite(n) || constants.ROW_LIMIT_OPTIONS.indexOf(n) < 0)
-			return;
+		if (!isFinite(n) || constants.ROW_LIMIT_OPTIONS.indexOf(n) < 0) return;
 
 		this.applyRowLimit(n);
 		this.saveRowLimit();
@@ -1061,16 +981,12 @@ return view.extend({
 		this.renderBucket = constants.RENDER_CAP_PER_SEC;
 		this.floodSuppressed = false;
 		this.pendingForceRender = true;
-		if (!this.paused)
-			this.renderRows(true);
-		else
-			this.updateStatus();
+		if (!this.paused) this.renderRows(true);
+		else this.updateStatus();
 		this.fetchEntries()
 			.then(() => {
-				if (this.paused)
-					this.updateStatus();
-				else
-					this.renderRows(true);
+				if (this.paused) this.updateStatus();
+				else this.renderRows(true);
 			})
 			.finally(() => {
 				this.pendingForceRender = false;
@@ -1081,7 +997,7 @@ return view.extend({
 		const pairs = [];
 		for (let i = 0; i < constants.ROW_LIMIT_OPTIONS.length; i++) {
 			const n = constants.ROW_LIMIT_OPTIONS[i];
-			pairs.push([ String(n), String(n) ]);
+			pairs.push([String(n), String(n)]);
 		}
 		return optionNodes(pairs);
 	},
@@ -1089,40 +1005,38 @@ return view.extend({
 	/* G Grouped: Common / Also seen / Exclude — curated PROTO values from logs. */
 	protoSelectOptions() {
 		return [
-			E('option', { 'value': '' }, [ _('Any protocol') ]),
+			E('option', { 'value': '' }, [_('Any protocol')]),
 			E('optgroup', { 'label': _('Common') }, [
-				E('option', { 'value': 'TCP' }, [ 'TCP' ]),
-				E('option', { 'value': 'UDP' }, [ 'UDP' ]),
-				E('option', { 'value': 'ICMP' }, [ 'ICMP' ]),
-				E('option', { 'value': 'ICMPV6' }, [ _('ICMPv6') ])
+				E('option', { 'value': 'TCP' }, ['TCP']),
+				E('option', { 'value': 'UDP' }, ['UDP']),
+				E('option', { 'value': 'ICMP' }, ['ICMP']),
+				E('option', { 'value': 'ICMPV6' }, [_('ICMPv6')])
 			]),
 			E('optgroup', { 'label': _('Also seen') }, [
-				E('option', { 'value': 'IGMP' }, [ 'IGMP' ]),
-				E('option', { 'value': 'GRE' }, [ 'GRE' ]),
-				E('option', { 'value': 'ESP' }, [ 'ESP' ]),
-				E('option', { 'value': 'AH' }, [ 'AH' ]),
-				E('option', { 'value': 'SCTP' }, [ 'SCTP' ])
+				E('option', { 'value': 'IGMP' }, ['IGMP']),
+				E('option', { 'value': 'GRE' }, ['GRE']),
+				E('option', { 'value': 'ESP' }, ['ESP']),
+				E('option', { 'value': 'AH' }, ['AH']),
+				E('option', { 'value': 'SCTP' }, ['SCTP'])
 			]),
 			E('optgroup', { 'label': _('Exclude') }, [
-				E('option', { 'value': '!TCP' }, [ _('not TCP') ]),
-				E('option', { 'value': '!UDP' }, [ _('not UDP') ]),
-				E('option', { 'value': '!ICMP' }, [ _('not ICMP') ]),
-				E('option', { 'value': '!ICMPV6' }, [ _('not ICMPv6') ]),
-				E('option', { 'value': '!IGMP' }, [ _('not IGMP') ]),
-				E('option', { 'value': '!GRE' }, [ _('not GRE') ]),
-				E('option', { 'value': '!ESP' }, [ _('not ESP') ]),
-				E('option', { 'value': '!AH' }, [ _('not AH') ]),
-				E('option', { 'value': '!SCTP' }, [ _('not SCTP') ])
+				E('option', { 'value': '!TCP' }, [_('not TCP')]),
+				E('option', { 'value': '!UDP' }, [_('not UDP')]),
+				E('option', { 'value': '!ICMP' }, [_('not ICMP')]),
+				E('option', { 'value': '!ICMPV6' }, [_('not ICMPv6')]),
+				E('option', { 'value': '!IGMP' }, [_('not IGMP')]),
+				E('option', { 'value': '!GRE' }, [_('not GRE')]),
+				E('option', { 'value': '!ESP' }, [_('not ESP')]),
+				E('option', { 'value': '!AH' }, [_('not AH')]),
+				E('option', { 'value': '!SCTP' }, [_('not SCTP')])
 			])
 		];
 	},
 
 	filterClick(field, value, ev) {
-		if (ev && ev.preventDefault)
-			ev.preventDefault();
+		if (ev && ev.preventDefault) ev.preventDefault();
 
-		if (!value)
-			return;
+		if (!value) return;
 
 		this.setFilterFieldValue(field, value);
 		this.onFilterInput();
@@ -1133,23 +1047,18 @@ return view.extend({
 
 		for (let i = 0; i < entries.length; i++) {
 			const r = entries[i];
-			if (r.src && this.isLikelyIp(r.src))
-				ips.add(r.src);
-			if (r.dst && this.isLikelyIp(r.dst))
-				ips.add(r.dst);
+			if (r.src && this.isLikelyIp(r.src)) ips.add(r.src);
+			if (r.dst && this.isLikelyIp(r.dst)) ips.add(r.dst);
 		}
 
 		return Array.from(ips);
 	},
 
 	async resolveHostnamesForEntries(entries) {
-		if (!this.showHostnames || this.resolveInFlight)
-			return;
+		if (!this.showHostnames || this.resolveInFlight) return;
 
-		if (!this.hostnameCache)
-			this.hostnameCache = new Map();
-		if (!this.hostnameFailed)
-			this.hostnameFailed = new Map();
+		if (!this.hostnameCache) this.hostnameCache = new Map();
+		if (!this.hostnameFailed) this.hostnameFailed = new Map();
 
 		const ips = this.collectIpsFromEntries(entries);
 		const need = [];
@@ -1157,15 +1066,12 @@ return view.extend({
 
 		for (let i = 0; i < ips.length && need.length < 32; i++) {
 			const ip = ips[i];
-			if (this.hostnameCache.has(ip))
-				continue;
-			if (hostname.failIsHot(this.hostnameFailed, ip, now))
-				continue;
+			if (this.hostnameCache.has(ip)) continue;
+			if (hostname.failIsHot(this.hostnameFailed, ip, now)) continue;
 			need.push(ip);
 		}
 
-		if (!need.length)
-			return;
+		if (!need.length) return;
 
 		this.resolveGeneration = (this.resolveGeneration || 0) + 1;
 		const gen = this.resolveGeneration;
@@ -1173,8 +1079,7 @@ return view.extend({
 
 		try {
 			const res = await callFwliveResolve({ addresses: need });
-			if (gen !== this.resolveGeneration)
-				return;
+			if (gen !== this.resolveGeneration) return;
 
 			/* rpc.declare expect: { names: {} } already unwraps — res IS the map (#243). */
 			const names = res || {};
@@ -1191,23 +1096,19 @@ return view.extend({
 				}
 			}
 
-			if (updated)
-				this.renderRows(true);
+			if (updated) this.renderRows(true);
 		} catch (e) {
 			/* resolve unavailable — show IPs */
 		} finally {
-			if (gen === this.resolveGeneration)
-				this.resolveInFlight = false;
+			if (gen === this.resolveGeneration) this.resolveInFlight = false;
 		}
 	},
 
 	setFilterFieldValue(field, value) {
-		if (field === 'proto')
-			return proto.setProtoFilterValue(value);
+		if (field === 'proto') return proto.setProtoFilterValue(value);
 
 		const el = document.getElementById('fwlive-' + field);
-		if (!el)
-			return false;
+		if (!el) return false;
 
 		/* SELECT: ensure uncommon click-to-filter / hash values remain selectable. */
 		if (el.tagName === 'SELECT' && value) {
@@ -1218,20 +1119,17 @@ return view.extend({
 					break;
 				}
 			}
-			if (!found)
-				el.appendChild(E('option', { 'value': value }, [ value ]));
+			if (!found) el.appendChild(E('option', { 'value': value }, [value]));
 		}
 
 		el.value = value;
-		if (el.tagName === 'SELECT')
-			el.dispatchEvent(new Event('change', { bubbles: true }));
+		if (el.tagName === 'SELECT') el.dispatchEvent(new Event('change', { bubbles: true }));
 
 		return true;
 	},
 
 	clearFilter(field, ev) {
-		if (ev && ev.preventDefault)
-			ev.preventDefault();
+		if (ev && ev.preventDefault) ev.preventDefault();
 
 		this.setFilterFieldValue(field, '');
 		this.onFilterInput();
@@ -1245,50 +1143,48 @@ return view.extend({
 
 		if (field === 'proto') {
 			const cur = proto.readProtoFilter();
-			if (!cur)
-				return;
+			if (!cur) return;
 			proto.setProtoFilterValue(log.toggleFilterNegation(cur));
 			this.onFilterInput();
 			return;
 		}
 
 		const el = document.getElementById('fwlive-' + field);
-		if (!el || !el.value)
-			return;
+		if (!el || !el.value) return;
 
 		this.setFilterFieldValue(field, log.toggleFilterNegation(el.value));
 		this.onFilterInput();
 	},
 
 	clearAllFilters(ev) {
-		if (ev && ev.preventDefault)
-			ev.preventDefault();
+		if (ev && ev.preventDefault) ev.preventDefault();
 
 		for (let i = 0; i < this.FILTER_CHIP_FIELDS.length; i++) {
 			const el = document.getElementById('fwlive-' + this.FILTER_CHIP_FIELDS[i].key);
-			if (el)
-				el.value = '';
+			if (el) el.value = '';
 		}
 		const protoCustom = document.getElementById('fwlive-proto-custom');
-		if (protoCustom)
-			protoCustom.value = '';
+		if (protoCustom) protoCustom.value = '';
 
 		this.onFilterInput();
 	},
 
 	renderFilterChips() {
 		const bar = document.getElementById('fwlive-chips');
-		if (!bar)
-			return;
+		if (!bar) return;
 
-		chips.renderFilterChips(bar, {
-			filters: Object.assign({}, this.readFilters()),
-			chipFields: this.FILTER_CHIP_FIELDS
-		}, {
-			onInvert: (field, ev) => this.invertFilter(field, ev),
-			onClear: (field, ev) => this.clearFilter(field, ev),
-			onClearAll: (ev) => this.clearAllFilters(ev)
-		});
+		chips.renderFilterChips(
+			bar,
+			{
+				filters: Object.assign({}, this.readFilters()),
+				chipFields: this.FILTER_CHIP_FIELDS
+			},
+			{
+				onInvert: (field, ev) => this.invertFilter(field, ev),
+				onClear: (field, ev) => this.clearFilter(field, ev),
+				onClearAll: (ev) => this.clearAllFilters(ev)
+			}
+		);
 	},
 
 	readMessageLayout() {
@@ -1308,30 +1204,24 @@ return view.extend({
 			scroll.classList.toggle('fwlive-msg-oneline', oneline);
 			scroll.classList.toggle('fwlive-msg-wrap', !oneline);
 		}
-		if (wrapBtn)
-			wrapBtn.setAttribute('aria-pressed', oneline ? 'false' : 'true');
-		if (onelineBtn)
-			onelineBtn.setAttribute('aria-pressed', oneline ? 'true' : 'false');
+		if (wrapBtn) wrapBtn.setAttribute('aria-pressed', oneline ? 'false' : 'true');
+		if (onelineBtn) onelineBtn.setAttribute('aria-pressed', oneline ? 'true' : 'false');
 	},
 
 	setMessageLayout(layout) {
 		const next = layout === 'oneline' ? 'oneline' : 'wrap';
-		if (next === this.messageLayout)
-			return;
+		if (next === this.messageLayout) return;
 
 		this.messageLayout = next;
 		this.saveMessageLayout();
 		this.updateMessageLayoutUi();
-		if (this.paused)
-			this.updateStatus();
-		else
-			this.renderRows(true);
+		if (this.paused) this.updateStatus();
+		else this.renderRows(true);
 	},
 
 	renderRows(force) {
 		const el = document.getElementById('fwlive-table');
-		if (!el)
-			return;
+		if (!el) return;
 
 		const body = el.querySelector('tbody');
 		const empty = document.getElementById('fwlive-empty');
@@ -1359,32 +1249,33 @@ return view.extend({
 
 		const prevScroll = scroll ? scroll.scrollTop : 0;
 
-		if (empty)
-			empty.style.display = rows.length ? 'none' : 'block';
+		if (empty) empty.style.display = rows.length ? 'none' : 'block';
 		this.updateStatus(rows);
 		this.renderFilterChips();
 
-		table.renderRows(body, {
-			rows: rows.slice(),
-			columns: this.activeColumns().slice(),
-			viewMode: this.viewMode,
-			messageLayout: this.messageLayout,
-			expandedRowId: this.expandedRowId,
-			rowTint: this.rowTintEnabled(),
-			showHostnames: !!this.showHostnames,
-			hostnameCache: this.hostnameCache,
-			firewallBackend: this.firewallBackend
-		}, {
-			onRowClick: (rowId, ev) => this.onRowClick(rowId, ev),
-			onFilterClick: (field, value, ev) => this.filterClick(field, value, ev),
-			actionRowTintClass: (action) => this.actionRowTintClass(action)
-		});
+		table.renderRows(
+			body,
+			{
+				rows: rows.slice(),
+				columns: this.activeColumns().slice(),
+				viewMode: this.viewMode,
+				messageLayout: this.messageLayout,
+				expandedRowId: this.expandedRowId,
+				rowTint: this.rowTintEnabled(),
+				showHostnames: !!this.showHostnames,
+				hostnameCache: this.hostnameCache,
+				firewallBackend: this.firewallBackend
+			},
+			{
+				onRowClick: (rowId, ev) => this.onRowClick(rowId, ev),
+				onFilterClick: (field, value, ev) => this.filterClick(field, value, ev),
+				actionRowTintClass: (action) => this.actionRowTintClass(action)
+			}
+		);
 
 		if (scroll) {
-			if (!this.paused && this.followLive)
-				scroll.scrollTop = 0;
-			else
-				scroll.scrollTop = prevScroll;
+			if (!this.paused && this.followLive) scroll.scrollTop = 0;
+			else scroll.scrollTop = prevScroll;
 		}
 
 		this.lastRenderedRowCount = rows.length;
@@ -1392,13 +1283,11 @@ return view.extend({
 
 		if (rows.length && this.rowTintEnabled() && !this.tintProbeDone) {
 			const runProbe = () => {
-				if (!this.tintProbeDone)
-					this.probeRowTintPaint();
+				if (!this.tintProbeDone) this.probeRowTintPaint();
 			};
 			if (typeof requestAnimationFrame === 'function')
 				requestAnimationFrame(() => requestAnimationFrame(runProbe));
-			else
-				setTimeout(runProbe, 0);
+			else setTimeout(runProbe, 0);
 		} else if (!this.rowTintEnabled() && this.tintFallbackActive) {
 			this.clearTintFallback(document.querySelector('.fwlive-map'));
 			this.tintProbeDone = false;
@@ -1410,18 +1299,19 @@ return view.extend({
 	},
 
 	onFilterInputDebounced() {
-		if (this.filterInputTimer)
-			clearTimeout(this.filterInputTimer);
-		this.filterInputTimer = setTimeout(function() {
-			this.filterInputTimer = null;
-			this.onFilterInput();
-		}.bind(this), 100);
+		if (this.filterInputTimer) clearTimeout(this.filterInputTimer);
+		this.filterInputTimer = setTimeout(
+			function () {
+				this.filterInputTimer = null;
+				this.onFilterInput();
+			}.bind(this),
+			100
+		);
 	},
 
 	onScrollArea(ev) {
 		const scroll = ev && ev.target;
-		if (!scroll || this.paused)
-			return;
+		if (!scroll || this.paused) return;
 
 		this.followLive = scroll.scrollTop < 8;
 		this.updateStatus();
@@ -1429,62 +1319,57 @@ return view.extend({
 
 	attachHandlers() {
 		const scroll = document.getElementById('fwlive-scroll');
-		if (scroll)
-			scroll.addEventListener('scroll', this.onScrollArea.bind(this));
+		if (scroll) scroll.addEventListener('scroll', this.onScrollArea.bind(this));
 
-		const ids = [ 'q', 'action', 'interface', 'src', 'dst', 'sport', 'dport' ];
+		const ids = ['q', 'action', 'interface', 'src', 'dst', 'sport', 'dport'];
 		for (let i = 0; i < ids.length; i++) {
 			const el = document.getElementById('fwlive-' + ids[i]);
-			if (!el)
-				continue;
+			if (!el) continue;
 			/* Text inputs: debounce rebuilds. Selects: apply immediately. */
 			if (el.tagName === 'SELECT')
 				el.addEventListener('change', this.onFilterInput.bind(this));
-			else
-				el.addEventListener('input', this.onFilterInputDebounced.bind(this));
+			else el.addEventListener('input', this.onFilterInputDebounced.bind(this));
 		}
 
 		const protoSel = document.getElementById('fwlive-proto');
 		const protoCustom = document.getElementById('fwlive-proto-custom');
 		if (protoSel) {
-			protoSel.addEventListener('change', function() {
-				if (protoCustom)
-					protoCustom.value = '';
-				this.onFilterInput();
-			}.bind(this));
+			protoSel.addEventListener(
+				'change',
+				function () {
+					if (protoCustom) protoCustom.value = '';
+					this.onFilterInput();
+				}.bind(this)
+			);
 		}
 		if (protoCustom) {
-			protoCustom.addEventListener('input', function() {
-				if (protoCustom.value.trim() && protoSel)
-					protoSel.value = '';
-				this.onFilterInputDebounced();
-			}.bind(this));
+			protoCustom.addEventListener(
+				'input',
+				function () {
+					if (protoCustom.value.trim() && protoSel) protoSel.value = '';
+					this.onFilterInputDebounced();
+				}.bind(this)
+			);
 		}
 
 		const pauseBtn = document.getElementById('fwlive-pause');
-		if (pauseBtn)
-			pauseBtn.addEventListener('click', this.onPauseClick.bind(this));
+		if (pauseBtn) pauseBtn.addEventListener('click', this.onPauseClick.bind(this));
 
 		const limitSel = document.getElementById('fwlive-limit');
-		if (limitSel)
-			limitSel.addEventListener('change', this.onRowLimitChange.bind(this));
+		if (limitSel) limitSel.addEventListener('change', this.onRowLimitChange.bind(this));
 
 		const hostCb = document.getElementById('fwlive-show-hostnames');
-		if (hostCb)
-			hostCb.addEventListener('change', this.onShowHostnamesChange.bind(this));
+		if (hostCb) hostCb.addEventListener('change', this.onShowHostnamesChange.bind(this));
 
 		const tintCb = document.getElementById('fwlive-row-tint-toggle');
-		if (tintCb)
-			tintCb.addEventListener('change', this.onRowTintEnabledChange.bind(this));
+		if (tintCb) tintCb.addEventListener('change', this.onRowTintEnabledChange.bind(this));
 
 		const tintSel = document.getElementById('fwlive-row-tint');
-		if (tintSel)
-			tintSel.addEventListener('change', this.onRowTintPaletteChange.bind(this));
+		if (tintSel) tintSel.addEventListener('change', this.onRowTintPaletteChange.bind(this));
 	},
 
 	async pollData() {
-		if (this.pollDataInFlight)
-			return;
+		if (this.pollDataInFlight) return;
 
 		this.pollDataInFlight = true;
 		try {
@@ -1494,10 +1379,8 @@ return view.extend({
 				this.lastPollError = true;
 			}
 
-			if (this.paused)
-				this.updateStatus();
-			else
-				this.renderRows(!!this.pendingForceRender);
+			if (this.paused) this.updateStatus();
+			else this.renderRows(!!this.pendingForceRender);
 
 			try {
 				await this.resolveHostnamesForEntries(this.filteredRows());
@@ -1515,222 +1398,377 @@ return view.extend({
 			poll.add(this.pollFn, 1);
 			/* Best-effort teardown when leaving the page (LuCI SPA may full-reload). */
 			if (typeof window !== 'undefined' && window.addEventListener) {
-				window.addEventListener('pagehide', function() {
-					if (this.pollFn) {
-						try { poll.remove(this.pollFn); } catch (e) { /* poll gone */ }
-						this.pollFn = null;
-					}
-					if (this.filterInputTimer) {
-						clearTimeout(this.filterInputTimer);
-						this.filterInputTimer = null;
-					}
-				}.bind(this));
+				window.addEventListener(
+					'pagehide',
+					function () {
+						if (this.pollFn) {
+							try {
+								poll.remove(this.pollFn);
+							} catch (e) {
+								/* poll gone */
+							}
+							this.pollFn = null;
+						}
+						if (this.filterInputTimer) {
+							clearTimeout(this.filterInputTimer);
+							this.filterInputTimer = null;
+						}
+					}.bind(this)
+				);
 			}
 		}
-		return Promise.all([
-			this.loadRulesMap(),
-			this.loadLoggingStatus()
-		]).then(() => this.fetchEntries());
+		return Promise.all([this.loadRulesMap(), this.loadLoggingStatus()]).then(() =>
+			this.fetchEntries()
+		);
 	},
 
 	render() {
-		return E('div', { 'class': 'cbi-map fwlive-map', 'data-view': 'simple', 'data-row-tint': 'classic' }, [
-			E('style', {}, [css.styleText]),
-			E('div', { 'id': 'fwlive-title-row', 'class': 'fwlive-title-row' }, [
-				E('h2', {}, [
-					_('Firewall Live View'),
-					E('span', { 'id': 'fwlive-backend', 'class': 'fwlive-backend' }, [ '' ])
-				]),
-				E('div', { 'class': 'fwlive-title-status' }, [
-					E('span', { 'id': 'fwlive-watch-dot', 'class': 'fwlive-dot fwlive-dot-on', 'aria-hidden': 'true' }, [ '' ]),
-					E('span', { 'id': 'fwlive-watch-label', 'class': 'fwlive-watch-label' }, [ _('Watching') ]),
-					E('span', { 'id': 'fwlive-status', 'class': 'fwlive-status' }, [ '' ]),
-					E('span', {
-						'id': 'fwlive-tint-warn',
-						'class': 'fwlive-tint-warn',
-						'title': _('Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds.')
-					}, [ _('Theme tint fallback') ])
-				])
-			]),
-			E('div', { 'id': 'fwlive-watch-strip', 'class': 'fwlive-watch-strip' }, [
-				E('div', { 'class': 'fwlive-watch-group' }, [
-					E('button', {
-						'id': 'fwlive-pause',
-						'class': 'cbi-button fwlive-btn-ghost',
-						'type': 'button'
-					}, [ _('Pause') ]),
-					E('span', { 'id': 'fwlive-logging-bar', 'class': 'fwlive-logging-bar' }, [])
-				]),
-				E('div', { 'class': 'fwlive-watch-group' }, [
-					E('span', { 'class': 'fwlive-watch-group-label' }, [ _('View') ]),
-					E('div', {
-						'class': 'fwlive-watch-seg',
-						'role': 'group',
-						'aria-label': _('View')
-					}, [
-						E('button', {
-							'id': 'fwlive-view-simple',
-							'class': 'cbi-button fwlive-seg-btn',
-							'type': 'button',
-							'aria-pressed': 'true',
-							'click': () => this.setViewMode('simple')
-						}, [ _('Simple') ]),
-						E('button', {
-							'id': 'fwlive-view-detail',
-							'class': 'cbi-button fwlive-seg-btn',
-							'type': 'button',
-							'aria-pressed': 'false',
-							'click': () => this.setViewMode('detailed')
-						}, [ _('Detail') ])
-					])
-				]),
-				E('div', {
-					'id': 'fwlive-msg-group',
-					'class': 'fwlive-watch-group'
-				}, [
-					E('span', { 'class': 'fwlive-watch-group-label' }, [ _('Message') ]),
-					E('div', {
-						'id': 'fwlive-msg-seg',
-						'class': 'fwlive-watch-seg',
-						'role': 'group',
-						'aria-label': _('Message')
-					}, [
-						E('button', {
-							'id': 'fwlive-msg-wrap',
-							'class': 'cbi-button fwlive-seg-btn',
-							'type': 'button',
-							'aria-pressed': 'true',
-							'click': () => this.setMessageLayout('wrap')
-						}, [ _('Wrap') ]),
-						E('button', {
-							'id': 'fwlive-msg-oneline',
-							'class': 'cbi-button fwlive-seg-btn',
-							'type': 'button',
-							'aria-pressed': 'false',
-							'click': () => this.setMessageLayout('oneline')
-						}, [ _('One line') ])
-					])
-				])
-			]),
-			E('div', { 'id': 'fwlive-flood', 'class': 'fwlive-flood' }, [ '' ]),
-			E('div', { 'id': 'fwlive-display-drawer', 'class': 'fwlive-display-bar' }, [
-				E('span', { 'class': 'fwlive-display-bar-label' }, [ _('Display options') ]),
-				E('div', { 'class': 'fwlive-display-controls' }, [
-					E('label', { 'class': 'fwlive-display-ctl', 'for': 'fwlive-limit' }, [
-						_('Limit'),
-						E('select', {
-							'id': 'fwlive-limit',
-							'class': 'cbi-input-select'
-						}, this.limitSelectOptions())
+		return E(
+			'div',
+			{ 'class': 'cbi-map fwlive-map', 'data-view': 'simple', 'data-row-tint': 'classic' },
+			[
+				E('style', {}, [css.styleText]),
+				E('div', { 'id': 'fwlive-title-row', 'class': 'fwlive-title-row' }, [
+					E('h2', {}, [
+						_('Firewall Live View'),
+						E('span', { 'id': 'fwlive-backend', 'class': 'fwlive-backend' }, [''])
 					]),
-					E('label', { 'class': 'fwlive-display-ctl' }, [
-						E('input', {
-							'id': 'fwlive-row-tint-toggle',
-							'type': 'checkbox',
-							'title': _('Show pass/deny row background colors')
-						}),
-						_('Row tint')
-					]),
-					E('label', {
-						'id': 'fwlive-row-tint-palette-wrap',
-						'class': 'fwlive-display-ctl',
-						'for': 'fwlive-row-tint'
-					}, [
-						_('Palette'),
-						E('select', {
-							'id': 'fwlive-row-tint',
-							'class': 'cbi-input-select',
-							'title': _('Classic uses green/red; Accessible uses teal/orange')
-						}, this.rowTintPaletteOptions())
-					]),
-					E('label', { 'class': 'fwlive-display-ctl' }, [
-						E('input', {
-							'id': 'fwlive-show-hostnames',
-							'type': 'checkbox'
-						}),
-						_('Show hostnames')
-					])
-				])
-			]),
-			E('div', { 'id': 'fwlive-filter-panel', 'class': 'fwlive-filter-panel fwlive-find-row' }, [
-				E('div', { 'class': 'fwlive-grid fwlive-grid-core' }, [
-					E('input', { 'id': 'fwlive-q', 'class': 'cbi-input-text', 'placeholder': _('Quick search') }),
-					E('select', { 'id': 'fwlive-action', 'class': 'cbi-input-select' }, [
-						E('option', { 'value': '' }, [ _('Any action') ]),
-						E('option', { 'value': 'pass' }, [ 'pass' ]),
-						E('option', { 'value': 'block' }, [ 'block' ]),
-						E('option', { 'value': 'drop' }, [ 'drop' ]),
-						E('option', { 'value': 'reject' }, [ 'reject' ]),
-						E('option', { 'value': 'unknown' }, [ 'unknown' ]),
-						E('option', { 'value': '!pass' }, [ _('not pass') ]),
-						E('option', { 'value': '!drop' }, [ _('not drop') ]),
-						E('option', { 'value': '!block' }, [ _('not block') ]),
-						E('option', { 'value': '!reject' }, [ _('not reject') ]),
-						E('option', { 'value': '!unknown' }, [ _('not unknown') ])
-					]),
-					E('div', { 'class': 'fwlive-proto-pair' }, [
-						E('select', {
-							'id': 'fwlive-proto',
-							'class': 'cbi-input-select',
-							'title': _('Protocol — common values')
-						}, this.protoSelectOptions()),
-						E('input', {
-							'id': 'fwlive-proto-custom',
-							'class': 'cbi-input-text',
-							'placeholder': _('or type…'),
-							'title': _('Custom protocol (prefix ! to exclude). Overrides the menu when set.'),
-							'autocomplete': 'off'
-						})
+					E('div', { 'class': 'fwlive-title-status' }, [
+						E(
+							'span',
+							{
+								'id': 'fwlive-watch-dot',
+								'class': 'fwlive-dot fwlive-dot-on',
+								'aria-hidden': 'true'
+							},
+							['']
+						),
+						E('span', { 'id': 'fwlive-watch-label', 'class': 'fwlive-watch-label' }, [
+							_('Watching')
+						]),
+						E('span', { 'id': 'fwlive-status', 'class': 'fwlive-status' }, ['']),
+						E(
+							'span',
+							{
+								'id': 'fwlive-tint-warn',
+								'class': 'fwlive-tint-warn',
+								'title': _(
+									'Row tint used a local color fallback because the active LuCI theme did not apply pass/deny backgrounds.'
+								)
+							},
+							[_('Theme tint fallback')]
+						)
 					])
 				]),
-				E('details', { 'id': 'fwlive-more-filters', 'class': 'fwlive-more-filters' }, [
-					E('summary', {}, [ _('More filters') ]),
-					E('div', { 'class': 'fwlive-grid fwlive-grid-extra' }, [
-						E('input', { 'id': 'fwlive-interface', 'class': 'cbi-input-text', 'placeholder': _('Interface (prefix ! to exclude)') }),
-						E('input', { 'id': 'fwlive-src', 'class': 'cbi-input-text', 'placeholder': _('Source IP contains (! to exclude)') }),
-						E('input', { 'id': 'fwlive-sport', 'class': 'cbi-input-text', 'placeholder': _('Source port (! to exclude)') }),
-						E('input', { 'id': 'fwlive-dst', 'class': 'cbi-input-text', 'placeholder': _('Destination IP contains (! to exclude)') }),
-						E('input', { 'id': 'fwlive-dport', 'class': 'cbi-input-text', 'placeholder': _('Destination port (! to exclude)') })
-					])
-				])
-			]),
-			E('div', { 'id': 'fwlive-chips', 'class': 'fwlive-chips' }, []),
-			E('p', { 'class': 'fwlive-hint-line' },
-				[ _('Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message') ]),
-			E('div', {
-				'id': 'fwlive-empty',
-				'class': 'fwlive-empty',
-				'style': 'display:none'
-			}, []),
-			E('div', { 'id': 'fwlive-scroll', 'class': 'fwlive-scroll fwlive-msg-wrap' }, [
-				E('table', { 'id': 'fwlive-table', 'class': 'table cbi-section-table' }, [
-					E('thead', {}, E('tr', {}, [])),
-					E('tbody', {}, [])
-				])
-			]),
-			E('div', { 'class': 'fwlive-help-row' }, [
-				E('details', { 'id': 'fwlive-help', 'class': 'fwlive-help' }, [
-					E('summary', {}, [ _('Help') ]),
-					E('ul', {}, [
-						E('li', {}, [ _('The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast.') ]),
-						E('li', {}, [ _('Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing.') ]),
-						E('li', {}, [ _('Display options on the bar set Limit, row tint, palette, and hostnames.') ]),
-						E('li', {}, [ _('The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap.') ]),
-						E('li', { 'id': 'fwlive-manual-test' }, []),
-						E('li', {}, [ _('Click a row (Time or other non-link cells) to see the full log line (Simple view).') ]),
-						E('li', {}, [ _('Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude.') ]),
-						E('li', {}, [ _('Row tint shows pass/deny row backgrounds when checked. Choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way.') ]),
-						E('li', {}, [ _('Use Detail for all columns (flags, length, raw message).') ]),
-						E('li', {}, [ _('If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device).') ])
+				E('div', { 'id': 'fwlive-watch-strip', 'class': 'fwlive-watch-strip' }, [
+					E('div', { 'class': 'fwlive-watch-group' }, [
+						E(
+							'button',
+							{
+								'id': 'fwlive-pause',
+								'class': 'cbi-button fwlive-btn-ghost',
+								'type': 'button'
+							},
+							[_('Pause')]
+						),
+						E('span', { 'id': 'fwlive-logging-bar', 'class': 'fwlive-logging-bar' }, [])
+					]),
+					E('div', { 'class': 'fwlive-watch-group' }, [
+						E('span', { 'class': 'fwlive-watch-group-label' }, [_('View')]),
+						E(
+							'div',
+							{
+								'class': 'fwlive-watch-seg',
+								'role': 'group',
+								'aria-label': _('View')
+							},
+							[
+								E(
+									'button',
+									{
+										'id': 'fwlive-view-simple',
+										'class': 'cbi-button fwlive-seg-btn',
+										'type': 'button',
+										'aria-pressed': 'true',
+										'click': () => this.setViewMode('simple')
+									},
+									[_('Simple')]
+								),
+								E(
+									'button',
+									{
+										'id': 'fwlive-view-detail',
+										'class': 'cbi-button fwlive-seg-btn',
+										'type': 'button',
+										'aria-pressed': 'false',
+										'click': () => this.setViewMode('detailed')
+									},
+									[_('Detail')]
+								)
+							]
+						)
+					]),
+					E(
+						'div',
+						{
+							'id': 'fwlive-msg-group',
+							'class': 'fwlive-watch-group'
+						},
+						[
+							E('span', { 'class': 'fwlive-watch-group-label' }, [_('Message')]),
+							E(
+								'div',
+								{
+									'id': 'fwlive-msg-seg',
+									'class': 'fwlive-watch-seg',
+									'role': 'group',
+									'aria-label': _('Message')
+								},
+								[
+									E(
+										'button',
+										{
+											'id': 'fwlive-msg-wrap',
+											'class': 'cbi-button fwlive-seg-btn',
+											'type': 'button',
+											'aria-pressed': 'true',
+											'click': () => this.setMessageLayout('wrap')
+										},
+										[_('Wrap')]
+									),
+									E(
+										'button',
+										{
+											'id': 'fwlive-msg-oneline',
+											'class': 'cbi-button fwlive-seg-btn',
+											'type': 'button',
+											'aria-pressed': 'false',
+											'click': () => this.setMessageLayout('oneline')
+										},
+										[_('One line')]
+									)
+								]
+							)
+						]
+					)
+				]),
+				E('div', { 'id': 'fwlive-flood', 'class': 'fwlive-flood' }, ['']),
+				E('div', { 'id': 'fwlive-display-drawer', 'class': 'fwlive-display-bar' }, [
+					E('span', { 'class': 'fwlive-display-bar-label' }, [_('Display options')]),
+					E('div', { 'class': 'fwlive-display-controls' }, [
+						E('label', { 'class': 'fwlive-display-ctl', 'for': 'fwlive-limit' }, [
+							_('Limit'),
+							E(
+								'select',
+								{
+									'id': 'fwlive-limit',
+									'class': 'cbi-input-select'
+								},
+								this.limitSelectOptions()
+							)
+						]),
+						E('label', { 'class': 'fwlive-display-ctl' }, [
+							E('input', {
+								'id': 'fwlive-row-tint-toggle',
+								'type': 'checkbox',
+								'title': _('Show pass/deny row background colors')
+							}),
+							_('Row tint')
+						]),
+						E(
+							'label',
+							{
+								'id': 'fwlive-row-tint-palette-wrap',
+								'class': 'fwlive-display-ctl',
+								'for': 'fwlive-row-tint'
+							},
+							[
+								_('Palette'),
+								E(
+									'select',
+									{
+										'id': 'fwlive-row-tint',
+										'class': 'cbi-input-select',
+										'title': _(
+											'Classic uses green/red; Accessible uses teal/orange'
+										)
+									},
+									this.rowTintPaletteOptions()
+								)
+							]
+						),
+						E('label', { 'class': 'fwlive-display-ctl' }, [
+							E('input', {
+								'id': 'fwlive-show-hostnames',
+								'type': 'checkbox'
+							}),
+							_('Show hostnames')
+						])
 					])
 				]),
-				E('span', {
-					'id': 'fwlive-build',
-					'class': 'fwlive-build',
-					'title': 'luci-app-fwlive'
-				}, [ 'v' + constants.APP_VERSION ])
-			])
-		]);
+				E(
+					'div',
+					{ 'id': 'fwlive-filter-panel', 'class': 'fwlive-filter-panel fwlive-find-row' },
+					[
+						E('div', { 'class': 'fwlive-grid fwlive-grid-core' }, [
+							E('input', {
+								'id': 'fwlive-q',
+								'class': 'cbi-input-text',
+								'placeholder': _('Quick search')
+							}),
+							E('select', { 'id': 'fwlive-action', 'class': 'cbi-input-select' }, [
+								E('option', { 'value': '' }, [_('Any action')]),
+								E('option', { 'value': 'pass' }, ['pass']),
+								E('option', { 'value': 'block' }, ['block']),
+								E('option', { 'value': 'drop' }, ['drop']),
+								E('option', { 'value': 'reject' }, ['reject']),
+								E('option', { 'value': 'unknown' }, ['unknown']),
+								E('option', { 'value': '!pass' }, [_('not pass')]),
+								E('option', { 'value': '!drop' }, [_('not drop')]),
+								E('option', { 'value': '!block' }, [_('not block')]),
+								E('option', { 'value': '!reject' }, [_('not reject')]),
+								E('option', { 'value': '!unknown' }, [_('not unknown')])
+							]),
+							E('div', { 'class': 'fwlive-proto-pair' }, [
+								E(
+									'select',
+									{
+										'id': 'fwlive-proto',
+										'class': 'cbi-input-select',
+										'title': _('Protocol — common values')
+									},
+									this.protoSelectOptions()
+								),
+								E('input', {
+									'id': 'fwlive-proto-custom',
+									'class': 'cbi-input-text',
+									'placeholder': _('or type…'),
+									'title': _(
+										'Custom protocol (prefix ! to exclude). Overrides the menu when set.'
+									),
+									'autocomplete': 'off'
+								})
+							])
+						]),
+						E(
+							'details',
+							{ 'id': 'fwlive-more-filters', 'class': 'fwlive-more-filters' },
+							[
+								E('summary', {}, [_('More filters')]),
+								E('div', { 'class': 'fwlive-grid fwlive-grid-extra' }, [
+									E('input', {
+										'id': 'fwlive-interface',
+										'class': 'cbi-input-text',
+										'placeholder': _('Interface (prefix ! to exclude)')
+									}),
+									E('input', {
+										'id': 'fwlive-src',
+										'class': 'cbi-input-text',
+										'placeholder': _('Source IP contains (! to exclude)')
+									}),
+									E('input', {
+										'id': 'fwlive-sport',
+										'class': 'cbi-input-text',
+										'placeholder': _('Source port (! to exclude)')
+									}),
+									E('input', {
+										'id': 'fwlive-dst',
+										'class': 'cbi-input-text',
+										'placeholder': _('Destination IP contains (! to exclude)')
+									}),
+									E('input', {
+										'id': 'fwlive-dport',
+										'class': 'cbi-input-text',
+										'placeholder': _('Destination port (! to exclude)')
+									})
+								])
+							]
+						)
+					]
+				),
+				E('div', { 'id': 'fwlive-chips', 'class': 'fwlive-chips' }, []),
+				E('p', { 'class': 'fwlive-hint-line' }, [
+					_(
+						'Click a cell to filter · ≠ on a chip to exclude · Ctrl+click a rule for firewall settings · in Simple view, click a row for the full message'
+					)
+				]),
+				E(
+					'div',
+					{
+						'id': 'fwlive-empty',
+						'class': 'fwlive-empty',
+						'style': 'display:none'
+					},
+					[]
+				),
+				E('div', { 'id': 'fwlive-scroll', 'class': 'fwlive-scroll fwlive-msg-wrap' }, [
+					E('table', { 'id': 'fwlive-table', 'class': 'table cbi-section-table' }, [
+						E('thead', {}, E('tr', {}, [])),
+						E('tbody', {}, [])
+					])
+				]),
+				E('div', { 'class': 'fwlive-help-row' }, [
+					E('details', { 'id': 'fwlive-help', 'class': 'fwlive-help' }, [
+						E('summary', {}, [_('Help')]),
+						E('ul', {}, [
+							E('li', {}, [
+								_(
+									'The table updates automatically when your firewall logs traffic. Use Pause if it moves too fast.'
+								)
+							]),
+							E('li', {}, [
+								_(
+									'Enable logging turns on WAN zone drop/reject logging only (same as Network → Firewall). It does not add rules or log normal LAN browsing.'
+								)
+							]),
+							E('li', {}, [
+								_(
+									'Display options on the bar set Limit, row tint, palette, and hostnames.'
+								)
+							]),
+							E('li', {}, [
+								_(
+									'The rate shown for WAN logging is the firewall zone log_limit. OpenWrt defaults to 10/minute when no explicit limit is configured; fwlive does not impose this cap.'
+								)
+							]),
+							E('li', { 'id': 'fwlive-manual-test' }, []),
+							E('li', {}, [
+								_(
+									'Click a row (Time or other non-link cells) to see the full log line (Simple view).'
+								)
+							]),
+							E('li', {}, [
+								_(
+									'Click an IP, action, or protocol to filter; use the Protocol menu (or ≠ on a chip) to exclude.'
+								)
+							]),
+							E('li', {}, [
+								_(
+									'Row tint shows pass/deny row backgrounds when checked. Choose Classic (green/red, default) or Accessible (teal/orange). Action text stays colored either way.'
+								)
+							]),
+							E('li', {}, [
+								_('Use Detail for all columns (flags, length, raw message).')
+							]),
+							E('li', {}, [
+								_(
+									'If Row tint looks missing, the active LuCI theme may omit success/error or info/warn CSS variables; fwlive falls back to local colors (air-gapped, no data leaves the device).'
+								)
+							])
+						])
+					]),
+					E(
+						'span',
+						{
+							'id': 'fwlive-build',
+							'class': 'fwlive-build',
+							'title': 'luci-app-fwlive'
+						},
+						['v' + constants.APP_VERSION]
+					)
+				])
+			]
+		);
 	},
 
 	addFooter() {
@@ -1760,7 +1798,6 @@ return view.extend({
 		const testLi = document.getElementById('fwlive-manual-test');
 		if (testLi)
 			logging.renderManualTestNodes(testLi, { firewallBackend: this.firewallBackend }, {});
-		if (this.showHostnames)
-			this.resolveHostnamesForEntries(this.filteredRows());
+		if (this.showHostnames) this.resolveHostnamesForEntries(this.filteredRows());
 	}
 });

--- a/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
+++ b/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
@@ -1,4 +1,6 @@
 'use strict';
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */
 /*
  * LuCI Firewall Live View — client-side view (view.extend + ubus fwlive.poll).
  * UI interaction patterns inspired by OPNsense Live View; original implementation

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh
@@ -4,6 +4,7 @@
 # GENERATED FILE — do not edit. Run: ./scripts/gen-all.sh
 # source: core/fwlive-log.js CLASSIFY_SPEC
 # Shared isFirewallEvent parity logic (shell). Sourced by fwlive-log-filter.sh and tests.
+# Sourced library: do not add set -euo here (callers own strict mode, #291 C3).
 # One awk process classifies a batch (MODE=json) or one message (default).
 
 _fwlive_run_classify() {

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh
@@ -8,6 +8,14 @@
 #
 # Perf (#219): one jsonfilter for @.log[*] plus one awk classify. Process
 # count is constant per poll, not O(entries).
+#
+# Entry point (pipeline). The classifier sibling is sourced and must not
+# set -euo itself (#291 C3).
+set -eu
+# pipefail: BusyBox ash supports it; Debian dash (host `sh`) rejects a
+# bare `set -o pipefail`. Probe in a subshell (same class as #244).
+# shellcheck disable=SC3040 # pipefail is ash/bash; dash probe is a subshell
+(set -o pipefail) 2>/dev/null && set -o pipefail
 
 if ! command -v jsonfilter >/dev/null 2>&1; then
 	command -v logger >/dev/null 2>&1 && logger -t fwlive "jsonfilter not found; cannot filter firewall logs"
@@ -26,5 +34,7 @@ printf '%s' '{"log":['
 # Prefer stdin over -s: Linux MAX_ARG_STRLEN is 128KiB; a raised logd ring
 # (or paused FETCH_LINES_MAX poll) can exceed that and make jsonfilter fail
 # while this script still printed {"log":[]} and exited 0 (#234).
-printf '%s' "$input" | jsonfilter -e '@.log[*]' 2>/dev/null | _fwlive_filter_json_entries
+# jsonfilter miss / empty @.log is not fatal; must still close JSON (#220).
+# set -e + pipefail cannot apply to this pipeline (#291 C3).
+printf '%s' "$input" | jsonfilter -e '@.log[*]' 2>/dev/null | _fwlive_filter_json_entries || true
 printf '%s' ']}'

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh
@@ -3,6 +3,11 @@
 # Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com>
 #
 # WAN zone logging helpers for ubus fwlive (logging_status / enable / disable).
+#
+# Sourced library (rpcd plugin, package prerm). Do not `set -euo pipefail`
+# here: prerm is best-effort (`restore ... || logger`; exit 0) and callers
+# expect soft failures. The rpcd entry point enables strict mode; critical
+# paths use explicit `|| return 1` / `|| true` (#244, #291 C3).
 
 NF_LOG_IPV4='/proc/sys/net/netfilter/nf_log/2'
 NF_LOG_IPV6='/proc/sys/net/netfilter/nf_log/10'
@@ -121,11 +126,16 @@ find_wan_zone_section() {
 	# Match anonymous (@zone[N]) and named (e.g. wan) sections whose name option
 	# is 'wan'. Prefer the first section whose type is zone (issue #168); skip
 	# non-zone sections that happen to share name='wan'.
+	# uci missing / no wan zone is empty, not fatal. pipefail + set -e
+	# cannot apply to this pipeline (#291 C3).
 	_zones=$(uci -q show firewall 2>/dev/null \
-		| sed -n "s/^firewall\.\([^.]*\)\.name='wan'$/\1/p")
+		| sed -n "s/^firewall\.\([^.]*\)\.name='wan'$/\1/p") || true
 	for zone in $_zones; do
 		[ -n "$zone" ] || continue
-		[ "$(uci -q get "firewall.${zone}" 2>/dev/null)" = "zone" ] || continue
+		# uci -q get exits 1 on a missing section. Capture with || true so
+		# set -e cannot abort inside "$(…)" before || continue (#291 C3).
+		_type=$(uci -q get "firewall.${zone}" 2>/dev/null || true)
+		[ "$_type" = "zone" ] || continue
 		printf '%s' "$zone"
 		return 0
 	done
@@ -133,14 +143,16 @@ find_wan_zone_section() {
 }
 
 firewall_changes_pending() {
-	pending="$(uci -q changes firewall 2>/dev/null)"
+	# uci miss is "no pending changes". set -e cannot apply (#291 C3).
+	pending="$(uci -q changes firewall 2>/dev/null || true)"
 	[ -n "$pending" ]
 }
 
 wan_zone_log_value() {
 	zone="$1"
 	[ -n "$zone" ] || return 1
-	uci -q get "firewall.${zone}.log" 2>/dev/null
+	# Unset option is a valid empty value; uci -q get exits 1 (#291 C3).
+	uci -q get "firewall.${zone}.log" 2>/dev/null || true
 }
 
 # Resolve a firewall section id to its canonical cfgXXXX form (issue B-1 /
@@ -284,7 +296,8 @@ maybe_snapshot_wan_log_baseline() {
 restore_wan_log_baseline() {
 	path="$(wan_log_baseline_path)"
 	[ -f "$path" ] || return 0
-	baseline=$(cat "$path" 2>/dev/null)
+	# Empty file is a valid "option was unset" baseline (#291 C3).
+	baseline=$(cat "$path" 2>/dev/null || true)
 	zone=$(find_wan_zone_section)
 	if [ -z "$zone" ]; then
 		logger -t fwlive "WAN log baseline restore skipped: no WAN zone" 2>/dev/null || true
@@ -363,7 +376,7 @@ wan_filter_log_clear_value() {
 read_nf_log_backend() {
 	path="$1"
 	[ -f "$path" ] || return 1
-	val=$(cat "$path" 2>/dev/null)
+	val=$(cat "$path" 2>/dev/null) || return 1
 	[ -n "$val" ] && [ "$val" != 'none' ]
 }
 
@@ -403,8 +416,9 @@ collect_logging_blockers() {
 	check_nf_log_ipv4 || logging_blockers_append 'nf_log_ipv4_missing'
 	check_nf_log_ipv6 || logging_blockers_append 'nf_log_ipv6_missing'
 
-	[ -n "$LOGGING_BLOCKERS" ] || return 0
-	return 1
+	# Report via LOGGING_BLOCKERS, not exit status: return 1 would abort
+	# build_logging_status_json under set -e (#291 C3).
+	return 0
 }
 
 collect_logging_warnings() {
@@ -414,8 +428,8 @@ collect_logging_warnings() {
 	# Warnings are diagnostics only — do not gate the enable-logging CTA.
 	command -v timeout >/dev/null 2>&1 || logging_warnings_append 'timeout_missing'
 
-	[ -n "$LOGGING_WARNINGS" ] || return 0
-	return 1
+	# Report via LOGGING_WARNINGS, not exit status (#291 C3).
+	return 0
 }
 
 json_null_or_string() {
@@ -430,8 +444,13 @@ json_null_or_string() {
 
 build_logging_status_json() {
 	zone=$(find_wan_zone_section)
-	log_val=$(wan_zone_log_value "$zone")
-	limit_val=$( [ -n "$zone" ] && uci -q get "firewall.${zone}.log_limit" 2>/dev/null )
+	# Empty zone / unset log bit are valid; set -e cannot apply (#291 C3).
+	log_val=$(wan_zone_log_value "$zone") || log_val=
+	# Unset log_limit is a valid empty value; uci -q get exits 1 (#291 C3).
+	limit_val=
+	if [ -n "$zone" ]; then
+		limit_val=$(uci -q get "firewall.${zone}.log_limit" 2>/dev/null || true)
+	fi
 	wan_log=false
 	if wan_filter_log_enabled "$log_val"; then
 		wan_log=true

--- a/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
+++ b/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive
@@ -8,6 +8,17 @@
 #   resolve — reverse DNS for IP addresses (BusyBox nslookup)
 #   logging_status — WAN zone logging readiness (no args)
 #   enable_wan_logging / disable_wan_logging — opt-in WAN zone log=1 (no args)
+#
+# Entry point (rpcd plugin). Sourced helpers inherit these options. Do not
+# copy set -euo into fwlive-logging.sh — prerm sources that file alone (#222)
+# and keeps soft-fail / || return 1 contracts (#244, #291 C3).
+set -eu
+# pipefail: BusyBox ash (device) supports it; Debian dash (host `sh` in
+# CI) rejects `set -o pipefail` as a startup abort. Probe in a subshell —
+# a failed `set` in-process is fatal even under `if` (same class as #244
+# failed exec).
+# shellcheck disable=SC3040 # pipefail is ash/bash; dash probe is a subshell
+(set -o pipefail) 2>/dev/null && set -o pipefail
 
 FW4_TAG='!fw4: '
 LIBEXEC_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -83,7 +94,9 @@ map_add() {
 }
 
 uci_rule_names() {
-	uci -q show firewall 2>/dev/null | sed -n "s/^firewall\.@rule\[[0-9]*\]\.name='\(.*\)'$/\1/p"
+	# uci missing / empty firewall config is "no names", not fatal.
+	# pipefail + set -e cannot apply to this pipeline (#291 C3).
+	uci -q show firewall 2>/dev/null | sed -n "s/^firewall\.@rule\[[0-9]*\]\.name='\(.*\)'$/\1/p" || true
 }
 
 is_uci_style_name() {
@@ -396,7 +409,8 @@ poll_lines_from_input() {
 		json_get_var first 1
 		json_select ..
 		# shellcheck disable=SC2154 # set by json_get_var above
-		case "$first" in
+		# Missing addresses[1] leaves first unset; set -u (#291 C3).
+		case "${first:-}" in
 			''|*[!0-9]*) ;;
 			*) lines="$first" ;;
 		esac
@@ -462,9 +476,10 @@ resolve_hostname() {
 	[ -n "$ip" ] || return 1
 	is_resolvable_address "$ip" || return 1
 	command -v nslookup >/dev/null 2>&1 || return 1
-	out=$(run_with_timeout "$RESOLVE_TIMEOUT" nslookup "$ip")
+	# timeout/nslookup miss is "no PTR", not a plugin abort (#291 C3).
+	out=$(run_with_timeout "$RESOLVE_TIMEOUT" nslookup "$ip") || return 1
 	[ -n "$out" ] || return 1
-	name=$(parse_nslookup_name "$out")
+	name=$(parse_nslookup_name "$out") || return 1
 	[ -n "$name" ] || return 1
 	printf '%s' "$name"
 }
@@ -598,11 +613,14 @@ resolve_addresses() {
 			now=$(date +%s)
 			[ $((now - start)) -ge "$RESOLVE_BUDGET" ] && break
 			json_get_var ip "$idx"
-			if ! is_resolvable_address "$ip"; then
+			# Missing/empty element: set -u cannot read bare $ip (#291 C3).
+			if ! is_resolvable_address "${ip:-}"; then
 				idx=$((idx + 1))
 				continue
 			fi
-			name=$(resolve_hostname "$ip")
+			# NXDOMAIN / timeout: resolve_hostname returns 1. set -e
+			# cannot apply to this assignment (#291 C3).
+			name=$(resolve_hostname "$ip") || name=
 			if [ -n "$name" ]; then
 				map_add "$ip" "$name"
 				count=$((count + 1))
@@ -789,6 +807,17 @@ Address: 127.0.0.1:53")
 
 	run_logging_selftest || return 1
 
+	# Strict-mode smoke (#291 C3): status JSON uses soft-fail helpers
+	# (uci miss, empty WAN zone). Must not abort under dash/ash set -e.
+	_status=$(build_logging_status_json) || {
+		echo "build_logging_status_json: aborted under set -e" >&2
+		return 1
+	}
+	case "$_status" in
+		*'"blockers":'*) ;;
+		*) echo "build_logging_status_json: missing blockers: $_status" >&2; return 1 ;;
+	esac
+
 	if ! command -v jshn >/dev/null 2>&1; then
 		echo "skip: jshn not available (poll cap via jshn not tested)" >&2
 		return 0
@@ -834,7 +863,7 @@ Address: 127.0.0.1:53")
 	return 0
 }
 
-case "$1" in
+case "${1:-}" in
 	__selftest)
 		run_selftest
 		exit $?
@@ -845,22 +874,22 @@ case "$1" in
 		exit $?
 		;;
 	__poll_clamp)
-		poll_clamp_lines "$2"
+		poll_clamp_lines "${2:-}"
 		exit $?
 		;;
 	__tmp_dir_ok)
-		_fwlive_tmp_dir_ok "$2"
+		_fwlive_tmp_dir_ok "${2:-}"
 		exit $?
 		;;
 	__resolve_one)
-		if name=$(resolve_hostname "$2"); then
+		if name=$(resolve_hostname "${2:-}"); then
 			printf '%s\n' "$name"
 			exit 0
 		fi
 		exit 1
 		;;
 	__parse_nslookup)
-		name=$(parse_nslookup_name "$2")
+		name=$(parse_nslookup_name "${2:-}")
 		if [ -n "$name" ]; then
 			printf '%s\n' "$name"
 			exit 0
@@ -874,15 +903,16 @@ case "$1" in
 		echo '{"rules":{},"poll":{"addresses":[]},"resolve":{"addresses":[]},"logging_status":{},"enable_wan_logging":{},"disable_wan_logging":{}}'
 		;;
 	call)
-		case "$2" in
+		case "${2:-}" in
 			rules)
 				build_rules_map
 				;;
 			poll)
-				poll_logs "$3"
+				# rpcd may omit argv $3 and pass JSON on stdin (#291 C3).
+				poll_logs "${3:-}"
 				;;
 			resolve)
-				resolve_addresses "$3"
+				resolve_addresses "${3:-}"
 				;;
 			logging_status)
 				build_logging_status_json

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,1196 @@
     "": {
       "name": "fwlive",
       "devDependencies": {
-        "playwright": "1.60.0"
+        "@eslint/js": "9.39.5",
+        "eslint": "9.39.5",
+        "playwright": "1.60.0",
+        "prettier": "3.9.6",
+        "stylelint": "17.14.1",
+        "stylelint-config-standard": "40.0.0"
       }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.1.tgz",
+      "integrity": "sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colord": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -22,6 +1210,655 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.4.tgz",
+      "integrity": "sha512-c8B/VNLmxRcmqqenRA9t+9IyOjf9+V6lTxPaUJLqOCONdQkWZ0ETYgX0qbtJqPsgCNusT9MZ5Jeidw8Eb9tn2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "micromatch": "^4.0.8",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.7.tgz",
+      "integrity": "sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/playwright": {
@@ -50,6 +1887,728 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint": {
+      "version": "17.14.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+      "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.2",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.5",
+        "global-modules": "^2.0.0",
+        "globby": "^16.2.1",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.16",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.4",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.5.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/file-entry-cache": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.23"
+      }
+    },
+    "node_modules/stylelint/node_modules/flat-cache": {
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.7.tgz",
+      "integrity": "sha512-dML0wP6oak21rsNYCJpJB6O1BJIEwNpGrTw0URPfAk4hm0e3pRfCtzkfB6olBcXcVlU2rouCyz7lCyRB0OMVCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,18 @@
     "test": "./scripts/fwlive-test.sh",
     "test:links": "./scripts/fwlive-linkcheck.sh",
     "test:ui": "node scripts/capture-fwlive-screenshots.mjs",
-    "test:view": "node tests/fwlive-view-smoke.mjs"
+    "test:view": "node tests/fwlive-view-smoke.mjs",
+    "lint:js": "eslint \"openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/**/*.js\" \"openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js\"",
+    "lint:format": "prettier --check \"openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/**/*.js\" \"openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js\"",
+    "lint:css": "stylelint \"openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive/fwlive.css\"",
+    "lint": "npm run lint:js && npm run lint:format && npm run lint:css"
   },
   "devDependencies": {
-    "playwright": "1.60.0"
+    "@eslint/js": "9.39.5",
+    "eslint": "9.39.5",
+    "playwright": "1.60.0",
+    "prettier": "3.9.6",
+    "stylelint": "17.14.1",
+    "stylelint-config-standard": "40.0.0"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+exclude = [
+	"out",
+	"build",
+	"node_modules",
+	"lab",
+	"wave",
+	"coverage",
+	"openwrt",
+	".sdk",
+	".ci-sdk-cache",
+	".venv",
+]
+
+[tool.ruff.lint]
+# House norm: check only — never --fix / --unsafe-fixes in CI (#290 L3).
+select = ["E", "F", "W", "B", "UP"]
+ignore = [
+	"E501", # line length — existing corpus uses long fixture strings
+	"W191", # tabs — house style in some scripts (match shell/JS)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B011"]

--- a/scripts/embed-fwlive-css.js
+++ b/scripts/embed-fwlive-css.js
@@ -29,6 +29,8 @@ function generate(cssText) {
 	const styleText = '\n' + body;
 	return [
 		"'use strict';",
+		'/* SPDX-License-Identifier: Apache-2.0 */',
+		'/* Copyright 2025-2026 Lucas Albers <lucas.b.albers@gmail.com> */',
 		"'require baseclass';",
 		'',
 		'/**',

--- a/scripts/fwlive-shellcheck.sh
+++ b/scripts/fwlive-shellcheck.sh
@@ -1,21 +1,46 @@
 #!/usr/bin/env bash
-# Run shellcheck on shipped rpcd/libexec shell scripts (#86).
+# Run shellcheck on shipped rpcd/libexec shell scripts (#86, #290 L7).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIBEXEC="$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec"
+BASELINE="$ROOT/scripts/shellcheck-baseline.txt"
 
 if ! command -v shellcheck >/dev/null 2>&1; then
 	echo "Install shellcheck (e.g. apt install shellcheck) to run this gate." >&2
 	exit 1
 fi
 
-# Enumerate by discovery, not a fixed list, so a newly added script cannot
-# silently escape this gate (it previously named 4 files explicitly). The
-# shipped rpcd entrypoint `rpcd/fwlive` has no extension, so match *.sh OR
-# that exact name. Do not use -x: sourced paths are runtime-resolved
-# ($FILTER_DIR / $LOGGING_SH).
-find "$LIBEXEC" -type f \( -name '*.sh' -o -name 'fwlive' \) -print0 \
-	| xargs -0 -r shellcheck -s sh
+# Curated exclusions: SC ids from baseline with a "# reason" annotation.
+# Empty baseline → no --exclude (fail closed on any new warning).
+EXCLUDE_ARGS=()
+if [[ -f "$BASELINE" ]]; then
+	SC_IDS=()
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		[[ "$line" =~ ^[[:space:]]*# ]] && continue
+		[[ -z "${line//[[:space:]]/}" ]] && continue
+		if [[ "$line" =~ ^(SC[0-9]+) ]]; then
+			id="${BASH_REMATCH[1]}"
+			if [[ "$line" != *#* ]]; then
+				echo "FAIL: shellcheck-baseline entry missing # reason: $line" >&2
+				exit 1
+			fi
+			SC_IDS+=("$id")
+		fi
+	done < "$BASELINE"
+	if [[ ${#SC_IDS[@]} -gt 0 ]]; then
+		# Unique sorted ids for --exclude=A,B,C
+		mapfile -t SC_IDS < <(printf '%s\n' "${SC_IDS[@]}" | sort -u)
+		EXCLUDE_ARGS=(--exclude="$(IFS=,; echo "${SC_IDS[*]}")")
+	fi
+fi
 
-echo "fwlive shellcheck OK" >&2
+# Enumerate by discovery, not a fixed list, so a newly added script cannot
+# silently escape this gate. The shipped rpcd entrypoint `rpcd/fwlive` has no
+# extension, so match *.sh OR that exact name. Do not use -x: sourced paths
+# are runtime-resolved ($FILTER_DIR / $LOGGING_SH).
+# --severity=warning: style-only nits stay non-gating; warnings+ fail the build.
+find "$LIBEXEC" -type f \( -name '*.sh' -o -name 'fwlive' \) -print0 \
+	| xargs -0 -r shellcheck -s sh --severity=warning "${EXCLUDE_ARGS[@]}"
+
+echo "fwlive shellcheck OK (severity=warning; baseline=$(basename "$BASELINE"))" >&2

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -17,6 +17,22 @@ if [[ -z "$NODE" ]]; then
 	fi
 fi
 
+echo "== fwlive JS/CSS lint stack (#290) ==" >&2
+if [[ ! -d "$ROOT/node_modules/eslint" ]]; then
+	echo "Installing npm devDependencies for lint gates..." >&2
+	(cd "$ROOT" && npm ci)
+fi
+(cd "$ROOT" && npm run lint:js)
+(cd "$ROOT" && npm run lint:format)
+(cd "$ROOT" && npm run lint:css)
+if command -v ruff >/dev/null 2>&1; then
+	echo "== fwlive ruff (Python) ==" >&2
+	ruff check "$ROOT/tests" "$ROOT/scripts"
+else
+	echo "FAIL: ruff not found on PATH (install ruff for #290 L3)" >&2
+	exit 1
+fi
+
 echo "== fwlive view syntax (node --check) ==" >&2
 "$NODE" --check openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
 

--- a/scripts/fwlive-test.sh
+++ b/scripts/fwlive-test.sh
@@ -20,6 +20,34 @@ fi
 echo "== fwlive view syntax (node --check) ==" >&2
 "$NODE" --check openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js
 
+echo "== fwlive SPDX headers on shipped surface (#291) ==" >&2
+SPDX_FAIL=0
+SPDX_FILES=(
+	"$ROOT/openwrt-feed/luci-app-fwlive/Makefile"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh"
+	"$ROOT/openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-is-firewall-event.sh"
+	"$ROOT/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/view/status/fwlive.js"
+)
+while IFS= read -r -d '' f; do
+	SPDX_FILES+=("$f")
+done < <(find \
+	"$ROOT/openwrt-feed/luci-app-fwlive/htdocs/luci-static/resources/fwlive" \
+	-type f -name '*.js' -print0)
+for f in "${SPDX_FILES[@]}"; do
+	[[ -f "$f" ]] || { echo "FAIL: expected shipped file missing: $f" >&2; SPDX_FAIL=1; continue; }
+	if ! grep -q 'SPDX-License-Identifier' "$f"; then
+		echo "FAIL: missing SPDX-License-Identifier: $f" >&2
+		SPDX_FAIL=1
+	fi
+done
+if [[ "$SPDX_FAIL" -ne 0 ]]; then
+	echo "FAIL: add SPDX-License-Identifier to shipped files (#291 C2)" >&2
+	exit 1
+fi
+echo "OK: SPDX headers present on shipped JS/shell/Makefile" >&2
+
 echo "== fwlive shellcheck (libexec/rpcd) ==" >&2
 bash "$ROOT/scripts/fwlive-shellcheck.sh"
 

--- a/scripts/gen-shell-classifier.js
+++ b/scripts/gen-shell-classifier.js
@@ -180,6 +180,7 @@ const out = [
 	'# GENERATED FILE — do not edit. Run: ./scripts/gen-all.sh',
 	'# source: core/fwlive-log.js CLASSIFY_SPEC',
 	'# Shared isFirewallEvent parity logic (shell). Sourced by fwlive-log-filter.sh and tests.',
+	'# Sourced library: do not add set -euo here (callers own strict mode, #291 C3).',
 	'# One awk process classifies a batch (MODE=json) or one message (default).',
 	'',
 	'_fwlive_run_classify() {',

--- a/scripts/shellcheck-baseline.txt
+++ b/scripts/shellcheck-baseline.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Curated shellcheck exclusions for shipped libexec/rpcd (#290 L7).
+# Format: SC####<optional trailing junk>  then "# reason" on the same line.
+# Only the SC id before the first non-id character is used for --exclude.
+# New SC findings at --severity=warning MUST NOT be added casually — each
+# entry needs a reviewer-auditable reason (same bar as CodeQL suppressions).
+#
+# As of 2026-09-06 the shipped surface is clean at warning (and style) under
+# `shellcheck -s sh`. This file intentionally has zero suppressions so the
+# gate fails closed on the next new SC id.
+

--- a/tests/fwlive-logging.test.sh
+++ b/tests/fwlive-logging.test.sh
@@ -161,6 +161,29 @@ got=$(find_wan_zone_section)
 [ "$got" = "@zone[0]" ] || die "skip non-zone name=wan expected @zone[0], got '$got'"
 ok "find_wan_zone_section skips non-zone name=wan"
 
+# uci -q get miss must not abort WAN discovery under set -e (#291 C3).
+uci() {
+	case "$*" in
+		'-q show firewall')
+			cat <<'EOF'
+firewall.gone.name='wan'
+firewall.@zone[0]=zone
+firewall.@zone[0].name='wan'
+EOF
+			;;
+		'-q get firewall.gone')
+			return 1
+			;;
+		'-q get firewall.@zone[0]')
+			printf 'zone\n'
+			;;
+		*) return 1 ;;
+	esac
+}
+got=$(find_wan_zone_section)
+[ "$got" = "@zone[0]" ] || die "uci get miss must continue, expected @zone[0], got '$got'"
+ok "find_wan_zone_section continues after uci get miss"
+
 # firewall_changes_pending + enable refuse (issue #168)
 PENDING_STAGED=1
 UCI_COMMITTED=0

--- a/tests/fwlive-rules-map.test.js
+++ b/tests/fwlive-rules-map.test.js
@@ -10,6 +10,10 @@ const os = require('node:os');
 const ROOT = path.join(__dirname, '..');
 const RPCD = path.join(ROOT,
 	'openwrt-feed/luci-app-fwlive/root/usr/libexec/rpcd/fwlive');
+const FILTER_SH = path.join(ROOT,
+	'openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-log-filter.sh');
+const LOGGING_SH = path.join(ROOT,
+	'openwrt-feed/luci-app-fwlive/root/usr/libexec/fwlive-logging.sh');
 const FIXTURE = path.join(__dirname, 'fixtures', 'iptables-save.sample');
 const RULESMAP = '/tmp/rulesmap';
 const RULESMAP_LOCK = '/tmp/fwlive-rulesmap-test.lock';
@@ -97,6 +101,64 @@ function runRpcd(shell, args, opts) {
 	throw new Error('dash not found for runRpcd');
 }
 
+function runPosixFile(shell, file, opts) {
+	if (shell === 'busybox') {
+		for (const p of ['/usr/bin/busybox', '/bin/busybox', 'busybox']) {
+			try {
+				return execFileSync(p, ['sh', file], opts);
+			} catch (e) {
+				if (e.code !== 'ENOENT') throw e;
+			}
+		}
+		throw new Error('busybox not found for runPosixFile');
+	}
+	for (const p of ['/bin/dash', '/usr/bin/dash', 'dash']) {
+		try {
+			return execFileSync(p, [file], opts);
+		} catch (e) {
+			if (e.code !== 'ENOENT') throw e;
+		}
+	}
+	throw new Error('dash not found for runPosixFile');
+}
+
+function runPosixC(shell, script, opts) {
+	if (shell === 'busybox') {
+		for (const p of ['/usr/bin/busybox', '/bin/busybox', 'busybox']) {
+			try {
+				return execFileSync(p, ['sh', '-c', script], opts);
+			} catch (e) {
+				if (e.code !== 'ENOENT') throw e;
+			}
+		}
+		throw new Error('busybox not found for runPosixC');
+	}
+	for (const p of ['/bin/dash', '/usr/bin/dash', 'dash']) {
+		try {
+			return execFileSync(p, ['-c', script], opts);
+		} catch (e) {
+			if (e.code !== 'ENOENT') throw e;
+		}
+	}
+	throw new Error('dash not found for runPosixC');
+}
+
+function resetCalled(stubDir) {
+	try { fs.unlinkSync(path.join(stubDir, 'called')); } catch { /* absent */ }
+}
+
+function readCalled(stubDir) {
+	return fs.readFileSync(path.join(stubDir, 'called'), 'utf8');
+}
+
+function hostCommand(name) {
+	const out = execFileSync('/bin/sh', ['-c', 'command -v "$1"', 'sh', name], {
+		encoding: 'utf8',
+	}).trim();
+	assert.ok(out, `need host ${name} to exec from PATH stub`);
+	return out;
+}
+
 function runWithShell(shell, env) {
 	// shell is 'dash' or 'busybox' (busybox needs 'sh' arg)
 	return runRpcd(shell, ['call', 'rules'], { encoding: 'utf8', env });
@@ -130,6 +192,7 @@ function busyboxHonorsPath(cmd) {
 		makeStub(probe, cmd, '#!/bin/sh\necho STUB_RAN\nexit 0\n');
 		const out = execFileSync('busybox', ['sh', '-c', `${cmd} 192.0.2.1`], {
 			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'ignore'],
 			env: { ...process.env, PATH: `${probe}:${process.env.PATH}` },
 		});
 		return out.includes('STUB_RAN');
@@ -139,6 +202,36 @@ function busyboxHonorsPath(cmd) {
 	} finally {
 		if (probe) fs.rmSync(probe, { recursive: true, force: true });
 	}
+}
+
+function pathHonouringShells(cmd) {
+	const shells = posixShells().filter((s) => s !== 'busybox' || busyboxHonorsPath(cmd));
+	assert.ok(shells.length > 0, `need a PATH-honouring POSIX shell for ${cmd} stub`);
+	return shells;
+}
+
+function stubPathEnv(stubDir) {
+	return { ...process.env, PATH: `${stubDir}:${process.env.PATH}` };
+}
+
+function installNftUciStubs(stubDir) {
+	makeStub(stubDir, 'nft', `#!/bin/sh
+[ "$1" = list ] && [ "$2" = ruleset ] || exit 1
+cat <<'EOF'
+table inet fw4 {
+	chain input {
+		log prefix "fwlive-ssh" comment "!fw4: Allow-SSH"
+	}
+}
+EOF
+`);
+	makeStub(stubDir, 'uci', '#!/bin/sh\nexit 0\n');
+}
+
+function assertNftSshRules(shell, raw) {
+	const res = JSON.parse(raw);
+	assert.equal(res.backend, 'nft', `[${shell}] backend should be nft`);
+	assert.equal(res.rules['fwlive-ssh'], 'Allow-SSH', `[${shell}] fwlive-ssh`);
 }
 
 function testProductionNft() {
@@ -1129,6 +1222,142 @@ fi
 	} finally { fs.rmSync(stubDir, { recursive: true, force: true }); }
 }
 
+function installNslookupStub(stubDir) {
+	makeStub(stubDir, 'nslookup', `#!/bin/sh
+echo "marker-nslookup $1" >> "${stubDir}/called"
+cat <<'EOF'
+Server: 127.0.0.1
+Address: 127.0.0.1:53
+
+1.2.0.192.in-addr.arpa	name = ptr.example.
+EOF
+`);
+}
+
+function testBusyboxPathShadowNslookup() {
+	// Production: resolve_hostname → run_with_timeout nslookup (rpcd/fwlive).
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwlive-bbshadow-ns-'));
+	try {
+		installNslookupStub(stubDir);
+		const env = stubPathEnv(stubDir);
+		for (const shell of pathHonouringShells('nslookup')) {
+			resetCalled(stubDir);
+			const out = runRpcd(shell, ['__resolve_one', '192.0.2.1'], { encoding: 'utf8', env }).trim();
+			assert.equal(out, 'ptr.example', `[${shell}] PATH-first nslookup still parses`);
+			assert.ok(readCalled(stubDir).includes('marker-nslookup 192.0.2.1'),
+				`[${shell}] nslookup stub ran`);
+		}
+	} finally { fs.rmSync(stubDir, { recursive: true, force: true }); }
+}
+
+function testBusyboxPathShadowTimeout() {
+	// Production: run_with_timeout wraps nft list ruleset on the rules path.
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwlive-bbshadow-to-'));
+	try {
+		makeStub(stubDir, 'timeout', `#!/bin/sh
+echo "marker-timeout" >> "${stubDir}/called"
+shift
+exec "$@"
+`);
+		installNftUciStubs(stubDir);
+		const env = stubPathEnv(stubDir);
+		for (const shell of pathHonouringShells('timeout')) {
+			resetCalled(stubDir);
+			assertNftSshRules(shell, runWithShell(shell, env));
+			assert.ok(readCalled(stubDir).includes('marker-timeout'),
+				`[${shell}] timeout stub ran`);
+		}
+	} finally { fs.rmSync(stubDir, { recursive: true, force: true }); }
+}
+
+function testBusyboxPathShadowJsonfilter() {
+	// Production: fwlive-log-filter.sh pipes poll JSON through jsonfilter -e '@.log[*]'.
+	// rules never calls jsonfilter — drive the filter, not the rules map.
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwlive-bbshadow-jf-'));
+	try {
+		makeStub(stubDir, 'jsonfilter', `#!/bin/sh
+echo "marker-jsonfilter $*" >> "${stubDir}/called"
+printf '%s\\n' '{"msg":"IN=wan OUT= SRC=203.0.113.77 DST=192.0.2.77 PROTO=TCP","id":"path-shadow-jsonfilter"}'
+`);
+		const env = stubPathEnv(stubDir);
+		const payload = JSON.stringify({
+			log: [{ msg: 'not-a-firewall-line', id: 'host-jsonfilter-must-not-win' }]
+		});
+		for (const shell of pathHonouringShells('jsonfilter')) {
+			resetCalled(stubDir);
+			const raw = runPosixFile(shell, FILTER_SH, { encoding: 'utf8', env, input: payload });
+			assert.ok(readCalled(stubDir).includes('marker-jsonfilter'),
+				`[${shell}] jsonfilter stub ran`);
+			assert.ok(raw.includes('path-shadow-jsonfilter'),
+				`[${shell}] filter used PATH-first jsonfilter output`);
+			assert.ok(!raw.includes('host-jsonfilter-must-not-win'),
+				`[${shell}] host jsonfilter must not win`);
+		}
+	} finally { fs.rmSync(stubDir, { recursive: true, force: true }); }
+}
+
+function testBusyboxPathShadowStat() {
+	// Production dropped `stat -c` from wan_log_lock_dir_safe (#232).
+	// Lock-dir safety is `[ -O ]` + `find -prune -perm`. PATH-shadow find.
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwlive-bbshadow-stat-'));
+	const safeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwlive-bbshadow-lockdir-'));
+	try {
+		fs.chmodSync(safeDir, 0o755);
+		const realFind = hostCommand('find');
+		makeStub(stubDir, 'find', `#!/bin/sh
+echo "marker-find $*" >> "${stubDir}/called"
+exec "${realFind}" "$@"
+`);
+		const env = stubPathEnv(stubDir);
+		const script = `. "${LOGGING_SH}" && wan_log_lock_dir_safe "${safeDir}"`;
+		for (const shell of pathHonouringShells('find')) {
+			resetCalled(stubDir);
+			runPosixC(shell, script, { encoding: 'utf8', env });
+			const called = readCalled(stubDir);
+			assert.ok(called.includes('marker-find'),
+				`[${shell}] find stub ran (stat replacement #232)`);
+			assert.ok(called.includes(safeDir), `[${shell}] find saw the lock dir`);
+		}
+	} finally {
+		fs.rmSync(stubDir, { recursive: true, force: true });
+		fs.rmSync(safeDir, { recursive: true, force: true });
+	}
+}
+
+function testBusyboxPathShadowGetent() {
+	// getent is not on the production resolve path (#218/#228).
+	// PATH-shadow coverage is testBusyboxPathShadowNslookup (the replacement).
+	// A "must not run" stub is not PATH-shadow coverage — do not add one.
+	const src = fs.readFileSync(RPCD, 'utf8');
+	assert.equal(src.includes('getent'), false,
+		'rpcd/fwlive must not call getent; resolve uses nslookup (#218/#228)');
+}
+
+function testBusyboxPathShadowIptablesSave() {
+	// Production: build_rules_map iptables backend → run_with_timeout iptables-save.
+	const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwlive-bbshadow-ipt-'));
+	try {
+		makeStub(stubDir, 'iptables-save', `#!/bin/sh
+echo "marker-iptables-save" >> "${stubDir}/called"
+cat <<'EOF'
+-A INPUT -m comment --comment "Allow-SSH" -j LOG --log-prefix "fwlive-ssh "
+EOF
+`);
+		makeStub(stubDir, 'nft', '#!/bin/sh\nexit 1\n');
+		makeStub(stubDir, 'uci', '#!/bin/sh\nexit 0\n');
+		const env = stubPathEnv(stubDir);
+		for (const shell of pathHonouringShells('iptables-save')) {
+			resetCalled(stubDir);
+			const raw = runWithShell(shell, env);
+			const res = JSON.parse(raw);
+			assert.equal(res.backend, 'iptables', `[${shell}] backend should be iptables`);
+			assert.equal(res.rules['fwlive-ssh'], 'Allow-SSH', `[${shell}] iptables fwlive-ssh`);
+			assert.ok(readCalled(stubDir).includes('marker-iptables-save'),
+				`[${shell}] iptables-save stub ran`);
+		}
+	} finally { fs.rmSync(stubDir, { recursive: true, force: true }); }
+}
+
 function run() {
 	runRedirectPath();
 	testProductionNft();
@@ -1148,6 +1377,12 @@ function run() {
 	testTmpDirSticky();
 	testUciWhitespaceNames();
 	testResolveNslookup();
+	testBusyboxPathShadowNslookup();
+	testBusyboxPathShadowTimeout();
+	testBusyboxPathShadowJsonfilter();
+	testBusyboxPathShadowStat();
+	testBusyboxPathShadowGetent();
+	testBusyboxPathShadowIptablesSave();
 	console.log('fwlive rules map tests passed');
 }
 


### PR DESCRIPTION
## Summary
Aggregate review PR for the audit backlog wave already merged to `master`. **Not for merge** — base is a frozen pre-wave tip (`e833048` / v0.1.38) so CodeRabbit can see the full session diff in one place.

### Included (already on master)
| PR | Issue | Topic |
|---|---|---|
| #294 | #293 | Housekeeping hygiene (stale branch + ledger; GHAS H2 still operator UI) |
| #295 | #291 C1/C2 | SPDX headers + CI gate |
| #296 | #291 C3 | rpcd/libexec strict mode |
| #297 | #285 | BusyBox PATH-shadow stub tests |
| #299 | #290 L6/L7 | actionlint + shellcheck warning baseline |
| #298 | #290 L1–L5 | ESLint + Prettier + Ruff + stylelint |

Parent plan #288 and children #285/#290/#291 closed; #209 left open (upstream). #293 remains open only for GHAS Validity checks / Non-provider patterns UI toggles.

### Range
`e833048` → `4f3d7a1` (`origin/master` at open time)

## Test plan
- [x] Host suite on master after land (`./scripts/fwlive-test.sh`)
- [x] Mocked view smoke (`npm run test:view`)
- [x] BusyBox shell-filter parity
- [ ] CodeRabbit round on this aggregate PR (purpose of this PR)
- [ ] Do **not** merge this PR into the review base; close after CodeRabbit finishes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Firewall Live View reliability when firewall configuration entries, DNS lookups, or network addresses are missing or unavailable.
  - Shell-based logging and filtering now handle empty responses and unsupported shell features without unexpectedly stopping.
  - Added safer handling for missing command-line arguments and incomplete configuration data.

- **Quality Improvements**
  - Expanded automated validation for JavaScript, CSS, Python, shell scripts, workflow files, and license headers.
  - Added coverage for edge cases involving firewall discovery, command lookup, and BusyBox environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->