### PR TITLE
ci(release): GitHub Release body from CHANGELOG section (kill empty generate-notes bodies)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -262,7 +262,16 @@ jobs:
           printf '  %s\n' "${assets[@]##*/}"
 
           publish_new() {
-            gh release create "$tag" "${assets[@]}" --title "$tag" --generate-notes
+            # CHANGELOG section is the authoritative body; GitHub's
+            # --generate-notes lists only merged PRs in the tag range and
+            # ships near-empty bodies otherwise (v0.1.40: compare link only).
+            local notes="${RUNNER_TEMP}/fwlive-release-notes.md"
+            if feed_publish_release_notes_file "$notes" "$tag"; then
+              gh release create "$tag" "${assets[@]}" --title "$tag" --notes-file "$notes"
+            else
+              echo "warn: no CHANGELOG.md section for $tag; falling back to --generate-notes" >&2
+              gh release create "$tag" "${assets[@]}" --title "$tag" --generate-notes
+            fi
           }
 
           if gh release view "$tag" >/dev/null 2>&1; then

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -1,7 +1,7 @@
 # Security review state
 
-> **Status:** 46 controls in force; 0 open security findings; housekeeping GHAS sub-features N/A on personal account (#293 H2 closed).
-> **Last review:** 2026-09-11 delta on shell helpers (#321/#308); full-surface housekeeping review 2026-09-08 (H1 stale branch deleted; H2 Validity checks + Non-provider patterns plan-gated — not available on personal GitHub accounts; tracked upstream in [housekeeping#24](https://github.com/lucas-albers-lz4/housekeeping/issues/24)).
+> **Status:** 47 controls in force; 0 open security findings; housekeeping GHAS sub-features N/A on personal account (#293 H2 closed).
+> **Last review:** 2026-09-11 delta on release-notes pipeline (#322 follow-up: CHANGELOG-driven GitHub Release body, publish workflow + host test); shell-helpers delta same day (#321/#308); full-surface housekeeping review 2026-09-08 (H1 stale branch deleted; H2 Validity checks + Non-provider patterns plan-gated — not available on personal GitHub accounts; tracked upstream in [housekeeping#24](https://github.com/lucas-albers-lz4/housekeeping/issues/24)).
 > **Open:** None from #293. Housekeeping may still emit `secret_validity_checks_off` / `secret_nonprovider_patterns_off` as false positives until [housekeeping#24](https://github.com/lucas-albers-lz4/housekeeping/issues/24) lands plan-aware scanning.
 > **Next:** On the next `v*` tag, re-check pins and run full docker usign (gap 4). The full surface re-pass is deferred — the gate criteria are not met (skill § Multi-model pass / full-pass gate). Lab gaps 1–3 ran as smoke tests on 2026-09-04 (`./scripts/qemu-security-gaps-smoke.sh` green). The gap 2 flock residual is unchanged.
 > **How to verify:** `./scripts/fwlive-test.sh` runs automated host checks. Multi-model pass: [`.cursor/skills/security-audit/SKILL.md`](../../.cursor/skills/security-audit/SKILL.md) § Multi-model pass. Values current as of this PR.
@@ -85,6 +85,7 @@ should carry a note saying what would raise it.
 | UCI rule names with whitespace are not word-split into junk keys | `host` | `tests/fwlive-rules-map.test.js` `testUciWhitespaceNames` |
 | `jsonfilter` declared; missing filter exits non-zero with `error` | `host` | Makefile `LUCI_DEPENDS`; `tests/fwlive-shell-filter.test.js` `runMissingJsonfilter` |
 | Generated classifier asset is required; missing asset exits non-zero with `classifier_missing` instead of silently filtering everything out | `host` | `tests/fwlive-shell-filter.test.js` `runMissingClassifier`; codegen freshness covers the `.awk` asset |
+| GitHub Release body is the CHANGELOG section (no empty `--generate-notes` bodies); fallback is loud | `host` | `feed_publish_release_notes_file` in `scripts/lib/feed-publish.sh`; `tests/feed-publish-release-assets.test.sh` notes assertions; `publish_new` warn on fallback |
 | JSON filter unescapes libubox string escapes (`\b` `\f` `\n` `\r` `\t` `\u00XX`) before classify | `host` | `tests/fwlive-shell-filter.test.js` `runJsonGetMsgEscapes` / `runJsonParity` |
 | JSON string content escaped per RFC 8259 | `host` | rpcd `__selftest` |
 | WAN log toggle serialized against concurrent callers | `host` | `tests/fwlive-logging-lock.test.sh` (32-trial race) |

--- a/docs/developer/security-review.md
+++ b/docs/developer/security-review.md
@@ -85,7 +85,7 @@ should carry a note saying what would raise it.
 | UCI rule names with whitespace are not word-split into junk keys | `host` | `tests/fwlive-rules-map.test.js` `testUciWhitespaceNames` |
 | `jsonfilter` declared; missing filter exits non-zero with `error` | `host` | Makefile `LUCI_DEPENDS`; `tests/fwlive-shell-filter.test.js` `runMissingJsonfilter` |
 | Generated classifier asset is required; missing asset exits non-zero with `classifier_missing` instead of silently filtering everything out | `host` | `tests/fwlive-shell-filter.test.js` `runMissingClassifier`; codegen freshness covers the `.awk` asset |
-| GitHub Release body is the CHANGELOG section (no empty `--generate-notes` bodies); fallback is loud | `host` | `feed_publish_release_notes_file` in `scripts/lib/feed-publish.sh`; `tests/feed-publish-release-assets.test.sh` notes assertions; `publish_new` warn on fallback |
+| GitHub Release normal-path body is the CHANGELOG section; missing-section fallback is `--generate-notes` with a loud warning (body may be sparse — fold before tagging) | `host` | `feed_publish_release_notes_file` in `scripts/lib/feed-publish.sh`; `tests/feed-publish-release-assets.test.sh` notes assertions; `publish_new` warn on fallback |
 | JSON filter unescapes libubox string escapes (`\b` `\f` `\n` `\r` `\t` `\u00XX`) before classify | `host` | `tests/fwlive-shell-filter.test.js` `runJsonGetMsgEscapes` / `runJsonParity` |
 | JSON string content escaped per RFC 8259 | `host` | rpcd `__selftest` |
 | WAN log toggle serialized against concurrent callers | `host` | `tests/fwlive-logging-lock.test.sh` (32-trial race) |

--- a/docs/release.md
+++ b/docs/release.md
@@ -88,7 +88,20 @@ Make sure that the filenames match `PKG_VERSION` in the Makefile.
 
 ## Release notes template
 
-Include in each release:
+The publish workflow generates the GitHub Release **body from the matching
+`## [vX.Y.Z]` section of CHANGELOG.md** (`feed_publish_release_notes_file`) —
+not from GitHub's `--generate-notes`, which enumerates only merged PRs in the
+tag range and ships a near-empty body when the range holds direct commits
+(v0.1.40 shipped with just the compare link). Consequences for the cut:
+
+- **The CHANGELOG fold for the version is required before tagging** — if the
+  section is missing, the workflow falls back to `--generate-notes` with a
+  warning, which is exactly the empty-body behavior we removed.
+- Keep each folded section readable standalone on the release page: it is
+  copied verbatim; the workflow appends the feed-install footer and the
+  previous-tag compare link.
+
+Include in each release (CHANGELOG section content):
 
 - Supported OpenWrt: **21.02**, **22.03**, **23.05**, **24.10** (opkg) · **25.12** (apk)
 - Feed install: [binary-feed.md](binary-feed.md)

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -493,3 +493,42 @@ feed_publish_write_manifest() {
 	done
 	printf '\n  ]\n}\n' >> "$manifest"
 }
+
+# Write the release notes body for tag $2 into $1 from CHANGELOG.md (repo root
+# of $FEED_PUBLISH_ROOT). GitHub's --generate-notes lists merged PRs in the
+# tag range only — direct commits and versions cut in the same hour leave an
+# effectively empty body (v0.1.39 never existed, v0.1.40 shipped with only the
+# compare link). The CHANGELOG fold is the authoritative record; use it.
+# Returns 0 and writes the file when the section exists; non-zero (caller
+# falls back to --generate-notes) when CHANGELOG.md or the version section is
+# missing. Trailing footer: feed/install pointers + previous/compare links.
+feed_publish_release_notes_file() {
+	local out="$1" tag="$2" root prev changelog
+	[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	root="$(feed_publish_root)"
+	changelog="$root/CHANGELOG.md"
+	[[ -f "$changelog" ]] || return 1
+	# Section: from '## [vX.Y.Z]' up to (excluding) the next '## [' heading.
+	local ver="$tag"
+	python3 - "$changelog" "$ver" "$out" <<'PY' || return 1
+import re, sys
+path, ver, out = sys.argv[1:4]
+text = open(path, encoding="utf-8").read()
+m = re.search(r"^## \[%s\].*?(?=^## \[|\Z)" % re.escape(ver), text, re.M | re.S)
+if not m:
+	sys.exit(1)
+open(out, "w", encoding="utf-8").write(m.group(0).rstrip() + "\n")
+PY
+	# Footer: stable usage pointers + lineage links (previous tag if known).
+	prev="$(git -C "$root" tag --sort=v:refname 2>/dev/null |
+		awk -v want="$tag" 'prev && $0==want {print prev} {prev=$0}' | head -1)"
+	{
+		printf '\n**Install (recommended):** signed feed — see [docs/binary-feed.md](https://github.com/lucas-albers-lz4/fwlive/blob/master/docs/binary-feed.md) · Manual download: the assets below\n\n'
+		if [[ -n "$prev" ]]; then
+			printf '**Full Changelog**: https://github.com/lucas-albers-lz4/fwlive/compare/%s...%s\n' "$prev" "$tag"
+		else
+			printf '**Package versions**: PKG_VERSION %s = APP_VERSION (lockstep)\n' "${tag#v}"
+		fi
+	} >> "$out"
+	return 0
+}

--- a/scripts/lib/feed-publish.sh
+++ b/scripts/lib/feed-publish.sh
@@ -529,6 +529,6 @@ PY
 		else
 			printf '**Package versions**: PKG_VERSION %s = APP_VERSION (lockstep)\n' "${tag#v}"
 		fi
-	} >> "$out"
+	} >> "$out" || return 1
 	return 0
 }

--- a/tests/feed-publish-release-assets.test.sh
+++ b/tests/feed-publish-release-assets.test.sh
@@ -240,9 +240,9 @@ cat > "$notes_fix/CHANGELOG.md" <<'EOF'
 - Older section must not leak
 EOF
 FEED_PUBLISH_ROOT="$notes_fix" feed_publish_release_notes_file "${fixture}/notes.md" v9.9.9 ||
-	echo "FAIL: notes helper must succeed for a known version" >&2
+	{ echo "FAIL: notes helper must succeed for a known version" >&2; exit 1; }
 grep -q "Synthetic fix" "${fixture}/notes.md" ||
-	echo "FAIL: notes must carry the version section" >&2
+	{ echo "FAIL: notes must carry the version section" >&2; exit 1; }
 grep -q "Older section must not leak" "${fixture}/notes.md" &&
 	{ echo "FAIL: notes must stop at the next heading" >&2; exit 1; }
 grep -q "## \[v9.9.8\]" "${fixture}/notes.md" &&

--- a/tests/feed-publish-release-assets.test.sh
+++ b/tests/feed-publish-release-assets.test.sh
@@ -217,4 +217,60 @@ if [[ -s "${fixture}/abort-staging/manifest.json" ]] && \
 fi
 unset MOCK_REPO_DIGESTS MOCK_NO_ID
 
+# Release notes body = CHANGELOG section (generate-notes lists only merged PRs
+# in the tag range → near-empty bodies for direct-commit ranges, v0.1.40).
+notes_fix="${fixture}/notes-repo"
+mkdir -p "$notes_fix"
+cat > "$notes_fix/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [v9.9.9] — 2026-09-11
+
+### Fixed
+- Synthetic fix (#000)
+
+### Added
+- Synthetic addition
+
+## [v9.9.8] — 2026-09-01
+
+### Fixed
+- Older section must not leak
+EOF
+FEED_PUBLISH_ROOT="$notes_fix" feed_publish_release_notes_file "${fixture}/notes.md" v9.9.9 ||
+	echo "FAIL: notes helper must succeed for a known version" >&2
+grep -q "Synthetic fix" "${fixture}/notes.md" ||
+	echo "FAIL: notes must carry the version section" >&2
+grep -q "Older section must not leak" "${fixture}/notes.md" &&
+	{ echo "FAIL: notes must stop at the next heading" >&2; exit 1; }
+grep -q "## \[v9.9.8\]" "${fixture}/notes.md" &&
+	{ echo "FAIL: next heading leaked" >&2; exit 1; }
+# Non-repo root → no previous tag resolvable: version-line fallback footer,
+# never a bogus compare range.
+grep -q "PKG_VERSION 9.9.9" "${fixture}/notes.md" ||
+	{ echo "FAIL: fallback version footer missing" >&2; exit 1; }
+grep -q "Full Changelog" "${fixture}/notes.md" &&
+	{ echo "FAIL: compare footer must not appear without tags" >&2; exit 1; }
+# Real git root with tags → previous-tag compare footer.
+git_fix="${fixture}/git-repo"
+mkdir -p "$git_fix"
+cp "$notes_fix/CHANGELOG.md" "$git_fix/CHANGELOG.md"
+git -C "$git_fix" init -q
+git -C "$git_fix" -c user.name=t -c user.email=t@t add CHANGELOG.md
+git -C "$git_fix" -c user.name=t -c user.email=t@t commit -qm x
+git -C "$git_fix" tag v9.9.8
+git -C "$git_fix" tag v9.9.9
+FEED_PUBLISH_ROOT="$git_fix" feed_publish_release_notes_file "${fixture}/notes-git.md" v9.9.9 ||
+	{ echo "FAIL: notes helper must succeed in a tagged repo" >&2; exit 1; }
+grep -q "compare/v9\.9\.8\.\.\.v9\.9\.9" "${fixture}/notes-git.md" ||
+	{ echo "FAIL: compare footer missing in tagged repo" >&2; exit 1; }
+# Unknown version → non-zero (caller falls back to --generate-notes)
+FEED_PUBLISH_ROOT="$notes_fix" feed_publish_release_notes_file "${fixture}/none.md" v9.9.7 &&
+	{ echo "FAIL: unknown version must return non-zero" >&2; exit 1; }
+# Malformed tag → non-zero before touching the changelog
+FEED_PUBLISH_ROOT="$notes_fix" feed_publish_release_notes_file "${fixture}/bad.md" 'v9.9.9; rm' &&
+	{ echo "FAIL: malformed tag must return non-zero" >&2; exit 1; }
+
 echo "feed-publish release asset tests passed"


### PR DESCRIPTION
## Summary

- `feed_publish_release_notes_file` (scripts/lib/feed-publish.sh): extracts the matching `## [vX.Y.Z]` section from CHANGELOG.md, appends the feed-install footer + previous-tag compare link; non-zero on missing section (caller falls back loudly).
- `publish_new` in publish-packages.yml: `--notes-file` from CHANGELOG when available; `--generate-notes` + warning otherwise.
- Host test: section extraction, next-heading stop, footer fallback (non-repo root) vs compare link (tagged repo), unknown-version + malformed-tag non-zero.
- Docs: release.md notes-template section rewritten (CHANGELOG fold is now a hard pre-tag requirement); security-review.md control row + header delta.

## Why

The releases page is inconsistent because GitHub's `--generate-notes` enumerates only **merged PRs** in the tag-to-tag window: v0.1.37/38 windows had PRs → rich bodies; v0.1.40's window held only the direct fix commit → 88-char body (compare link only); v0.1.39's publish failed at 15s so its release never existed. CHANGELOG.md already carried accurate entries for all of them — the two channels were simply never connected.

## Verification

- `bash tests/feed-publish-release-assets.test.sh` — green (incl. new notes assertions)
- `NODE=… ./scripts/fwlive-test.sh` — green except host jshn-fixture gap (CI installs the variants)
- `actionlint` + `fwlive-shellcheck` — clean

Refs #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Release descriptions now use the matching version section from `CHANGELOG.md`.
  * Release descriptions include installation guidance and comparison or package-version details.
  * If the matching changelog section is unavailable, the system falls back to generated release notes and displays a warning.

* **Documentation**
  * Release guidance now explains changelog-based release descriptions, fallback behavior, and standalone readability requirements.
  * Security review records have been updated to reflect the additional control.

* **Tests**
  * Added coverage for changelog extraction, version matching, fallback behavior, comparison links, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->