### PR TITLE
test: run full QEMU smoke on x86_64 and armsr

### DIFF
--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -53,6 +53,13 @@ Back-compat: `./scripts/validate-openwrt-23.05.sh` → `validate-openwrt.sh --ve
 
 Via `qemu-smoke-fwlive.sh`:
 
+For a release or compatibility sign-off, run both lab architectures with
+`scripts/qemu-smoke-matrix.sh` after starting and installing the package in
+each guest. The wrapper keeps the existing single-guest smoke unchanged and
+fails if either guest fails. x86_64 is the fast lab path; armsr/armv8 runs
+under TCG and is substantially slower, so the two-architecture check is
+manual/release validation rather than a required pull-request CI job.
+
 - SSH, OpenWrt release, guest arch
 - `ubus fwlive poll`, `ubus fwlive rules`, `ubus fwlive resolve`
 - LuCI static JS + dispatcher (HTTP 403 login = OK)

--- a/scripts/qemu-smoke-matrix.sh
+++ b/scripts/qemu-smoke-matrix.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run the complete fwlive QEMU smoke against both lab architectures.
+# Guests must already be running and have the package installed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+run_arch() {
+	local label="$1" ssh_port="$2" http_port="$3"
+	echo "== full smoke: ${label} ==" >&2
+	OPENWRT_SSH_PORT="$ssh_port" OWRT_HOSTFWD_HTTP="$http_port" \
+		"${ROOT}/scripts/qemu-smoke-fwlive.sh"
+}
+
+run_arch x86_64 "${FWLIVE_X86_SSH_PORT:-2222}" "${FWLIVE_X86_HTTP_PORT:-8080}"
+run_arch armsr-armv8 "${FWLIVE_ARMSR_SSH_PORT:-2223}" "${FWLIVE_ARMSR_HTTP_PORT:-8081}"
+
+echo "== both architecture smokes passed ==" >&2

--- a/scripts/qemu-smoke-matrix.sh
+++ b/scripts/qemu-smoke-matrix.sh
@@ -12,7 +12,16 @@ run_arch() {
 		"${ROOT}/scripts/qemu-smoke-fwlive.sh"
 }
 
+set +e
 run_arch x86_64 "${FWLIVE_X86_SSH_PORT:-2222}" "${FWLIVE_X86_HTTP_PORT:-8080}"
+x86_status=$?
 run_arch armsr-armv8 "${FWLIVE_ARMSR_SSH_PORT:-2223}" "${FWLIVE_ARMSR_HTTP_PORT:-8081}"
+armsr_status=$?
+set -e
+
+if (( x86_status != 0 || armsr_status != 0 )); then
+	echo "== architecture smoke failed (x86_64=${x86_status}, armsr-armv8=${armsr_status}) ==" >&2
+	exit 1
+fi
 
 echo "== both architecture smokes passed ==" >&2


### PR DESCRIPTION
Closes #314.

Adds `scripts/qemu-smoke-matrix.sh`, which runs the existing complete fwlive smoke for configured x86_64 and armsr/armv8 guests with explicit ports. The single-guest smoke remains unchanged.

The validation matrix now documents this as a manual/release compatibility check. x86_64 remains appropriate for fast CI; armsr uses TCG and is intentionally not required on every pull request.

Validation: shell syntax check, diff check, repository hooks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-architecture smoke validation for x86_64 and ARMv8 environments after package installation.
  - Runs both architecture checks even when one fails, reports each result, and fails overall if either check fails.
  - Continues to support single-environment smoke testing.

- **Documentation**
  - Added release and compatibility guidance for the validation process.
  - Clarified that multi-architecture validation is intended for manual or release checks, not pull-request CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->