### PR TITLE
perf(#319): memory-census harness and profiling stub

### DIFF
--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -216,8 +216,88 @@ standalone file-open cost. Stage shares remain inclusive and non-additive.
 - [x] Stage attribution on `tests/fixtures/logread-2000.json` (five raw samples, median and spread)
 - [x] Record substrate (`qemu-armsr-tcg`) + date + git SHA
 
+## Memory profiling (#319)
+
+Harness: [`scripts/memory-census.sh`](../../scripts/memory-census.sh). Manual/release
+profiling only — no CI guest job yet (same stance as the #310 device table).
+
+### Metric contract
+
+- **Budget series = summed VmRSS (kB)** of the chosen process tree. Soft ceilings
+  bind on RSS, not PSS. On x86, emit PSS from `smaps_rollup` as a companion to
+  quantify shared-page overcount; armsr has no `CONFIG_PROC_PAGE_MONITOR`, so
+  VmRSS/VmHWM only.
+- **Idle ≠ peak.** Idle is rpcd-at-rest (+ leaked descendants). Peak is the max
+  of concurrent ~50 ms tree samples during one poll (BusyBox `sleep` may be 1 s
+  only — the harness busy-waits on `/proc/uptime` centiseconds). Sampled peak is
+  not `/proc` `VmPeak` (virtual); worker `VmHWM` is an optional companion.
+- **Split roots.** C1 (PATH-shim direct `/usr/libexec/rpcd/fwlive call poll`,
+  fixture-backed `log read`) uses `root=fwlive`. C2 / idle / retention
+  (`ubus call fwlive poll`) use `root=rpcd`. Never walk rpcd for C1.
+- **C1 exercises the full poll path** (`raw=$(ubus…)` + filter), not filter-only.
+- **RSS sums double-count** shared text across ash/jsonfilter/awk children —
+  intentional; document it; use x86 PSS to quantify.
+- **Sub-50 ms children** (jshn/dirname/cat) may be missed by the sampler;
+  jsonfilter/awk usually appear.
+- **Retention:** T0 idle → 10 polls → 60 s idle → T1; `Δ = T1 − T0`. **nofork:**
+  same 60 s with zero polls. Soft-budget **Z is sized from the nofork Δ only**.
+- **logd** RSS is a context metric only — never added to the fwlive budget sum.
+- **Line pins:** C2 `addresses:["50"]` = normal; C1 fixture / `["2000"]` = max.
+  Record returned `lines=` (stock 64 KiB ring may not hold 2000).
+- Emit `n=5` peak samples per poll case (same convention as #310). Join CPU and
+  memory rows with `PROFILE_META run_id=…` (`FWLIVE_PROFILE_RUN_ID` or auto).
+
+### Soft budget (provisional)
+
+| Ceiling | Value | Notes |
+|---|---|---|
+| Idle RSS (X) | ≤ 8 MB | ~5–10% of the 128 MB device class |
+| Peak process-tree RSS (Y) | ≤ 16 MB | ≈ 2× idle; fork-heavy poll |
+| Retained Δ RSS (Z) | TBD | Commit from first nofork baseline before accepting results |
+| Future stretch | 64 MB class | Documented only; not binding |
+
+- **Binding substrate:** x86_64 guest `OWRT_QEMU_MEM=128` (hardcoded `-smp 2` is fine).
+- **Production-target confirmation:** armsr `OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256`.
+- **Owner:** @lucas-albers-lz4. Re-evaluate each release; re-open automation if a
+  single change regresses peak RSS by >10% or retained RSS by > Z.
+
+### Actionable rule (AC-4)
+
+A memory change is actionable if **any** of: > 2σ of the pre-change 5-run baseline
+mean, OR > 5% of that baseline’s peak RSS, OR > 8 MB absolute. Disposition before
+merge: owner approval, blocking follow-up issue, or documented exception here.
+
+### #308 gate linkage (AC-6)
+
+Any #308 S-candidate PR that changes fork/exec count or pipeline structure must
+include pre/post peak and retained RSS snapshots (from this harness) in the PR
+description.
+
+### Checklist
+
+- [x] Harness + this stub
+- [ ] Guest primitive probe confirm (x86 PSS / armsr VmRSS)
+- [ ] Idle / nofork / C2 / retention / C1 baselines (n=5)
+- [ ] Commit numeric Z from nofork; fill result tables
+- [ ] armsr confirmation run against soft budget
+- [ ] Degraded-mode baselines (adaptive cap + visibility pause) — **blocked on #306**
+
+### Sample invocation
+
+```sh
+# Binding: x86_64 128 MB class
+OWRT_QEMU_MEM=128 ./scripts/run-openwrt-x86-qemu.sh
+# wait + install fwlive, then:
+OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh
+
+# Confirmation: armsr weak-device rig
+OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256 ./scripts/run-openwrt-armsr-armv8-qemu.sh
+OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh
+```
+
 ## Further reading
 
 - [`../armvirt-armsr-testing.md`](../armvirt-armsr-testing.md)
 - [`../openwrt-rootfs-x86-docker.md`](../openwrt-rootfs-x86-docker.md) — optional Docker experiment
 - [`../../lab/README.md`](../../lab/README.md)
+- [#319](https://github.com/lucas-albers-lz4/fwlive/issues/319) — memory footprint requirements

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -239,8 +239,10 @@ profiling only — no CI guest job yet (same stance as the #310 device table).
   intentional; document it; use x86 PSS to quantify.
 - **Sub-50 ms children** (jshn/dirname/cat) may be missed by the sampler;
   jsonfilter/awk usually appear.
-- **Retention:** T0 idle → 10 polls → 60 s idle → T1; `Δ = T1 − T0`. **nofork:**
-  same 60 s with zero polls. Soft-budget **Z is sized from the nofork Δ only**.
+- **Retention:** settle after prior poll cases, then T0 idle → 10 polls → 60 s
+  idle → T1; `Δ = T1 − T0`. **nofork:** same 60 s with zero polls. Soft-budget
+  **Z is sized from the nofork Δ only**. A peak sample with no in-flight tree
+  observation is emitted as `value=invalid`, not a post-exit walk.
 - **logd** RSS is a context metric only — never added to the fwlive budget sum.
 - **Line pins:** C2 `addresses:["50"]` = normal; C1 fixture / `["2000"]` = max.
   Record returned `lines=` (stock 64 KiB ring may not hold 2000).

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -224,9 +224,10 @@ profiling only — no CI guest job yet (same stance as the #310 device table).
 ### Metric contract
 
 - **Budget series = summed VmRSS (kB)** of the chosen process tree. Soft ceilings
-  bind on RSS, not PSS. On x86, emit PSS from `smaps_rollup` as a companion to
-  quantify shared-page overcount; armsr has no `CONFIG_PROC_PAGE_MONITOR`, so
-  VmRSS/VmHWM only.
+  bind on RSS, not PSS. The harness **probes** `/proc/*/smaps_rollup` each run:
+  when PSS is available it emits `PROFILE_META primitive=pss` and companion
+  `pss_kb` samples; otherwise `primitive=vmrss` and no PSS rows. Do not assume
+  PSS by architecture — record the probe result from the guest run.
 - **Idle ≠ peak.** Idle is rpcd-at-rest (+ leaked descendants). Peak is the max
   of concurrent ~50 ms tree samples during one poll (BusyBox `sleep` may be 1 s
   only — the harness busy-waits on `/proc/uptime` centiseconds). Sampled peak is
@@ -236,13 +237,15 @@ profiling only — no CI guest job yet (same stance as the #310 device table).
   (`ubus call fwlive poll`) use `root=rpcd`. Never walk rpcd for C1.
 - **C1 exercises the full poll path** (`raw=$(ubus…)` + filter), not filter-only.
 - **RSS sums double-count** shared text across ash/jsonfilter/awk children —
-  intentional; document it; use x86 PSS to quantify.
+  intentional; document it; use PSS to quantify when the probe finds it.
 - **Sub-50 ms children** (jshn/dirname/cat) may be missed by the sampler;
   jsonfilter/awk usually appear.
-- **Retention:** settle after prior poll cases, then T0 idle → 10 polls → 60 s
-  idle → T1; `Δ = T1 − T0`. **nofork:** same 60 s with zero polls. Soft-budget
-  **Z is sized from the nofork Δ only**. A peak sample with no in-flight tree
-  observation is emitted as `value=invalid`, not a post-exit walk.
+- **Case order and settles:** idle → **nofork** (60 s zero-poll baseline, **no**
+  10 s settle) → C2 (n=5) → **10 s settle** → retention T0 → 10× C2 polls →
+  60 s idle → T1 (`Δ = T1 − T0`; `delta_rss_kb=invalid` if any retention poll
+  fails) → C1 last. Soft-budget **Z is sized from the nofork Δ only**. A peak
+  sample with no in-flight tree observation is `value=invalid`, not a post-exit
+  walk.
 - **logd** RSS is a context metric only — never added to the fwlive budget sum.
 - **Line pins:** C2 `addresses:["50"]` = normal; C1 fixture / `["2000"]` = max.
   Record returned `lines=` (stock 64 KiB ring may not hold 2000).
@@ -265,10 +268,25 @@ profiling only — no CI guest job yet (same stance as the #310 device table).
 
 ### Actionable rule (AC-4)
 
-A memory change is actionable if **any** of: > 2σ of the pre-change 5-run baseline
-mean, OR > 5% of that baseline’s peak RSS, OR > 8 MB absolute. Disposition before
-merge: owner approval, blocking follow-up issue, or documented exception here.
+Compare a candidate’s **post** C1 (or C2) peak series to the **pre-change**
+baseline of the same case. Units are kB (VmRSS process-tree peak).
 
+Definitions (from the five `peak_rss_kb` samples for that case):
+
+- `baseline_peak` / `post_peak` — median of the five samples (kB)
+- `baseline_mean` — arithmetic mean of the five baseline samples (kB)
+- `σ` — sample standard deviation of those five baseline samples (kB)
+- `Δ_peak` — `post_peak − baseline_peak` (kB); actionable thresholds apply to
+  this **increase**, not to the absolute post value alone
+
+A memory change is actionable if **any** of:
+
+1. `Δ_peak > 2σ`, or
+2. `Δ_peak > 0.05 × baseline_peak`, or
+3. `Δ_peak > 8192` (8 MB absolute)
+
+Disposition before merge: owner approval, blocking follow-up issue, or
+documented exception here.
 ### #308 gate linkage (AC-6)
 
 Any #308 S-candidate PR that changes fork/exec count or pipeline structure must

--- a/scripts/memory-census.sh
+++ b/scripts/memory-census.sh
@@ -343,8 +343,8 @@ measure_peak() {
 	# Capture starttime while watch still lives; never fall back to min_start=0
 	# (that would count all pre-existing rpcd descendants as poll peak).
 	min_start=
-	i=0
-	while [ "$i" -lt 20 ]; do
+	st_try=0
+	while [ "$st_try" -lt 20 ]; do
 		if kill -0 "$watch" 2>/dev/null; then
 			st=$(read_starttime "$watch")
 			if [ -n "$st" ] && [ "$st" -gt 0 ] 2>/dev/null; then
@@ -354,7 +354,7 @@ measure_peak() {
 		else
 			break
 		fi
-		i=$((i + 1))
+		st_try=$((st_try + 1))
 	done
 	if [ -z "$min_start" ]; then
 		wait "$watch" 2>/dev/null || true

--- a/scripts/memory-census.sh
+++ b/scripts/memory-census.sh
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Measure fwlive process-tree RSS on a running OpenWrt guest (#319).
+#
+# Budget series is summed VmRSS (kB). Peak is the max of a concurrent ~50 ms
+# sampler, not VmPeak. Soft ceilings bind on RSS; PSS is an x86 companion.
+#
+# Usage:
+#   OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh [fixture]
+#   ./scripts/memory-census.sh --help
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST="${OPENWRT_HOST:-127.0.0.1}"
+PORT="${OPENWRT_SSH_PORT:-2222}"
+FIXTURE="${1:-${ROOT}/tests/fixtures/logread-2000.json}"
+REMOTE_FIXTURE=/tmp/fwlive-logread-2000.json
+KNOWN_HOSTS="${FWLIVE_KNOWN_HOSTS:-${ROOT}/lab/qemu-known_hosts}"
+
+usage() {
+	sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+mkdir -p "$(dirname "$KNOWN_HOSTS")"
+touch "$KNOWN_HOSTS"
+SSH_OPTS=(-o StrictHostKeyChecking="${FWLIVE_STRICT_HOST_KEY_CHECKING:-accept-new}" -o UserKnownHostsFile="$KNOWN_HOSTS" -o ConnectTimeout=15 -p "$PORT")
+
+[[ -f "$FIXTURE" ]] || { echo "fixture not found: $FIXTURE" >&2; exit 1; }
+ssh "${SSH_OPTS[@]}" "root@$HOST" 'echo connected' >/dev/null
+
+echo "Copying $(basename "$FIXTURE") to root@$HOST:$PORT:$REMOTE_FIXTURE" >&2
+if scp -O -q -P "$PORT" -o StrictHostKeyChecking="${FWLIVE_STRICT_HOST_KEY_CHECKING:-accept-new}" -o UserKnownHostsFile="$KNOWN_HOSTS" \
+	"$FIXTURE" "root@$HOST:$REMOTE_FIXTURE" 2>/dev/null; then
+	:
+else
+	ssh "${SSH_OPTS[@]}" "root@$HOST" "cat > $REMOTE_FIXTURE" <"$FIXTURE"
+fi
+
+RUN_ID="${FWLIVE_PROFILE_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$RANDOM}"
+
+ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- "$REMOTE_FIXTURE" "$RUN_ID" <<'REMOTE'
+set -eu
+fixture=$1
+run_id=$2
+
+DUMP=/tmp/fwlive-mem-dump
+PEAK=/tmp/fwlive-mem-peak
+C1_IN=/tmp/fwlive-mem-c1-in
+POLL_OUT=/tmp/fwlive-mem-poll-out
+HAS_PSS=0
+TREE_RSS=0
+TREE_PSS=0
+TREE_HWM=0
+TREE_NPROCS=0
+
+clock_cs() {
+	read uptime _ </proc/uptime
+	seconds=${uptime%.*}
+	fraction=${uptime#*.}
+	fraction=${fraction#0}
+	[ -n "$fraction" ] || fraction=0
+	printf '%s\n' $((seconds * 100 + fraction))
+}
+
+wait_cs() {
+	target=$(($(clock_cs) + $1))
+	while [ "$(clock_cs)" -lt "$target" ]; do
+		:
+	done
+}
+
+read_self_pid() {
+	line=
+	read line </proc/self/stat || true
+	printf '%s\n' "${line%% *}"
+}
+
+read_starttime() {
+	pid=$1
+	line=
+	read line <"/proc/$pid/stat" || true
+	[ -n "$line" ] || { printf '%s\n' 0; return; }
+	rest=${line##*)}
+	set -- $rest
+	printf '%s\n' "${20:-0}"
+}
+
+read_pss() {
+	pid=$1
+	[ -r "/proc/$pid/smaps_rollup" ] || { printf '%s\n' 0; return; }
+	while read key val unit; do
+		case "$key" in
+			Pss:) printf '%s\n' "${val:-0}"; return ;;
+		esac
+	done <"/proc/$pid/smaps_rollup"
+	printf '%s\n' 0
+}
+
+find_named_pid() {
+	name=$1
+	pid=
+	if command -v pidof >/dev/null 2>&1; then
+		pid=$(pidof "$name" 2>/dev/null || true)
+		pid=${pid%% *}
+	fi
+	if [ -z "$pid" ]; then
+		for status in /proc/[0-9]*/status; do
+			[ -r "$status" ] || continue
+			n=$(sed -n 's/^Name:[[:space:]]*//p' "$status" 2>/dev/null || true)
+			if [ "$n" = "$name" ]; then
+				pid=${status#/proc/}
+				pid=${pid%/status}
+				break
+			fi
+		done
+	fi
+	printf '%s\n' "$pid"
+}
+
+rpcd_pid() {
+	pid=$(find_named_pid rpcd)
+	[ -n "$pid" ] || { echo "PROFILE_ERROR reason=rpcd_not_running" >&2; exit 1; }
+	printf '%s\n' "$pid"
+}
+
+probe_pss() {
+	[ -r /proc/self/smaps_rollup ] || return 1
+	while read key val unit; do
+		case "$key" in
+			Pss:) return 0 ;;
+		esac
+	done </proc/self/smaps_rollup
+	return 1
+}
+
+scan_proc() {
+	: >"$DUMP"
+	for status in /proc/[0-9]*/status; do
+		[ -r "$status" ] || continue
+		pid=${status#/proc/}
+		pid=${pid%/status}
+		ppid=0
+		rss=0
+		hwm=0
+		while read key val unit; do
+			case "$key" in
+				PPid:) ppid=${val:-0} ;;
+				VmRSS:) rss=${val:-0} ;;
+				VmHWM:) hwm=${val:-0} ;;
+			esac
+		done <"$status"
+		printf '%s %s %s %s\n' "$pid" "$ppid" "$rss" "$hwm" >>"$DUMP"
+	done
+}
+
+# BFS under root. Peak walks always include root RSS; descendants contribute
+# only when starttime >= min_start (empty min_start = no filter). Sampler PID
+# is omitted entirely, including its children.
+walk_tree() {
+	root=$1
+	exclude=$2
+	min_start=$3
+
+	scan_proc
+	TREE_RSS=0
+	TREE_PSS=0
+	TREE_HWM=0
+	TREE_NPROCS=0
+
+	queue=$root
+	seen=" $root "
+
+	while [ -n "$queue" ]; do
+		set -- $queue
+		pid=$1
+		shift
+		queue=$*
+
+		[ "$pid" != "$exclude" ] || continue
+
+		found=0
+		rss=0
+		hwm=0
+		while read dpid dppid drss dhwm; do
+			if [ "$dpid" = "$pid" ]; then
+				rss=$drss
+				hwm=$dhwm
+				found=1
+				break
+			fi
+		done <"$DUMP"
+		[ "$found" = 1 ] || continue
+
+		include=1
+		if [ "$pid" != "$root" ] && [ -n "$min_start" ]; then
+			st=$(read_starttime "$pid")
+			[ "$st" -ge "$min_start" ] 2>/dev/null || include=0
+		fi
+		if [ "$include" = 1 ]; then
+			TREE_RSS=$((TREE_RSS + rss))
+			[ "$hwm" -gt "$TREE_HWM" ] && TREE_HWM=$hwm
+			TREE_NPROCS=$((TREE_NPROCS + 1))
+			if [ "$HAS_PSS" = 1 ]; then
+				pss=$(read_pss "$pid")
+				TREE_PSS=$((TREE_PSS + pss))
+			fi
+		fi
+
+		while read dpid dppid drss dhwm; do
+			[ "$dppid" = "$pid" ] || continue
+			[ "$dpid" != "$exclude" ] || continue
+			case "$seen" in
+				*" $dpid "*) continue ;;
+			esac
+			seen="$seen$dpid "
+			queue="$queue $dpid"
+		done <"$DUMP"
+	done
+}
+
+emit() {
+	printf 'MEMORY_SAMPLE'
+	for kv in "$@"; do
+		printf ' %s' "$kv"
+	done
+	printf '\n'
+}
+
+count_log_lines() {
+	file=$1
+	[ -s "$file" ] || { printf '%s\n' 0; return; }
+	n=0
+	if command -v jsonfilter >/dev/null 2>&1; then
+		n=$(jsonfilter -e '@.log[*]' <"$file" 2>/dev/null | wc -l || true)
+		n=$(printf '%s' "$n" | tr -d ' \n')
+	fi
+	[ -n "$n" ] || n=0
+	printf '%s\n' "$n"
+}
+
+sample_idle_tree() {
+	root=$(rpcd_pid)
+	walk_tree "$root" "$(read_self_pid)" ""
+}
+
+emit_tree() {
+	case=$1
+	root_kind=$2
+	metric=$3
+	value=$4
+	extra=${5:-}
+	if [ -n "$extra" ]; then
+		emit "case=$case" "root=$root_kind" "metric=$metric" "value=$value" "nprocs=$TREE_NPROCS" "$extra"
+	else
+		emit "case=$case" "root=$root_kind" "metric=$metric" "value=$value" "nprocs=$TREE_NPROCS"
+	fi
+}
+
+emit_idle_metrics() {
+	case=$1
+	extra=${2:-}
+	sample_idle_tree
+	emit_tree "$case" rpcd rss_kb "$TREE_RSS" "$extra"
+	if [ "$HAS_PSS" = 1 ]; then
+		emit_tree "$case" rpcd pss_kb "$TREE_PSS" "$extra"
+	fi
+}
+
+emit_logd() {
+	case=$1
+	pid=$(find_named_pid logd)
+	if [ -z "$pid" ] || [ ! -r "/proc/$pid/status" ]; then
+		emit "case=$case" metric=logd_rss_kb value=0
+		return
+	fi
+	rss=0
+	while read key val unit; do
+		case "$key" in
+			VmRSS:) rss=${val:-0}; break ;;
+		esac
+	done <"/proc/$pid/status"
+	emit "case=$case" metric=logd_rss_kb "value=$rss"
+}
+
+# Concurrent ~50 ms sampler. Peak is the max tree RSS while watch_pid lives.
+sampler_loop() {
+	root=$1
+	watch=$2
+	min_start=$3
+	out=$4
+	exclude=$(read_self_pid)
+
+	peak_rss=0
+	peak_pss=0
+	peak_hwm=0
+	peak_n=0
+
+	while kill -0 "$watch" 2>/dev/null; do
+		walk_tree "$root" "$exclude" "$min_start"
+		if [ "$TREE_RSS" -gt "$peak_rss" ]; then
+			peak_rss=$TREE_RSS
+			peak_pss=$TREE_PSS
+			peak_hwm=$TREE_HWM
+			peak_n=$TREE_NPROCS
+		fi
+		kill -0 "$watch" 2>/dev/null || break
+		wait_cs 5
+	done
+
+	if [ "$peak_n" -eq 0 ]; then
+		walk_tree "$root" "$exclude" "$min_start"
+		peak_rss=$TREE_RSS
+		peak_pss=$TREE_PSS
+		peak_hwm=$TREE_HWM
+		peak_n=$TREE_NPROCS
+	fi
+
+	printf '%s %s %s %s\n' "$peak_rss" "$peak_n" "$peak_pss" "$peak_hwm" >"$out"
+}
+
+measure_peak() {
+	case=$1
+	root_kind=$2
+	sample_i=$3
+
+	if [ "$root_kind" = fwlive ]; then
+		printf '%s' '{"addresses":["2000"]}' >"$C1_IN"
+		PATH="$shim_dir:$PATH" /usr/libexec/rpcd/fwlive call poll <"$C1_IN" >"$POLL_OUT" 2>/dev/null &
+		root=$!
+		watch=$root
+	else
+		root=$(rpcd_pid)
+		ubus call fwlive poll '{"addresses":["50"]}' >"$POLL_OUT" 2>/dev/null &
+		watch=$!
+	fi
+
+	min_start=$(read_starttime "$watch")
+	rm -f "$PEAK"
+	sampler_loop "$root" "$watch" "$min_start" "$PEAK" &
+	sampler=$!
+	wait "$watch" || echo "PROFILE_ERROR case=$case sample_i=$sample_i command_failed" >&2
+	wait "$sampler" || true
+
+	peak_rss=0
+	peak_n=0
+	peak_pss=0
+	peak_hwm=0
+	[ -s "$PEAK" ] && read peak_rss peak_n peak_pss peak_hwm <"$PEAK" || true
+	lines=$(count_log_lines "$POLL_OUT")
+
+	emit "case=$case" "root=$root_kind" metric=peak_rss_kb "value=$peak_rss" "nprocs=$peak_n" "sample_i=$sample_i" "lines=$lines"
+	if [ "$HAS_PSS" = 1 ]; then
+		emit "case=$case" "root=$root_kind" metric=pss_kb "value=$peak_pss" "nprocs=$peak_n" "sample_i=$sample_i"
+	fi
+	emit "case=$case" "root=$root_kind" metric=hwm_kb "value=$peak_hwm" "sample_i=$sample_i"
+}
+
+setup_c1_shim() {
+	shim_dir=/tmp/fwlive-mem-shims
+	rm -rf "$shim_dir"
+	mkdir "$shim_dir"
+	cat >"$shim_dir/wrap" <<'WRAP'
+#!/bin/sh
+name=${0##*/}
+case "$name" in
+  cat) real=/bin/cat ;;
+  jsonfilter) real=/usr/bin/jsonfilter ;;
+  awk) real=/usr/bin/awk ;;
+  dirname) real=/usr/bin/dirname ;;
+  sed) real=/bin/sed ;;
+  jshn) real=/usr/bin/jshn ;;
+  ubus)
+    if [ "$1" = call ] && [ "$2" = log ] && [ "$3" = read ]; then
+      exec /bin/cat /tmp/fwlive-logread-2000.json
+    fi
+    real=/bin/ubus ;;
+  *) exit 127 ;;
+esac
+exec "$real" "$@"
+WRAP
+	chmod +x "$shim_dir/wrap"
+	for command in cat jsonfilter awk dirname sed jshn ubus; do
+		ln -s wrap "$shim_dir/$command"
+	done
+}
+
+if probe_pss; then
+	HAS_PSS=1
+	primitive=pss
+else
+	primitive=vmrss
+fi
+
+mem_kb=$(sed -n 's/^MemTotal:[[:space:]]*\([0-9]*\).*/\1/p' /proc/meminfo)
+mem_mib=$((${mem_kb:-0} / 1024))
+smp=$(grep -c '^processor' /proc/cpuinfo 2>/dev/null || true)
+[ -n "$smp" ] && [ "$smp" -gt 0 ] || smp=1
+
+echo "PROFILE_META release=$(sed -n 's/^DISTRIB_RELEASE=//p' /etc/openwrt_release)"
+echo "PROFILE_META revision=$(sed -n 's/^DISTRIB_REVISION=//p' /etc/openwrt_release)"
+echo "PROFILE_META arch=$(uname -m) busybox=$(opkg status busybox 2>/dev/null | sed -n 's/^Version: //p')"
+echo "PROFILE_META mem_mib=$mem_mib smp=$smp"
+echo "PROFILE_META fixture=$(wc -c <"$fixture" | tr -d ' ')_bytes"
+echo "PROFILE_META primitive=$primitive"
+echo "PROFILE_META run_id=$run_id"
+echo "PROFILE_META lines_c2=50 lines_c1=2000"
+
+# --- idle ---
+emit_idle_metrics idle
+emit_logd idle
+
+# --- nofork: 60s idle, zero polls; Z is sized from this delta later ---
+emit_idle_metrics nofork sample_i=0
+t0=$TREE_RSS
+echo "waiting 60s (nofork)" >&2
+sleep 60
+emit_idle_metrics nofork sample_i=1
+emit "case=nofork" root=rpcd metric=delta_rss_kb "value=$((TREE_RSS - t0))"
+
+# --- C2: live ubus poll, root=rpcd, n=5 ---
+i=1
+while [ "$i" -le 5 ]; do
+	measure_peak c2_live rpcd "$i"
+	i=$((i + 1))
+done
+
+# --- retention: T0 idle → 10× C2 polls → 60s idle → T1 ---
+emit_idle_metrics retention sample_i=0
+t0=$TREE_RSS
+j=1
+while [ "$j" -le 10 ]; do
+	ubus call fwlive poll '{"addresses":["50"]}' >/dev/null 2>&1 || \
+		echo "PROFILE_ERROR case=retention poll=$j command_failed" >&2
+	j=$((j + 1))
+done
+echo "waiting 60s (retention)" >&2
+sleep 60
+emit_idle_metrics retention sample_i=1
+emit "case=retention" root=rpcd metric=delta_rss_kb "value=$((TREE_RSS - t0))"
+emit_logd retention
+
+# --- C1 last: PATH-shim direct plugin, fixture-backed log read, root=fwlive ---
+setup_c1_shim
+i=1
+while [ "$i" -le 5 ]; do
+	measure_peak c1_fixture fwlive "$i"
+	i=$((i + 1))
+done
+
+echo "MEMORY_SKIP case=adaptive reason=needs_306"
+echo "MEMORY_SKIP case=visibility reason=needs_306"
+REMOTE

--- a/scripts/memory-census.sh
+++ b/scripts/memory-census.sh
@@ -42,6 +42,13 @@ else
 fi
 
 RUN_ID="${FWLIVE_PROFILE_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$RANDOM}"
+# OpenSSH joins remote argv into a shell command; keep run_id safe as $2.
+case "$RUN_ID" in
+	''|*[!A-Za-z0-9._-]*)
+		echo "invalid FWLIVE_PROFILE_RUN_ID (use [A-Za-z0-9._-]+): $RUN_ID" >&2
+		exit 1
+		;;
+esac
 
 ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- "$REMOTE_FIXTURE" "$RUN_ID" <<'REMOTE'
 set -eu
@@ -312,14 +319,8 @@ sampler_loop() {
 		wait_cs 5
 	done
 
-	if [ "$peak_n" -eq 0 ]; then
-		walk_tree "$root" "$exclude" "$min_start"
-		peak_rss=$TREE_RSS
-		peak_pss=$TREE_PSS
-		peak_hwm=$TREE_HWM
-		peak_n=$TREE_NPROCS
-	fi
-
+	# No post-exit fallback: a zero-sample peak is invalid (poll finished
+	# before the concurrent sampler recorded an in-flight tree).
 	printf '%s %s %s %s\n' "$peak_rss" "$peak_n" "$peak_pss" "$peak_hwm" >"$out"
 }
 
@@ -339,7 +340,29 @@ measure_peak() {
 		watch=$!
 	fi
 
-	min_start=$(read_starttime "$watch")
+	# Capture starttime while watch still lives; never fall back to min_start=0
+	# (that would count all pre-existing rpcd descendants as poll peak).
+	min_start=
+	i=0
+	while [ "$i" -lt 20 ]; do
+		if kill -0 "$watch" 2>/dev/null; then
+			st=$(read_starttime "$watch")
+			if [ -n "$st" ] && [ "$st" -gt 0 ] 2>/dev/null; then
+				min_start=$st
+				break
+			fi
+		else
+			break
+		fi
+		i=$((i + 1))
+	done
+	if [ -z "$min_start" ]; then
+		wait "$watch" 2>/dev/null || true
+		echo "PROFILE_ERROR case=$case sample_i=$sample_i reason=starttime_unreadable" >&2
+		emit "case=$case" "root=$root_kind" metric=peak_rss_kb value=invalid "sample_i=$sample_i"
+		return 0
+	fi
+
 	rm -f "$PEAK"
 	sampler_loop "$root" "$watch" "$min_start" "$PEAK" &
 	sampler=$!
@@ -352,6 +375,12 @@ measure_peak() {
 	peak_hwm=0
 	[ -s "$PEAK" ] && read peak_rss peak_n peak_pss peak_hwm <"$PEAK" || true
 	lines=$(count_log_lines "$POLL_OUT")
+
+	if [ "$peak_n" -eq 0 ]; then
+		echo "PROFILE_ERROR case=$case sample_i=$sample_i reason=no_in_flight_sample" >&2
+		emit "case=$case" "root=$root_kind" metric=peak_rss_kb value=invalid "sample_i=$sample_i" "lines=$lines"
+		return 0
+	fi
 
 	emit "case=$case" "root=$root_kind" metric=peak_rss_kb "value=$peak_rss" "nprocs=$peak_n" "sample_i=$sample_i" "lines=$lines"
 	if [ "$HAS_PSS" = 1 ]; then
@@ -428,6 +457,10 @@ while [ "$i" -le 5 ]; do
 	measure_peak c2_live rpcd "$i"
 	i=$((i + 1))
 done
+
+# Settle so retention T0 is true idle, not post-C2 residual RSS/descendants.
+echo "waiting 10s (settle before retention T0)" >&2
+sleep 10
 
 # --- retention: T0 idle → 10× C2 polls → 60s idle → T1 ---
 emit_idle_metrics retention sample_i=0

--- a/scripts/memory-census.sh
+++ b/scripts/memory-census.sh
@@ -100,11 +100,18 @@ read_starttime() {
 read_pss() {
 	pid=$1
 	[ -r "/proc/$pid/smaps_rollup" ] || { printf '%s\n' 0; return; }
+	# Process may exit between -r and open; failed redirect must not abort (set -eu).
+	set +e
 	while read key val unit; do
 		case "$key" in
-			Pss:) printf '%s\n' "${val:-0}"; return ;;
+			Pss:)
+				set -e
+				printf '%s\n' "${val:-0}"
+				return
+				;;
 		esac
 	done <"/proc/$pid/smaps_rollup"
+	set -e
 	printf '%s\n' 0
 }
 
@@ -137,11 +144,16 @@ rpcd_pid() {
 
 probe_pss() {
 	[ -r /proc/self/smaps_rollup ] || return 1
+	set +e
 	while read key val unit; do
 		case "$key" in
-			Pss:) return 0 ;;
+			Pss:)
+				set -e
+				return 0
+				;;
 		esac
 	done </proc/self/smaps_rollup
+	set -e
 	return 1
 }
 
@@ -154,6 +166,8 @@ scan_proc() {
 		ppid=0
 		rss=0
 		hwm=0
+		# Race: PID can vanish after -r; skip instead of aborting under set -eu.
+		set +e
 		while read key val unit; do
 			case "$key" in
 				PPid:) ppid=${val:-0} ;;
@@ -161,6 +175,9 @@ scan_proc() {
 				VmHWM:) hwm=${val:-0} ;;
 			esac
 		done <"$status"
+		rc=$?
+		set -e
+		[ "$rc" -eq 0 ] || continue
 		printf '%s %s %s %s\n' "$pid" "$ppid" "$rss" "$hwm" >>"$DUMP"
 	done
 }
@@ -286,11 +303,15 @@ emit_logd() {
 		return
 	fi
 	rss=0
+	set +e
 	while read key val unit; do
 		case "$key" in
 			VmRSS:) rss=${val:-0}; break ;;
 		esac
 	done <"/proc/$pid/status"
+	rc=$?
+	set -e
+	[ "$rc" -eq 0 ] || rss=0
 	emit "case=$case" metric=logd_rss_kb "value=$rss"
 }
 
@@ -466,15 +487,22 @@ sleep 10
 emit_idle_metrics retention sample_i=0
 t0=$TREE_RSS
 j=1
+ret_ok=1
 while [ "$j" -le 10 ]; do
-	ubus call fwlive poll '{"addresses":["50"]}' >/dev/null 2>&1 || \
+	if ! ubus call fwlive poll '{"addresses":["50"]}' >/dev/null 2>&1; then
 		echo "PROFILE_ERROR case=retention poll=$j command_failed" >&2
+		ret_ok=0
+	fi
 	j=$((j + 1))
 done
 echo "waiting 60s (retention)" >&2
 sleep 60
 emit_idle_metrics retention sample_i=1
-emit "case=retention" root=rpcd metric=delta_rss_kb "value=$((TREE_RSS - t0))"
+if [ "$ret_ok" = 1 ]; then
+	emit "case=retention" root=rpcd metric=delta_rss_kb "value=$((TREE_RSS - t0))"
+else
+	emit "case=retention" root=rpcd metric=delta_rss_kb value=invalid
+fi
 emit_logd retention
 
 # --- C1 last: PATH-shim direct plugin, fixture-backed log read, root=fwlive ---

--- a/scripts/qemu-budget-split.sh
+++ b/scripts/qemu-budget-split.sh
@@ -31,9 +31,11 @@ else
 	ssh "${SSH_OPTS[@]}" "root@$HOST" "cat > $REMOTE_FIXTURE" <"$FIXTURE"
 fi
 
-ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- "$REMOTE_FIXTURE" <<'REMOTE'
+RUN_ID="${FWLIVE_PROFILE_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$RANDOM}"
+ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- "$REMOTE_FIXTURE" "$RUN_ID" <<'REMOTE'
 set -eu
 fixture=$1
+run_id=$2
 
 clock_cs() {
 	read uptime _ </proc/uptime
@@ -96,6 +98,7 @@ echo "PROFILE_META revision=$(sed -n 's/^DISTRIB_REVISION=//p' /etc/openwrt_rele
 echo "PROFILE_META arch=$(uname -m) busybox=$(opkg status busybox 2>/dev/null | sed -n 's/^Version: //p')"
 echo "PROFILE_META clock=/proc/uptime resolution_centiseconds"
 echo "PROFILE_META fixture=$(wc -c <"$fixture" | tr -d ' ')_bytes"
+echo "PROFILE_META run_id=$run_id"
 
 # Batches make elapsed values meaningful when a single command is below 10 ms.
 measure rpcd_parse 20 stage_rpcd_parse

--- a/scripts/qemu-budget-split.sh
+++ b/scripts/qemu-budget-split.sh
@@ -32,6 +32,13 @@ else
 fi
 
 RUN_ID="${FWLIVE_PROFILE_RUN_ID:-$(date +%Y%m%dT%H%M%S)-$RANDOM}"
+# OpenSSH joins remote argv into a shell command; keep run_id safe as $2.
+case "$RUN_ID" in
+	''|*[!A-Za-z0-9._-]*)
+		echo "invalid FWLIVE_PROFILE_RUN_ID (use [A-Za-z0-9._-]+): $RUN_ID" >&2
+		exit 1
+		;;
+esac
 ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- "$REMOTE_FIXTURE" "$RUN_ID" <<'REMOTE'
 set -eu
 fixture=$1


### PR DESCRIPTION
## Summary
- Add `scripts/memory-census.sh` for #319: guest process-tree VmRSS sampler with concurrent ~50 ms peak, C1 (`root=fwlive` PATH-shim full poll) vs C2 (`root=rpcd` ubus), idle/nofork/retention, logd context-only, `MEMORY_SKIP` for #306 degraded modes.
- Document Memory profiling contract + provisional soft budget (X=8 / Y=16 / Z TBD) and AC-4/AC-6 gate text in `docs/developer/qemu-lab.md`.
- Emit shared `PROFILE_META run_id` from memory-census and `qemu-budget-split.sh` for CPU/memory join.

## Test plan
- [x] `bash -n scripts/memory-census.sh scripts/qemu-budget-split.sh`
- [x] `./scripts/memory-census.sh --help` exits 0
- [ ] Guest run on x86 `OWRT_QEMU_MEM=128` (binding) after install
- [ ] Guest confirmation on armsr `OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256`
- [ ] Commit numeric Z from nofork Δ in a follow-up (out of this PR)

Refs #319. Housekeeping: #323 closed; #308 ACs refreshed (left open).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added memory profiling for running OpenWrt guests, including idle, peak, retention, and fixture-based measurements.
  - Added diagnostic output for profiling results, skipped cases, and errors.
  - Added run ID support for associating profiling results with individual runs.

- **Documentation**
  - Added QEMU lab guidance covering memory metrics, provisional budgets, acceptance thresholds, checklists, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->