### PR TITLE
lab(#306): adaptive flood harness + armsr C1 evidence

### DIFF
--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -359,17 +359,21 @@ FWLIVE_PROFILE_RUN_ID="flood-armsr-$(date +%Y%m%dT%H%M%S)" \
 
 `qemu-install-fwlive.sh` syncs `fwlive-adaptive-cap.sh` with the other libexec helpers.
 
-#### Binding table — armsr TCG (pending first green run)
+#### Binding table — armsr TCG PATH-shim C1 (pending first green run)
+
+Measurement path is **fixture PATH-shim** (same class as memory-census C1), not
+stock-ring logd. Induce uses the 2000-entry fixture filter (~15 s on armsr TCG);
+follow polls must honor `lines=` via the shim so delivered msgs ≤250.
 
 | field | value |
 |-------|-------|
-| substrate | `qemu-armsr-tcg` (pending) |
+| substrate | `qemu-armsr-tcg` / path=`c1_fixture_shim` (pending) |
 | SMP / MEM | `1` / `256` |
-| log UCI | pending (`FLOOD_META log_uci_key=…`) |
+| log UCI | skipped for C1 (`--raise-log` optional) |
 | run_id / git SHA | pending |
-| induce wall_ms (on) | pending — need >800 ms or `bucket=hot` |
-| follow×3 (on) | pending — `truncated:1`, `log_msgs≤250` |
-| A/B (off) | pending — `adaptive:0`, no shed cap |
+| induce (on) | pending — `state_bucket=hot` / `state_duration_ms>800` |
+| follow×3 (on) | pending — `truncated:1`, `log_msgs≤250`, `resolve disabled=load` after induce |
+| A/B (off) | pending — `adaptive:0`, `log_msgs≫250`, no shed |
 | `FLOOD_VERDICT ac_pass` | pending |
 
 Visibility-pause degraded baseline remains blocked on Layer 2.

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -341,7 +341,8 @@ this calibration.
 - [x] Idle / nofork / retention baselines + C2/C1 peak samples (n=5 peaks)
 - [x] Commit numeric Z from nofork; fill result tables
 - [x] armsr confirmation run against soft budget
-- [x] Degraded-mode baselines (adaptive cap + visibility pause) — harness: [`scripts/qemu-adaptive-flood.sh`](../../scripts/qemu-adaptive-flood.sh); binding armsr C1 table filled (`ac_pass=1`, run `flood-armsr-20260912T174001`). Visibility-pause baseline still blocked on Layer 2.
+- [x] Degraded-mode adaptive-cap baseline — harness: [`scripts/qemu-adaptive-flood.sh`](../../scripts/qemu-adaptive-flood.sh); binding armsr C1 table filled (`ac_pass=1`, run `flood-armsr-20260912T174001`)
+- [ ] Degraded-mode visibility-pause baseline — blocked on Layer 2 client backoff
 
 ### Adaptive flood evidence (#306 Layer 1)
 

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -374,6 +374,19 @@ FWLIVE_PROFILE_RUN_ID="flood-armsr-$(date +%Y%m%dT%H%M%S)" \
 
 Visibility-pause degraded baseline remains blocked on Layer 2.
 
+### Sample invocation (memory census)
+
+```sh
+# Binding: x86_64 128 MB class (lab: MEM=160 → guest MemTotal ≈ 128 MiB)
+OWRT_RELEASE=24.10.8 OWRT_QEMU_MEM=160 ./scripts/run-openwrt-x86-qemu.sh
+# wait + install fwlive, then:
+OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh
+
+# Confirmation: armsr weak-device rig
+OWRT_RELEASE=24.10.8 OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256 ./scripts/run-openwrt-armsr-armv8-qemu.sh
+OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh
+```
+
 ## Further reading
 
 - [`../armvirt-armsr-testing.md`](../armvirt-armsr-testing.md)

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -347,12 +347,13 @@ this calibration.
 
 Harness (host → guest SSH):
 
-```sh
+```bash
 OWRT_RELEASE=24.10.8 OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256 \
   ./scripts/run-openwrt-armsr-armv8-qemu.sh
 ./scripts/qemu-wait-guest.sh
 OWRT_FWLIVE_VERSION=24.10.8 OWRT_FWLIVE_ARCH=aarch64_generic \
   ./scripts/qemu-install-fwlive.sh
+set -o pipefail
 FWLIVE_PROFILE_RUN_ID="flood-armsr-$(date +%Y%m%dT%H%M%S)" \
   OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh | tee lab/flood-armsr-latest.txt
 ```

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -341,7 +341,7 @@ this calibration.
 - [x] Idle / nofork / retention baselines + C2/C1 peak samples (n=5 peaks)
 - [x] Commit numeric Z from nofork; fill result tables
 - [x] armsr confirmation run against soft budget
-- [ ] Degraded-mode baselines (adaptive cap + visibility pause) — harness: [`scripts/qemu-adaptive-flood.sh`](../../scripts/qemu-adaptive-flood.sh); binding armsr table **pending** (PR evidence fill)
+- [x] Degraded-mode baselines (adaptive cap + visibility pause) — harness: [`scripts/qemu-adaptive-flood.sh`](../../scripts/qemu-adaptive-flood.sh); binding armsr C1 table filled (`ac_pass=1`, run `flood-armsr-20260912T174001`). Visibility-pause baseline still blocked on Layer 2.
 
 ### Adaptive flood evidence (#306 Layer 1)
 
@@ -360,22 +360,27 @@ FWLIVE_PROFILE_RUN_ID="flood-armsr-$(date +%Y%m%dT%H%M%S)" \
 
 `qemu-install-fwlive.sh` syncs `fwlive-adaptive-cap.sh` with the other libexec helpers.
 
-#### Binding table — armsr TCG PATH-shim C1 (pending first green run)
+#### Binding table — armsr TCG PATH-shim C1
 
 Measurement path is **fixture PATH-shim** (same class as memory-census C1), not
-stock-ring logd. Induce uses the 2000-entry fixture filter (~15 s on armsr TCG);
-follow polls must honor `lines=` via the shim so delivered msgs ≤250.
+stock-ring logd. Induce uses the 2000-entry fixture filter (~37 s on armsr TCG);
+follow polls honor `lines=` via the shim so delivered msgs ≤250.
+
+Run: `flood-armsr-20260912T174001` · git `a4d0b2f` · 2026-09-12 · BusyBox 1.36.1-r3
 
 | field | value |
 |-------|-------|
-| substrate | `qemu-armsr-tcg` / path=`c1_fixture_shim` (pending) |
-| SMP / MEM | `1` / `256` |
+| substrate | `qemu-armsr-tcg` / path=`c1_fixture_shim` |
+| SMP / MEM | `1` / `256` (guest `nproc=1`, `memtotal_kb=238556`) |
+| OpenWrt | 24.10.8 `r29233-443ec4032a` |
 | log UCI | skipped for C1 (`--raise-log` optional) |
-| run_id / git SHA | pending |
-| induce (on) | pending — `state_bucket=hot` / `state_duration_ms>800` |
-| follow×3 (on) | pending — `truncated:1`, `log_msgs≤250`, `resolve disabled=load` after induce |
-| A/B (off) | pending — `adaptive:0`, `log_msgs≫250`, no shed |
-| `FLOOD_VERDICT ac_pass` | pending |
+| induce (on) | `state_bucket=hot`, `state_duration_ms=36630`, wall 37030 ms, 1143 msgs |
+| resolve (on) | `disabled=load` immediately after induce |
+| follow×3 (on) | `truncated:1`, `shed.limit=250`, **143** msgs each; wall ~5410–5640 ms |
+| A/B (off) | `adaptive:0`, no shed; **1143** msgs; follow wall ~36100–36670 ms |
+| `FLOOD_VERDICT ac_pass` | **1** (`on_induce_hot` ∧ `on_follow` ∧ `on_resolve` ∧ `off_follow`) |
+
+**Interpretation (Grok):** outcome row “on sheds ≤250; off stays large / slower” → next #306 slice is **Layer 2** (client surfacing + backoff), not threshold calibration and not fork-budget-first. Caveat: follow stays hot (~5 s > 800 ms) so cooldown / upward re-probe is not demonstrated on this substrate.
 
 Visibility-pause degraded baseline remains blocked on Layer 2.
 

--- a/docs/developer/qemu-lab.md
+++ b/docs/developer/qemu-lab.md
@@ -341,20 +341,38 @@ this calibration.
 - [x] Idle / nofork / retention baselines + C2/C1 peak samples (n=5 peaks)
 - [x] Commit numeric Z from nofork; fill result tables
 - [x] armsr confirmation run against soft budget
-- [ ] Degraded-mode baselines (adaptive cap + visibility pause) — **blocked on #306**
+- [ ] Degraded-mode baselines (adaptive cap + visibility pause) — harness: [`scripts/qemu-adaptive-flood.sh`](../../scripts/qemu-adaptive-flood.sh); binding armsr table **pending** (PR evidence fill)
 
-### Sample invocation
+### Adaptive flood evidence (#306 Layer 1)
+
+Harness (host → guest SSH):
 
 ```sh
-# Binding: x86_64 128 MB class (lab: MEM=160 → guest MemTotal ≈ 128 MiB)
-OWRT_RELEASE=24.10.8 OWRT_QEMU_MEM=160 ./scripts/run-openwrt-x86-qemu.sh
-# wait + install fwlive, then:
-OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh
-
-# Confirmation: armsr weak-device rig
-OWRT_RELEASE=24.10.8 OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256 ./scripts/run-openwrt-armsr-armv8-qemu.sh
-OPENWRT_SSH_PORT=2222 ./scripts/memory-census.sh
+OWRT_RELEASE=24.10.8 OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256 \
+  ./scripts/run-openwrt-armsr-armv8-qemu.sh
+./scripts/qemu-wait-guest.sh
+OWRT_FWLIVE_VERSION=24.10.8 OWRT_FWLIVE_ARCH=aarch64_generic \
+  ./scripts/qemu-install-fwlive.sh
+FWLIVE_PROFILE_RUN_ID="flood-armsr-$(date +%Y%m%dT%H%M%S)" \
+  OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh | tee lab/flood-armsr-latest.txt
 ```
+
+`qemu-install-fwlive.sh` syncs `fwlive-adaptive-cap.sh` with the other libexec helpers.
+
+#### Binding table — armsr TCG (pending first green run)
+
+| field | value |
+|-------|-------|
+| substrate | `qemu-armsr-tcg` (pending) |
+| SMP / MEM | `1` / `256` |
+| log UCI | pending (`FLOOD_META log_uci_key=…`) |
+| run_id / git SHA | pending |
+| induce wall_ms (on) | pending — need >800 ms or `bucket=hot` |
+| follow×3 (on) | pending — `truncated:1`, `log_msgs≤250` |
+| A/B (off) | pending — `adaptive:0`, no shed cap |
+| `FLOOD_VERDICT ac_pass` | pending |
+
+Visibility-pause degraded baseline remains blocked on Layer 2.
 
 ## Further reading
 

--- a/lab/flood-armsr-latest.txt
+++ b/lab/flood-armsr-latest.txt
@@ -1,0 +1,23 @@
+Copying logread-2000.json → root@127.0.0.1:2222:/tmp/fwlive-logread-2000.json
+FLOOD_META run_id=flood-armsr-20260912T174001 git_sha=a4d0b2f arch=aarch64 path=c1_fixture_shim
+FLOOD_META release='24.10.8' revision='r29233-443ec4032a'
+FLOOD_META nproc=1 memtotal_kb=238556
+FLOOD_META fixture_bytes=224365 requested=2000 follow_n=3 hot_ms=800 max_served=250
+FLOOD_META busybox=1.36.1-r3
+FLOOD_META log_uci=skipped path=c1_fixture_shim
+FLOOD_META fixture_entries=2000
+FLOOD_POLL phase=induce mode=on wall_ms=37030 adaptive=1 truncated=0 shed=0 shed_limit=0 log_msgs=1143 state_bucket=hot state_duration_ms=36630
+FLOOD_INDUCE mode=on wall_ms=37030 state_duration_ms=36630 state_bucket=hot hot_ok=1
+FLOOD_RESOLVE mode=on disabled=load
+FLOOD_POLL phase=follow1 mode=on wall_ms=5410 adaptive=1 truncated=1 shed=1 shed_limit=250 log_msgs=143 state_bucket=hot state_duration_ms=4910
+FLOOD_POLL phase=follow2 mode=on wall_ms=5640 adaptive=1 truncated=1 shed=1 shed_limit=250 log_msgs=143 state_bucket=hot state_duration_ms=5130
+FLOOD_POLL phase=follow3 mode=on wall_ms=5560 adaptive=1 truncated=1 shed=1 shed_limit=250 log_msgs=143 state_bucket=hot state_duration_ms=5090
+FLOOD_MODE_RESULT mode=on follow_pass=1 induce_hot_ok=1 resolve_pass=1
+FLOOD_POLL phase=induce mode=off wall_ms=36810 adaptive=0 truncated=0 shed=0 shed_limit=0 log_msgs=1143 state_bucket=none state_duration_ms=0
+FLOOD_INDUCE mode=off wall_ms=36810
+FLOOD_POLL phase=follow1 mode=off wall_ms=36240 adaptive=0 truncated=0 shed=0 shed_limit=0 log_msgs=1143 state_bucket=none state_duration_ms=0
+FLOOD_POLL phase=follow2 mode=off wall_ms=36100 adaptive=0 truncated=0 shed=0 shed_limit=0 log_msgs=1143 state_bucket=none state_duration_ms=0
+FLOOD_POLL phase=follow3 mode=off wall_ms=36670 adaptive=0 truncated=0 shed=0 shed_limit=0 log_msgs=1143 state_bucket=none state_duration_ms=0
+FLOOD_MODE_RESULT mode=off follow_pass=1 induce_hot_ok=0 resolve_pass=0
+FLOOD_VERDICT ac_pass=1 on_induce_hot=1 on_follow_pass=1 on_resolve_pass=1 off_follow_pass=1
+FLOOD_DONE run_id=flood-armsr-20260912T174001

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -4,15 +4,20 @@
 #
 # QEMU guest flood evidence for #306 Layer 1 adaptive shedding.
 #
-# Binding AC (armsr): OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256, raised log ring,
-# one flood poll >800 ms, next 3 polls truncated:1 and ≤250 lines; A/B with
-# /var/run/fwlive-adaptive-off.
+# Measurement path: PATH-shim C1 (fixture-backed log.read), same class as
+# memory-census C1 / budget-split fixture filter — not stock-ring logd.
+# Adaptive measures processing duration; the 2000-entry fixture filter is the
+# reliable way to exceed the hot threshold on armsr TCG.
+#
+# Binding AC (armsr): OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256; induce hot; next 3
+# polls truncated:1 and ≤250 delivered msgs; A/B with /var/run/fwlive-adaptive-off.
 #
 # Usage (guest already running + fwlive installed):
 #   OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh
-#   OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh --skip-raise-log
+#   OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh --raise-log
 #
-# Emits FLOOD_* lines for CI grepping / table fill.
+# Emits FLOOD_* lines. Host exits non-zero unless FLOOD_VERDICT ac_pass=1
+# (override with FWLIVE_FLOOD_STRICT=0).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -22,20 +27,23 @@ FIXTURE="${FWLIVE_FLOOD_FIXTURE:-${ROOT}/tests/fixtures/logread-2000.json}"
 REMOTE_FIXTURE=/tmp/fwlive-logread-2000.json
 KNOWN_HOSTS="${FWLIVE_KNOWN_HOSTS:-${ROOT}/lab/qemu-known_hosts}"
 LOG_SIZE_KIB="${FWLIVE_FLOOD_LOG_SIZE_KIB:-1024}"
-SKIP_RAISE_LOG=0
+# C1 fixture path does not need a raised ring; optional for rig documentation.
+RAISE_LOG=0
 REQUESTED_LINES="${FWLIVE_FLOOD_LINES:-2000}"
 FOLLOW_POLLS="${FWLIVE_FLOOD_FOLLOW_POLLS:-3}"
 HOT_MS="${FWLIVE_FLOOD_HOT_MS:-800}"
 MAX_SERVED="${FWLIVE_FLOOD_MAX_SERVED:-250}"
+STRICT="${FWLIVE_FLOOD_STRICT:-1}"
 
 usage() {
-	sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
 	exit "${1:-0}"
 }
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--skip-raise-log) SKIP_RAISE_LOG=1; shift ;;
+		--raise-log) RAISE_LOG=1; shift ;;
+		--skip-raise-log) RAISE_LOG=0; shift ;;
 		--fixture) FIXTURE="${2:?}"; shift 2 ;;
 		--log-size) LOG_SIZE_KIB="${2:?}"; shift 2 ;;
 		-h|--help) usage 0 ;;
@@ -74,21 +82,24 @@ else
 	ssh "${SSH_OPTS[@]}" "root@$HOST" "cat > $REMOTE_FIXTURE" <"$FIXTURE"
 fi
 
-# Ensure adaptive helper is present (source-sync installs historically omitted it).
 if ! ssh "${SSH_OPTS[@]}" "root@$HOST" 'test -f /usr/libexec/fwlive-adaptive-cap.sh'; then
 	echo "FLOOD_ERROR reason=adaptive_helper_missing hint=run_qemu-install-fwlive.sh" >&2
 	exit 1
 fi
 
+OUT_FILE="$(mktemp)"
+trap 'rm -f "$OUT_FILE"' EXIT
+
 ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- \
-	"$REMOTE_FIXTURE" "$RUN_ID" "$GIT_SHA" "$LOG_SIZE_KIB" "$SKIP_RAISE_LOG" \
-	"$REQUESTED_LINES" "$FOLLOW_POLLS" "$HOT_MS" "$MAX_SERVED" <<'REMOTE'
+	"$REMOTE_FIXTURE" "$RUN_ID" "$GIT_SHA" "$LOG_SIZE_KIB" "$RAISE_LOG" \
+	"$REQUESTED_LINES" "$FOLLOW_POLLS" "$HOT_MS" "$MAX_SERVED" \
+	<<'REMOTE' | tee "$OUT_FILE"
 set -eu
 fixture=$1
 run_id=$2
 git_sha=$3
 log_size_kib=$4
-skip_raise=$5
+raise_log=$5
 requested=$6
 follow_n=$7
 hot_ms=$8
@@ -98,49 +109,43 @@ STATE=/var/run/fwlive-state.json
 OFF=/var/run/fwlive-adaptive-off
 POLL_OUT=/tmp/fwlive-flood-poll.json
 SHIM_DIR=/tmp/fwlive-flood-shims
+ENTRIES=/tmp/fwlive-flood-entries.txt
 
+# Match product fwlive_adaptive_clock_cs (no octal; two frac digits).
 clock_cs() {
-	read uptime _ </proc/uptime
-	seconds=${uptime%.*}
-	fraction=${uptime#*.}
-	fraction=${fraction#0}
-	[ -n "$fraction" ] || fraction=0
-	# Avoid octal: strip leading zeros digit-wise for BusyBox ash.
-	_s=$seconds
-	_n=0
-	while [ -n "$_s" ]; do
-		_d=${_s%"${_s#?}"}
-		_s=${_s#?}
-		case "$_d" in [0-9]) _n=$((_n * 10 + _d)) ;; esac
-	done
-	_f=$fraction
-	_m=0
-	while [ -n "$_f" ]; do
-		_d=${_f%"${_f#?}"}
-		_f=${_f#?}
-		case "$_d" in [0-9]) _m=$((_m * 10 + _d)) ;; esac
-	done
-	# At most two frac digits.
-	case "$fraction" in
-		?) _m=$((_m * 10)) ;;
+	_up=
+	read -r _up _ </proc/uptime 2>/dev/null || { printf '%s\n' 0; return 0; }
+	_sec=${_up%.*}
+	_frac=${_up#*.}
+	[ "$_frac" = "$_up" ] && _frac=0
+	case "$_frac" in
+		'') _frac=0 ;;
+		?) _frac="${_frac}0" ;;
 		??) ;;
 		*)
-			_m=0
-			_f=$fraction
-			_i=0
-			while [ "$_i" -lt 2 ] && [ -n "$_f" ]; do
-				_d=${_f%"${_f#?}"}
-				_f=${_f#?}
-				case "$_d" in [0-9]) _m=$((_m * 10 + _d)) ;; esac
-				_i=$((_i + 1))
-			done
+			_a=${_frac%${_frac#?}}
+			_r=${_frac#?}
+			_b=${_r%${_r#?}}
+			_frac="${_a}${_b}"
 			;;
 	esac
-	printf '%s\n' $((_n * 100 + _m))
+	_atoi() {
+		_s=$1
+		_n=0
+		case "$_s" in ''|*[!0-9]*) printf '0'; return ;; esac
+		while [ -n "$_s" ]; do
+			_d=${_s%"${_s#?}"}
+			_s=${_s#?}
+			_n=$((_n * 10 + _d))
+		done
+		printf '%s' "$_n"
+	}
+	_sec=$(_atoi "$_sec")
+	_frac=$(_atoi "$_frac")
+	printf '%s\n' $((_sec * 100 + _frac))
 }
 
 json_int() {
-	# Extract first "key":N from one-line JSON (busybox-safe).
 	_blob=$1
 	_key=$2
 	_def=$3
@@ -166,7 +171,14 @@ json_int() {
 }
 
 count_log_msgs() {
+	# Prefer jsonfilter when present (off product hot path).
 	_json=$1
+	if command -v jsonfilter >/dev/null 2>&1; then
+		_n=$(printf '%s' "$_json" | jsonfilter -e '@.log[*]' 2>/dev/null | wc -l | tr -d ' \n')
+		case "$_n" in ''|*[!0-9]*) _n=0 ;; esac
+		printf '%s\n' "$_n"
+		return 0
+	fi
 	_n=0
 	_rest=$_json
 	while :; do
@@ -181,13 +193,59 @@ count_log_msgs() {
 	printf '%s\n' "$_n"
 }
 
+# Pre-split fixture entries once (one jsonfilter pass).
+prepare_entries() {
+	if command -v jsonfilter >/dev/null 2>&1; then
+		jsonfilter -i "$fixture" -e '@.log[*]' >"$ENTRIES" 2>/dev/null || : >"$ENTRIES"
+	else
+		: >"$ENTRIES"
+	fi
+	printf 'FLOOD_META fixture_entries=%s\n' "$(wc -l <"$ENTRIES" | tr -d ' ')"
+}
+
 setup_shim() {
 	rm -rf "$SHIM_DIR"
 	mkdir -p "$SHIM_DIR"
+	# Honor lines= from ubus JSON arg (Bugbot/Luna/Grok P1).
 	cat >"$SHIM_DIR/ubus" <<'UBUS'
 #!/bin/sh
 if [ "$1" = call ] && [ "$2" = log ] && [ "$3" = read ]; then
-	exec /bin/cat /tmp/fwlive-logread-2000.json
+	arg=${4:-}
+	lines=2000
+	case "$arg" in
+		*\"lines\":*)
+			rest=${arg#*\"lines\":}
+			while case "$rest" in ' '*) true;; *) false;; esac; do
+				rest=${rest# }
+			done
+			num=
+			while :; do
+				case "$rest" in '') break ;; esac
+				c=${rest%"${rest#?}"}
+				case "$c" in
+					[0-9]) num="${num}${c}"; rest=${rest#?} ;;
+					*) break ;;
+				esac
+			done
+			case "$num" in ''|*[!0-9]*) ;; *) lines=$num ;; esac
+			;;
+	esac
+	entries=/tmp/fwlive-flood-entries.txt
+	out=/tmp/fwlive-flood-shim-out.json
+	{
+		printf '{"log":['
+		i=0
+		first=1
+		while IFS= read -r ent; do
+			[ "$i" -ge "$lines" ] && break
+			[ "$first" = 1 ] || printf ','
+			first=0
+			printf '%s' "$ent"
+			i=$((i + 1))
+		done <"$entries"
+		printf ']}'
+	} >"$out"
+	exec /bin/cat "$out"
 fi
 exec /bin/ubus "$@"
 UBUS
@@ -195,15 +253,16 @@ UBUS
 }
 
 raise_log_ring() {
-	[ "$skip_raise" = 1 ] && return 0
-	# Prefer log_size (documented); fall back to log_buffer_size if present.
+	[ "$raise_log" = 1 ] || {
+		printf 'FLOOD_META log_uci=skipped path=c1_fixture_shim\n'
+		return 0
+	}
 	key=
 	if uci -q get system.@system[0].log_size >/dev/null 2>&1; then
 		key=log_size
 	elif uci -q get system.@system[0].log_buffer_size >/dev/null 2>&1; then
 		key=log_buffer_size
 	else
-		# Create log_size on anonymous system section.
 		key=log_size
 	fi
 	uci set "system.@system[0].${key}=${log_size_kib}"
@@ -234,16 +293,16 @@ poll_once() {
 	[ "$elapsed_cs" -lt 0 ] && elapsed_cs=0
 	wall_ms=$((elapsed_cs * 10))
 	raw=
-	IFS= read -r raw <"$POLL_OUT" || raw=
-	adaptive=$(json_int "$raw" adaptive 0)
-	truncated=$(json_int "$raw" truncated 0)
-	msgs=$(count_log_msgs "$raw")
-	# shed.limit if present
-	shed_limit=$(json_int "$raw" limit 0)
-	case "$raw" in
-		*'"shed"'*) shed=1 ;;
-		*) shed=0 ;;
-	esac
+	# Reply may be large — avoid stuffing into ash vars when possible.
+	adaptive=$(jsonfilter -i "$POLL_OUT" -e '@.adaptive' 2>/dev/null || echo 0)
+	truncated=$(jsonfilter -i "$POLL_OUT" -e '@.truncated' 2>/dev/null || echo 0)
+	case "$truncated" in ''|*[!0-9]*) truncated=0 ;; esac
+	case "$adaptive" in ''|*[!0-9]*) adaptive=0 ;; esac
+	msgs=$(count_log_msgs "$(cat "$POLL_OUT")")
+	shed_limit=$(jsonfilter -i "$POLL_OUT" -e '@.shed.limit' 2>/dev/null || echo 0)
+	case "$shed_limit" in ''|*[!0-9]*) shed_limit=0 ;; esac
+	shed=0
+	jsonfilter -i "$POLL_OUT" -e '@.shed' >/dev/null 2>&1 && shed=1
 	state_bucket=none
 	state_dur=0
 	if [ -f "$STATE" ]; then
@@ -255,24 +314,27 @@ poll_once() {
 	fi
 	printf 'FLOOD_POLL phase=%s mode=%s wall_ms=%s adaptive=%s truncated=%s shed=%s shed_limit=%s log_msgs=%s state_bucket=%s state_duration_ms=%s\n' \
 		"$label" "$mode" "$wall_ms" "$adaptive" "$truncated" "$shed" "$shed_limit" "$msgs" "$state_bucket" "$state_dur"
-	# Export for caller via files
 	printf '%s\n' "$wall_ms" >/tmp/fwlive-flood-last-wall
 	printf '%s\n' "$truncated" >/tmp/fwlive-flood-last-trunc
 	printf '%s\n' "$msgs" >/tmp/fwlive-flood-last-msgs
 	printf '%s\n' "$adaptive" >/tmp/fwlive-flood-last-adapt
 	printf '%s\n' "$state_bucket" >/tmp/fwlive-flood-last-bucket
 	printf '%s\n' "$shed" >/tmp/fwlive-flood-last-shed
+	printf '%s\n' "$shed_limit" >/tmp/fwlive-flood-last-shed-limit
+	printf '%s\n' "$state_dur" >/tmp/fwlive-flood-last-state-dur
 }
 
 resolve_check() {
 	mode=$1
 	out=$(ubus call fwlive resolve '{"addresses":["192.0.2.1"]}' 2>/dev/null || echo '{}')
 	case "$out" in
-		*'"disabled":"load"'*|*'\"disabled\":\"load\"'*)
+		*'"disabled":"load"'*)
 			printf 'FLOOD_RESOLVE mode=%s disabled=load\n' "$mode"
+			printf '1\n' >/tmp/fwlive-flood-last-resolve
 			;;
 		*)
-			printf 'FLOOD_RESOLVE mode=%s disabled=none raw=%s\n' "$mode" "$(printf '%s' "$out" | tr '\n' ' ')"
+			printf 'FLOOD_RESOLVE mode=%s disabled=none\n' "$mode"
+			printf '0\n' >/tmp/fwlive-flood-last-resolve
 			;;
 	esac
 }
@@ -286,21 +348,28 @@ run_mode() {
 		rm -f "$OFF"
 	fi
 
-	# Induce: first poll at full request (fixture-backed via PATH-shim).
 	poll_once induce "$mode" || return 1
-	wall=$(cat /tmp/fwlive-flood-last-wall)
 	bucket=$(cat /tmp/fwlive-flood-last-bucket)
-	shed=$(cat /tmp/fwlive-flood-last-shed)
+	state_dur=$(cat /tmp/fwlive-flood-last-state-dur)
+	wall=$(cat /tmp/fwlive-flood-last-wall)
 
 	hot_ok=0
 	if [ "$mode" = on ]; then
-		if [ "$wall" -gt "$hot_ms" ] || [ "$bucket" = hot ] || [ "$shed" = 1 ]; then
+		# Gate on product state after induce record — not harness wall (Grok P2).
+		if [ "$bucket" = hot ] || [ "$state_dur" -gt "$hot_ms" ]; then
 			hot_ok=1
 		fi
-		printf 'FLOOD_INDUCE mode=on wall_ms=%s hot_threshold_ms=%s hot_ok=%s\n' \
-			"$wall" "$hot_ms" "$hot_ok"
+		printf 'FLOOD_INDUCE mode=on wall_ms=%s state_duration_ms=%s state_bucket=%s hot_ok=%s\n' \
+			"$wall" "$state_dur" "$bucket" "$hot_ok"
+		if [ "$hot_ok" = 1 ]; then
+			resolve_check on
+		else
+			printf '0\n' >/tmp/fwlive-flood-last-resolve
+			printf 'FLOOD_RESOLVE mode=on skipped=induce_not_hot\n'
+		fi
 	else
-		printf 'FLOOD_INDUCE mode=off wall_ms=%s (no shed expected)\n' "$wall"
+		printf 'FLOOD_INDUCE mode=off wall_ms=%s\n' "$wall"
+		printf '0\n' >/tmp/fwlive-flood-last-resolve
 	fi
 
 	i=1
@@ -310,6 +379,8 @@ run_mode() {
 		trunc=$(cat /tmp/fwlive-flood-last-trunc)
 		msgs=$(cat /tmp/fwlive-flood-last-msgs)
 		adapt=$(cat /tmp/fwlive-flood-last-adapt)
+		shed=$(cat /tmp/fwlive-flood-last-shed)
+		slimit=$(cat /tmp/fwlive-flood-last-shed-limit)
 		if [ "$mode" = on ]; then
 			if [ "$trunc" != 1 ] || [ "$msgs" -gt "$max_served" ]; then
 				pass_follow=0
@@ -317,29 +388,35 @@ run_mode() {
 			if [ "$adapt" != 1 ]; then
 				pass_follow=0
 			fi
+			# When shed is present, limit must be the hot floor.
+			if [ "$shed" = 1 ] && [ "$slimit" -gt 0 ] && [ "$slimit" -gt "$max_served" ]; then
+				pass_follow=0
+			fi
 		else
-			# Off: no truncation from adaptive; may still be filter-sized.
 			if [ "$adapt" != 0 ]; then
+				pass_follow=0
+			fi
+			if [ "$shed" = 1 ]; then
+				pass_follow=0
+			fi
+			# Off: still full fixture-scale payload (firewall msgs >> max_served).
+			if [ "$msgs" -le "$max_served" ]; then
 				pass_follow=0
 			fi
 		fi
 		i=$((i + 1))
 	done
 
-	if [ "$mode" = on ] && [ "$hot_ok" = 1 ]; then
-		resolve_check on
-	elif [ "$mode" = on ]; then
-		printf 'FLOOD_RESOLVE mode=on skipped=induce_not_hot\n'
-	fi
-
-	printf 'FLOOD_MODE_RESULT mode=%s follow_pass=%s induce_hot_ok=%s\n' \
-		"$mode" "$pass_follow" "${hot_ok:-0}"
+	resolve_pass=$(cat /tmp/fwlive-flood-last-resolve 2>/dev/null || echo 0)
+	printf 'FLOOD_MODE_RESULT mode=%s follow_pass=%s induce_hot_ok=%s resolve_pass=%s\n' \
+		"$mode" "$pass_follow" "${hot_ok:-0}" "$resolve_pass"
 	printf '%s\n' "$pass_follow" >"/tmp/fwlive-flood-verdict-${mode}-follow"
 	printf '%s\n' "${hot_ok:-0}" >"/tmp/fwlive-flood-verdict-${mode}-hot"
+	printf '%s\n' "$resolve_pass" >"/tmp/fwlive-flood-verdict-${mode}-resolve"
 }
 
-# --- meta ---
-printf 'FLOOD_META run_id=%s git_sha=%s arch=%s\n' "$run_id" "$git_sha" "$(uname -m)"
+printf 'FLOOD_META run_id=%s git_sha=%s arch=%s path=c1_fixture_shim\n' \
+	"$run_id" "$git_sha" "$(uname -m)"
 printf 'FLOOD_META release=%s revision=%s\n' \
 	"$(sed -n 's/^DISTRIB_RELEASE=//p' /etc/openwrt_release)" \
 	"$(sed -n 's/^DISTRIB_REVISION=//p' /etc/openwrt_release)"
@@ -352,25 +429,31 @@ printf 'FLOOD_META busybox=%s\n' \
 	"$(opkg status busybox 2>/dev/null | sed -n 's/^Version: //p' || echo unknown)"
 
 raise_log_ring
+prepare_entries
 
 run_mode on
 run_mode off
 
+# Leave adaptive enabled for any follow-up UI work on the guest.
+rm -f "$OFF"
+
 on_hot=$(cat /tmp/fwlive-flood-verdict-on-hot 2>/dev/null || echo 0)
 on_follow=$(cat /tmp/fwlive-flood-verdict-on-follow 2>/dev/null || echo 0)
+on_resolve=$(cat /tmp/fwlive-flood-verdict-on-resolve 2>/dev/null || echo 0)
 off_follow=$(cat /tmp/fwlive-flood-verdict-off-follow 2>/dev/null || echo 0)
 
 ac_pass=0
-if [ "$on_hot" = 1 ] && [ "$on_follow" = 1 ] && [ "$off_follow" = 1 ]; then
+if [ "$on_hot" = 1 ] && [ "$on_follow" = 1 ] && [ "$on_resolve" = 1 ] && [ "$off_follow" = 1 ]; then
 	ac_pass=1
 fi
-printf 'FLOOD_VERDICT ac_pass=%s on_induce_hot=%s on_follow_pass=%s off_follow_pass=%s\n' \
-	"$ac_pass" "$on_hot" "$on_follow" "$off_follow"
+printf 'FLOOD_VERDICT ac_pass=%s on_induce_hot=%s on_follow_pass=%s on_resolve_pass=%s off_follow_pass=%s\n' \
+	"$ac_pass" "$on_hot" "$on_follow" "$on_resolve" "$off_follow"
 printf 'FLOOD_DONE run_id=%s\n' "$run_id"
 REMOTE
 
-# Host-side: fail if guest did not emit ac_pass=1 (optional strict mode).
-if [[ "${FWLIVE_FLOOD_STRICT:-0}" == 1 ]]; then
-	# Re-run would be needed to capture; instead tee is caller's job.
-	:
+if [[ "$STRICT" == 1 ]]; then
+	if ! grep -q 'FLOOD_VERDICT ac_pass=1' "$OUT_FILE"; then
+		echo "FLOOD_ERROR host: ac_pass!=1 (set FWLIVE_FLOOD_STRICT=0 to ignore)" >&2
+		exit 1
+	fi
 fi

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -49,7 +49,7 @@ if [[ "$FOLLOW_POLLS" -lt 1 ]]; then
 fi
 
 usage() {
-	sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
 	exit "${1:-0}"
 }
 
@@ -63,6 +63,28 @@ while [[ $# -gt 0 ]]; do
 		*) echo "unknown arg: $1" >&2; usage 1 ;;
 	esac
 done
+
+require_positive_int() {
+	_name=$1
+	_val=$2
+	case "$_val" in
+		''|*[!0-9]*)
+			echo "$_name must be a positive integer (got: $_val)" >&2
+			exit 1
+			;;
+	esac
+	_val=$((10#$_val))
+	if [[ "$_val" -lt 1 ]]; then
+		echo "$_name must be a positive integer (got: 0)" >&2
+		exit 1
+	fi
+	printf '%s' "$_val"
+}
+
+REQUESTED_LINES=$(require_positive_int FWLIVE_FLOOD_LINES "$REQUESTED_LINES")
+HOT_MS=$(require_positive_int FWLIVE_FLOOD_HOT_MS "$HOT_MS")
+MAX_SERVED=$(require_positive_int FWLIVE_FLOOD_MAX_SERVED "$MAX_SERVED")
+LOG_SIZE_KIB=$(require_positive_int FWLIVE_FLOOD_LOG_SIZE_KIB "$LOG_SIZE_KIB")
 
 if [[ "$FIXTURE" != /* ]]; then
 	FIXTURE="${ROOT}/${FIXTURE}"
@@ -344,7 +366,7 @@ resolve_check() {
 	# ubus may pretty-print ("disabled": "load") or compact ("disabled":"load").
 	out=$(ubus call fwlive resolve '{"addresses":["192.0.2.1"]}' 2>/dev/null || echo '{}')
 	case "$out" in
-		*'"disabled"'*'"load"'*)
+		*'"disabled"'*:*'"load"'*)
 			printf 'FLOOD_RESOLVE mode=%s disabled=load\n' "$mode"
 			printf '1\n' >/tmp/fwlive-flood-last-resolve
 			;;

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -36,11 +36,17 @@ MAX_SERVED="${FWLIVE_FLOOD_MAX_SERVED:-250}"
 STRICT="${FWLIVE_FLOOD_STRICT:-1}"
 
 case "$FOLLOW_POLLS" in
-	''|*[!0-9]*|0)
+	''|*[!0-9]*)
 		echo "FWLIVE_FLOOD_FOLLOW_POLLS must be a positive integer (got: $FOLLOW_POLLS)" >&2
 		exit 1
 		;;
 esac
+# Bash 10# avoids octal; reject 0 / 00 / 000 after normalize.
+FOLLOW_POLLS=$((10#$FOLLOW_POLLS))
+if [[ "$FOLLOW_POLLS" -lt 1 ]]; then
+	echo "FWLIVE_FLOOD_FOLLOW_POLLS must be a positive integer (got: 0)" >&2
+	exit 1
+fi
 
 usage() {
 	sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Lucas Albers <lucas.b.albers@gmail.com>
+#
+# QEMU guest flood evidence for #306 Layer 1 adaptive shedding.
+#
+# Binding AC (armsr): OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256, raised log ring,
+# one flood poll >800 ms, next 3 polls truncated:1 and ≤250 lines; A/B with
+# /var/run/fwlive-adaptive-off.
+#
+# Usage (guest already running + fwlive installed):
+#   OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh
+#   OPENWRT_SSH_PORT=2222 ./scripts/qemu-adaptive-flood.sh --skip-raise-log
+#
+# Emits FLOOD_* lines for CI grepping / table fill.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST="${OPENWRT_HOST:-127.0.0.1}"
+PORT="${OPENWRT_SSH_PORT:-2222}"
+FIXTURE="${FWLIVE_FLOOD_FIXTURE:-${ROOT}/tests/fixtures/logread-2000.json}"
+REMOTE_FIXTURE=/tmp/fwlive-logread-2000.json
+KNOWN_HOSTS="${FWLIVE_KNOWN_HOSTS:-${ROOT}/lab/qemu-known_hosts}"
+LOG_SIZE_KIB="${FWLIVE_FLOOD_LOG_SIZE_KIB:-1024}"
+SKIP_RAISE_LOG=0
+REQUESTED_LINES="${FWLIVE_FLOOD_LINES:-2000}"
+FOLLOW_POLLS="${FWLIVE_FLOOD_FOLLOW_POLLS:-3}"
+HOT_MS="${FWLIVE_FLOOD_HOT_MS:-800}"
+MAX_SERVED="${FWLIVE_FLOOD_MAX_SERVED:-250}"
+
+usage() {
+	sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+	exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--skip-raise-log) SKIP_RAISE_LOG=1; shift ;;
+		--fixture) FIXTURE="${2:?}"; shift 2 ;;
+		--log-size) LOG_SIZE_KIB="${2:?}"; shift 2 ;;
+		-h|--help) usage 0 ;;
+		*) echo "unknown arg: $1" >&2; usage 1 ;;
+	esac
+done
+
+if [[ "$FIXTURE" != /* ]]; then
+	FIXTURE="${ROOT}/${FIXTURE}"
+fi
+[[ -f "$FIXTURE" ]] || { echo "fixture not found: $FIXTURE" >&2; exit 1; }
+
+mkdir -p "$(dirname "$KNOWN_HOSTS")"
+touch "$KNOWN_HOSTS"
+SSH_OPTS=(-o StrictHostKeyChecking="${FWLIVE_STRICT_HOST_KEY_CHECKING:-accept-new}" \
+	-o UserKnownHostsFile="$KNOWN_HOSTS" -o ConnectTimeout=15 -p "$PORT")
+
+ssh "${SSH_OPTS[@]}" "root@$HOST" 'echo connected' >/dev/null
+
+RUN_ID="${FWLIVE_PROFILE_RUN_ID:-flood-$(date +%Y%m%dT%H%M%S)-$RANDOM}"
+case "$RUN_ID" in
+	''|*[!A-Za-z0-9._-]*)
+		echo "invalid FWLIVE_PROFILE_RUN_ID (use [A-Za-z0-9._-]+): $RUN_ID" >&2
+		exit 1
+		;;
+esac
+
+GIT_SHA="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+echo "Copying $(basename "$FIXTURE") → root@$HOST:$PORT:$REMOTE_FIXTURE" >&2
+if scp -O -q -P "$PORT" -o StrictHostKeyChecking="${FWLIVE_STRICT_HOST_KEY_CHECKING:-accept-new}" \
+	-o UserKnownHostsFile="$KNOWN_HOSTS" \
+	"$FIXTURE" "root@$HOST:$REMOTE_FIXTURE" 2>/dev/null; then
+	:
+else
+	ssh "${SSH_OPTS[@]}" "root@$HOST" "cat > $REMOTE_FIXTURE" <"$FIXTURE"
+fi
+
+# Ensure adaptive helper is present (source-sync installs historically omitted it).
+if ! ssh "${SSH_OPTS[@]}" "root@$HOST" 'test -f /usr/libexec/fwlive-adaptive-cap.sh'; then
+	echo "FLOOD_ERROR reason=adaptive_helper_missing hint=run_qemu-install-fwlive.sh" >&2
+	exit 1
+fi
+
+ssh "${SSH_OPTS[@]}" "root@$HOST" sh -s -- \
+	"$REMOTE_FIXTURE" "$RUN_ID" "$GIT_SHA" "$LOG_SIZE_KIB" "$SKIP_RAISE_LOG" \
+	"$REQUESTED_LINES" "$FOLLOW_POLLS" "$HOT_MS" "$MAX_SERVED" <<'REMOTE'
+set -eu
+fixture=$1
+run_id=$2
+git_sha=$3
+log_size_kib=$4
+skip_raise=$5
+requested=$6
+follow_n=$7
+hot_ms=$8
+max_served=$9
+
+STATE=/var/run/fwlive-state.json
+OFF=/var/run/fwlive-adaptive-off
+POLL_OUT=/tmp/fwlive-flood-poll.json
+SHIM_DIR=/tmp/fwlive-flood-shims
+
+clock_cs() {
+	read uptime _ </proc/uptime
+	seconds=${uptime%.*}
+	fraction=${uptime#*.}
+	fraction=${fraction#0}
+	[ -n "$fraction" ] || fraction=0
+	# Avoid octal: strip leading zeros digit-wise for BusyBox ash.
+	_s=$seconds
+	_n=0
+	while [ -n "$_s" ]; do
+		_d=${_s%"${_s#?}"}
+		_s=${_s#?}
+		case "$_d" in [0-9]) _n=$((_n * 10 + _d)) ;; esac
+	done
+	_f=$fraction
+	_m=0
+	while [ -n "$_f" ]; do
+		_d=${_f%"${_f#?}"}
+		_f=${_f#?}
+		case "$_d" in [0-9]) _m=$((_m * 10 + _d)) ;; esac
+	done
+	# At most two frac digits.
+	case "$fraction" in
+		?) _m=$((_m * 10)) ;;
+		??) ;;
+		*)
+			_m=0
+			_f=$fraction
+			_i=0
+			while [ "$_i" -lt 2 ] && [ -n "$_f" ]; do
+				_d=${_f%"${_f#?}"}
+				_f=${_f#?}
+				case "$_d" in [0-9]) _m=$((_m * 10 + _d)) ;; esac
+				_i=$((_i + 1))
+			done
+			;;
+	esac
+	printf '%s\n' $((_n * 100 + _m))
+}
+
+json_int() {
+	# Extract first "key":N from one-line JSON (busybox-safe).
+	_blob=$1
+	_key=$2
+	_def=$3
+	case "$_blob" in
+		*"\"$_key\""*) ;;
+		*) printf '%s\n' "$_def"; return 0 ;;
+	esac
+	_rest=${_blob#*"\"$_key\""}
+	_rest=${_rest#*:}
+	while case "$_rest" in ' '*) true;; *) false;; esac; do
+		_rest=${_rest# }
+	done
+	_num=
+	while :; do
+		case "$_rest" in '') break ;; esac
+		_c=${_rest%"${_rest#?}"}
+		case "$_c" in
+			[0-9]) _num="${_num}${_c}"; _rest=${_rest#?} ;;
+			*) break ;;
+		esac
+	done
+	case "$_num" in ''|*[!0-9]*) printf '%s\n' "$_def" ;; *) printf '%s\n' "$_num" ;; esac
+}
+
+count_log_msgs() {
+	_json=$1
+	_n=0
+	_rest=$_json
+	while :; do
+		case "$_rest" in
+			*'"msg"'*)
+				_n=$((_n + 1))
+				_rest=${_rest#*\"msg\"}
+				;;
+			*) break ;;
+		esac
+	done
+	printf '%s\n' "$_n"
+}
+
+setup_shim() {
+	rm -rf "$SHIM_DIR"
+	mkdir -p "$SHIM_DIR"
+	cat >"$SHIM_DIR/ubus" <<'UBUS'
+#!/bin/sh
+if [ "$1" = call ] && [ "$2" = log ] && [ "$3" = read ]; then
+	exec /bin/cat /tmp/fwlive-logread-2000.json
+fi
+exec /bin/ubus "$@"
+UBUS
+	chmod +x "$SHIM_DIR/ubus"
+}
+
+raise_log_ring() {
+	[ "$skip_raise" = 1 ] && return 0
+	# Prefer log_size (documented); fall back to log_buffer_size if present.
+	key=
+	if uci -q get system.@system[0].log_size >/dev/null 2>&1; then
+		key=log_size
+	elif uci -q get system.@system[0].log_buffer_size >/dev/null 2>&1; then
+		key=log_buffer_size
+	else
+		# Create log_size on anonymous system section.
+		key=log_size
+	fi
+	uci set "system.@system[0].${key}=${log_size_kib}"
+	uci commit system
+	/etc/init.d/log restart 2>/dev/null || true
+	sleep 1
+	val=$(uci -q get "system.@system[0].${key}" || echo unknown)
+	printf 'FLOOD_META log_uci_key=%s log_uci_value=%s\n' "$key" "$val"
+}
+
+clear_adaptive() {
+	rm -f "$STATE" "${STATE}.tmp."* "$OFF" 2>/dev/null || true
+}
+
+poll_once() {
+	label=$1
+	mode=$2
+	setup_shim
+	printf '%s' "{\"addresses\":[\"$requested\"]}" >/tmp/fwlive-flood-in.json
+	start=$(clock_cs)
+	PATH="$SHIM_DIR:$PATH" /usr/libexec/rpcd/fwlive call poll \
+		</tmp/fwlive-flood-in.json >"$POLL_OUT" 2>/dev/null || {
+		printf 'FLOOD_ERROR phase=%s mode=%s reason=poll_failed\n' "$label" "$mode"
+		return 1
+	}
+	end=$(clock_cs)
+	elapsed_cs=$((end - start))
+	[ "$elapsed_cs" -lt 0 ] && elapsed_cs=0
+	wall_ms=$((elapsed_cs * 10))
+	raw=
+	IFS= read -r raw <"$POLL_OUT" || raw=
+	adaptive=$(json_int "$raw" adaptive 0)
+	truncated=$(json_int "$raw" truncated 0)
+	msgs=$(count_log_msgs "$raw")
+	# shed.limit if present
+	shed_limit=$(json_int "$raw" limit 0)
+	case "$raw" in
+		*'"shed"'*) shed=1 ;;
+		*) shed=0 ;;
+	esac
+	state_bucket=none
+	state_dur=0
+	if [ -f "$STATE" ]; then
+		st=
+		IFS= read -r st <"$STATE" || st=
+		state_bucket=$(printf '%s' "$st" | sed -n 's/.*"bucket"[[:space:]]*:[[:space:]]*"\([a-z]*\)".*/\1/p' | head -n1)
+		[ -n "$state_bucket" ] || state_bucket=none
+		state_dur=$(json_int "$st" duration_ms 0)
+	fi
+	printf 'FLOOD_POLL phase=%s mode=%s wall_ms=%s adaptive=%s truncated=%s shed=%s shed_limit=%s log_msgs=%s state_bucket=%s state_duration_ms=%s\n' \
+		"$label" "$mode" "$wall_ms" "$adaptive" "$truncated" "$shed" "$shed_limit" "$msgs" "$state_bucket" "$state_dur"
+	# Export for caller via files
+	printf '%s\n' "$wall_ms" >/tmp/fwlive-flood-last-wall
+	printf '%s\n' "$truncated" >/tmp/fwlive-flood-last-trunc
+	printf '%s\n' "$msgs" >/tmp/fwlive-flood-last-msgs
+	printf '%s\n' "$adaptive" >/tmp/fwlive-flood-last-adapt
+	printf '%s\n' "$state_bucket" >/tmp/fwlive-flood-last-bucket
+	printf '%s\n' "$shed" >/tmp/fwlive-flood-last-shed
+}
+
+resolve_check() {
+	mode=$1
+	out=$(ubus call fwlive resolve '{"addresses":["192.0.2.1"]}' 2>/dev/null || echo '{}')
+	case "$out" in
+		*'"disabled":"load"'*|*'\"disabled\":\"load\"'*)
+			printf 'FLOOD_RESOLVE mode=%s disabled=load\n' "$mode"
+			;;
+		*)
+			printf 'FLOOD_RESOLVE mode=%s disabled=none raw=%s\n' "$mode" "$(printf '%s' "$out" | tr '\n' ' ')"
+			;;
+	esac
+}
+
+run_mode() {
+	mode=$1
+	clear_adaptive
+	if [ "$mode" = off ]; then
+		: >"$OFF"
+	else
+		rm -f "$OFF"
+	fi
+
+	# Induce: first poll at full request (fixture-backed via PATH-shim).
+	poll_once induce "$mode" || return 1
+	wall=$(cat /tmp/fwlive-flood-last-wall)
+	bucket=$(cat /tmp/fwlive-flood-last-bucket)
+	shed=$(cat /tmp/fwlive-flood-last-shed)
+
+	hot_ok=0
+	if [ "$mode" = on ]; then
+		if [ "$wall" -gt "$hot_ms" ] || [ "$bucket" = hot ] || [ "$shed" = 1 ]; then
+			hot_ok=1
+		fi
+		printf 'FLOOD_INDUCE mode=on wall_ms=%s hot_threshold_ms=%s hot_ok=%s\n' \
+			"$wall" "$hot_ms" "$hot_ok"
+	else
+		printf 'FLOOD_INDUCE mode=off wall_ms=%s (no shed expected)\n' "$wall"
+	fi
+
+	i=1
+	pass_follow=1
+	while [ "$i" -le "$follow_n" ]; do
+		poll_once "follow$i" "$mode" || return 1
+		trunc=$(cat /tmp/fwlive-flood-last-trunc)
+		msgs=$(cat /tmp/fwlive-flood-last-msgs)
+		adapt=$(cat /tmp/fwlive-flood-last-adapt)
+		if [ "$mode" = on ]; then
+			if [ "$trunc" != 1 ] || [ "$msgs" -gt "$max_served" ]; then
+				pass_follow=0
+			fi
+			if [ "$adapt" != 1 ]; then
+				pass_follow=0
+			fi
+		else
+			# Off: no truncation from adaptive; may still be filter-sized.
+			if [ "$adapt" != 0 ]; then
+				pass_follow=0
+			fi
+		fi
+		i=$((i + 1))
+	done
+
+	if [ "$mode" = on ] && [ "$hot_ok" = 1 ]; then
+		resolve_check on
+	elif [ "$mode" = on ]; then
+		printf 'FLOOD_RESOLVE mode=on skipped=induce_not_hot\n'
+	fi
+
+	printf 'FLOOD_MODE_RESULT mode=%s follow_pass=%s induce_hot_ok=%s\n' \
+		"$mode" "$pass_follow" "${hot_ok:-0}"
+	printf '%s\n' "$pass_follow" >"/tmp/fwlive-flood-verdict-${mode}-follow"
+	printf '%s\n' "${hot_ok:-0}" >"/tmp/fwlive-flood-verdict-${mode}-hot"
+}
+
+# --- meta ---
+printf 'FLOOD_META run_id=%s git_sha=%s arch=%s\n' "$run_id" "$git_sha" "$(uname -m)"
+printf 'FLOOD_META release=%s revision=%s\n' \
+	"$(sed -n 's/^DISTRIB_RELEASE=//p' /etc/openwrt_release)" \
+	"$(sed -n 's/^DISTRIB_REVISION=//p' /etc/openwrt_release)"
+printf 'FLOOD_META nproc=%s memtotal_kb=%s\n' \
+	"$(grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 0)" \
+	"$(awk '/MemTotal:/ {print $2}' /proc/meminfo)"
+printf 'FLOOD_META fixture_bytes=%s requested=%s follow_n=%s hot_ms=%s max_served=%s\n' \
+	"$(wc -c <"$fixture" | tr -d ' ')" "$requested" "$follow_n" "$hot_ms" "$max_served"
+printf 'FLOOD_META busybox=%s\n' \
+	"$(opkg status busybox 2>/dev/null | sed -n 's/^Version: //p' || echo unknown)"
+
+raise_log_ring
+
+run_mode on
+run_mode off
+
+on_hot=$(cat /tmp/fwlive-flood-verdict-on-hot 2>/dev/null || echo 0)
+on_follow=$(cat /tmp/fwlive-flood-verdict-on-follow 2>/dev/null || echo 0)
+off_follow=$(cat /tmp/fwlive-flood-verdict-off-follow 2>/dev/null || echo 0)
+
+ac_pass=0
+if [ "$on_hot" = 1 ] && [ "$on_follow" = 1 ] && [ "$off_follow" = 1 ]; then
+	ac_pass=1
+fi
+printf 'FLOOD_VERDICT ac_pass=%s on_induce_hot=%s on_follow_pass=%s off_follow_pass=%s\n' \
+	"$ac_pass" "$on_hot" "$on_follow" "$off_follow"
+printf 'FLOOD_DONE run_id=%s\n' "$run_id"
+REMOTE
+
+# Host-side: fail if guest did not emit ac_pass=1 (optional strict mode).
+if [[ "${FWLIVE_FLOOD_STRICT:-0}" == 1 ]]; then
+	# Re-run would be needed to capture; instead tee is caller's job.
+	:
+fi

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -35,6 +35,13 @@ HOT_MS="${FWLIVE_FLOOD_HOT_MS:-800}"
 MAX_SERVED="${FWLIVE_FLOOD_MAX_SERVED:-250}"
 STRICT="${FWLIVE_FLOOD_STRICT:-1}"
 
+case "$FOLLOW_POLLS" in
+	''|*[!0-9]*|0)
+		echo "FWLIVE_FLOOD_FOLLOW_POLLS must be a positive integer (got: $FOLLOW_POLLS)" >&2
+		exit 1
+		;;
+esac
+
 usage() {
 	sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
 	exit "${1:-0}"
@@ -110,6 +117,8 @@ OFF=/var/run/fwlive-adaptive-off
 POLL_OUT=/tmp/fwlive-flood-poll.json
 SHIM_DIR=/tmp/fwlive-flood-shims
 ENTRIES=/tmp/fwlive-flood-entries.txt
+# Always clear adaptive-off so a failed off-mode poll cannot leave the guest disabled.
+trap 'rm -f "$OFF"' EXIT HUP INT TERM
 
 # Match product fwlive_adaptive_clock_cs (no octal; two frac digits).
 clock_cs() {

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -41,12 +41,17 @@ case "$FOLLOW_POLLS" in
 		exit 1
 		;;
 esac
-# Bash 10# avoids octal; reject 0 / 00 / 000 after normalize.
-FOLLOW_POLLS=$((10#$FOLLOW_POLLS))
-if [[ "$FOLLOW_POLLS" -lt 1 ]]; then
+# FOLLOW_POLLS: same length cap + 10# as require_positive_int.
+_norm=$(printf '%s' "$FOLLOW_POLLS" | sed 's/^0*//')
+if [[ "$_norm" =~ ^0*$ ]]; then
 	echo "FWLIVE_FLOOD_FOLLOW_POLLS must be a positive integer (got: 0)" >&2
 	exit 1
 fi
+if [[ ! "$_norm" =~ ^[0-9]{1,18}$ ]]; then
+	echo "FWLIVE_FLOOD_FOLLOW_POLLS out of range (got: $FOLLOW_POLLS)" >&2
+	exit 1
+fi
+FOLLOW_POLLS=$((10#$FOLLOW_POLLS))
 
 usage() {
 	sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
@@ -64,6 +69,8 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+# Guards against values outside bash's signed 64-bit arithmetic range, which
+# would wrap silently under $((10#$v)) (CodeRabbit: 18446...7 wraps to 1).
 require_positive_int() {
 	_name=$1
 	_val=$2
@@ -73,11 +80,18 @@ require_positive_int() {
 			exit 1
 			;;
 	esac
-	_val=$((10#$_val))
-	if [[ "$_val" -lt 1 ]]; then
+	# Length-capped after stripping leading zeros: blocks wrap-widening values
+	# like 18446744073709551617, which $((10#...)) silently rounds (CodeRabbit).
+	_norm=$(printf '%s' "$_val" | sed 's/^0*//')
+	if [[ "$_norm" =~ ^0*$ ]]; then
 		echo "$_name must be a positive integer (got: 0)" >&2
 		exit 1
 	fi
+	if [[ ! "$_norm" =~ ^[0-9]{1,18}$ ]]; then
+		echo "$_name out of range (got: $_val)" >&2
+		exit 1
+	fi
+	_val=$((10#$_val))
 	printf '%s' "$_val"
 }
 
@@ -365,16 +379,28 @@ resolve_check() {
 	mode=$1
 	# ubus may pretty-print ("disabled": "load") or compact ("disabled":"load").
 	out=$(ubus call fwlive resolve '{"addresses":["192.0.2.1"]}' 2>/dev/null || echo '{}')
-	case "$out" in
-		*'"disabled"'*:*'"load"'*)
-			printf 'FLOOD_RESOLVE mode=%s disabled=load\n' "$mode"
-			printf '1\n' >/tmp/fwlive-flood-last-resolve
-			;;
-		*)
-			printf 'FLOOD_RESOLVE mode=%s disabled=none\n' "$mode"
-			printf '0\n' >/tmp/fwlive-flood-last-resolve
-			;;
-	esac
+	disabled=$(resolve_disabled_value "$out")
+	if [ "$disabled" = load ]; then
+		printf 'FLOOD_RESOLVE mode=%s disabled=load\n' "$mode"
+		printf '1\n' >/tmp/fwlive-flood-last-resolve
+	else
+		printf 'FLOOD_RESOLVE mode=%s disabled=%s\n' "$mode" "${disabled:-none}"
+		printf '0\n' >/tmp/fwlive-flood-last-resolve
+	fi
+}
+
+# Extract the value of the JSON "disabled" field only — not any other field
+# that happens to contain "disabled" or "load" (CodeRabbit: intervening fields).
+resolve_disabled_value() {
+	# awk parses field-aware; handles both compact and pretty-printed ubus JSON.
+	printf '%s' "$1" | awk 'BEGIN{RS=","; FS=":"} {
+		for (i = 1; i <= NF; i++) {
+			f = $i; gsub(/[[:space:]{}]+/, "", f)
+			if (f ~ /"disabled"$/) {
+				v = $(i + 1); gsub(/[^a-z]/, "", v); print v; exit
+			}
+		}
+	}'
 }
 
 run_mode() {

--- a/scripts/qemu-adaptive-flood.sh
+++ b/scripts/qemu-adaptive-flood.sh
@@ -335,9 +335,10 @@ poll_once() {
 
 resolve_check() {
 	mode=$1
+	# ubus may pretty-print ("disabled": "load") or compact ("disabled":"load").
 	out=$(ubus call fwlive resolve '{"addresses":["192.0.2.1"]}' 2>/dev/null || echo '{}')
 	case "$out" in
-		*'"disabled":"load"'*)
+		*'"disabled"'*'"load"'*)
 			printf 'FLOOD_RESOLVE mode=%s disabled=load\n' "$mode"
 			printf '1\n' >/tmp/fwlive-flood-last-resolve
 			;;

--- a/scripts/qemu-install-fwlive.sh
+++ b/scripts/qemu-install-fwlive.sh
@@ -101,6 +101,7 @@ FWLIVE_PKG="$ROOT/openwrt-feed/luci-app-fwlive"
 FWLIVE_DIR="$FWLIVE_PKG/htdocs/luci-static/resources"
 RPCD_BIN="$FWLIVE_PKG/root/usr/libexec/rpcd/fwlive"
 LIBEXEC_LOGGING="$FWLIVE_PKG/root/usr/libexec/fwlive-logging.sh"
+LIBEXEC_ADAPTIVE="$FWLIVE_PKG/root/usr/libexec/fwlive-adaptive-cap.sh"
 LIBEXEC_FILTER="$FWLIVE_PKG/root/usr/libexec/fwlive-log-filter.sh"
 LIBEXEC_ISFW="$FWLIVE_PKG/root/usr/libexec/fwlive-is-firewall-event.sh"
 LIBEXEC_ISFW_AWK="$FWLIVE_PKG/root/usr/libexec/fwlive-is-firewall-event.awk"
@@ -147,6 +148,12 @@ restore_wan_log_baseline || logger -t fwlive "WAN log baseline restore failed du
 # Always exit 0 — see Package/luci-app-fwlive/prerm (do not strand uninstall).
 exit 0
 EOF
+	fi
+	if [[ -f "$LIBEXEC_ADAPTIVE" ]]; then
+		echo "Syncing fwlive-adaptive-cap.sh (#306)..."
+		ssh -p "$OPENWRT_SSH_PORT" "${SSH_OPTS[@]}" "${OPENWRT_USER}@${OPENWRT_HOST}" \
+			"cat > /usr/libexec/fwlive-adaptive-cap.sh && chmod 644 /usr/libexec/fwlive-adaptive-cap.sh" \
+			< "$LIBEXEC_ADAPTIVE"
 	fi
 	if [[ -f "$LIBEXEC_FILTER" ]]; then
 		ssh -p "$OPENWRT_SSH_PORT" "${SSH_OPTS[@]}" "${OPENWRT_USER}@${OPENWRT_HOST}" \


### PR DESCRIPTION
## Summary
- Add `scripts/qemu-adaptive-flood.sh` (PATH-shim C1 A/B flood for Layer 1 adaptive shedding).
- Sync `fwlive-adaptive-cap.sh` in `qemu-install-fwlive.sh`.
- Fill binding armsr table in `docs/developer/qemu-lab.md` from run `flood-armsr-20260912T174001` (`ac_pass=1`).
- Artifact: `lab/flood-armsr-latest.txt`.

Combines plan PR A (harness) + PR B (evidence) on one branch — guest was already up.

## Evidence (binding)
| | on | off |
|---|---|---|
| Induce | hot 36630 ms / 1143 msgs | 36810 ms / 1143 msgs |
| Follow×3 msgs | 143 | 1143 |
| Follow wall | ~5.5 s | ~36 s |
| Resolve | `disabled=load` | n/a |
| Verdict | `ac_pass=1` | |

**Grok next slice:** Layer 2 client surfacing + backoff (not calibrate, not fork-budget-first).

## Test plan
- [x] Luna + Grok + Bugbot on harness
- [x] CodeRabbit first round (3 findings fixed; re-review rate-limited ~41m)
- [x] Binding armsr `OWRT_QEMU_SMP=1 OWRT_QEMU_MEM=256` flood `ac_pass=1`
- [ ] Luna + Grok + Bugbot on evidence docs
- [ ] CodeRabbit after rate-limit window
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated QEMU workflow for validating adaptive log behavior in OpenWrt environments.
  * Installation now synchronizes the adaptive-cap helper when available.
* **Tests**
  * Added a passing ARM64 flood-test run covering adaptive and non-adaptive modes, including truncation and shedding behavior.
* **Documentation**
  * Updated the degraded-mode checklist and evidence tables with run details, results, and known follow-up limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->